### PR TITLE
Fix bug when new user quits app while making first project

### DIFF
--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -1,7 +1,5 @@
 // @flow
 import {
-  START_CREATING_NEW_PROJECT,
-  CANCEL_CREATING_NEW_PROJECT,
   DISMISS_SIDEBAR_INTRO,
   ADD_PROJECT,
   REFRESH_PROJECTS,
@@ -11,7 +9,6 @@ import type { Action } from 'redux';
 
 export type State =
   | 'brand-new'
-  | 'creating-first-project'
   | 'introducing-sidebar'
   | 'done';
 
@@ -24,16 +21,8 @@ export default (state: State = initialState, action: Action) => {
   }
 
   switch (action.type) {
-    case START_CREATING_NEW_PROJECT: {
-      return state === 'brand-new' ? 'creating-first-project' : state;
-    }
-
-    case CANCEL_CREATING_NEW_PROJECT: {
-      return state === 'creating-first-project' ? 'brand-new' : state;
-    }
-
     case ADD_PROJECT: {
-      return state === 'creating-first-project' ? 'introducing-sidebar' : state;
+      return state === 'brand-new' ? 'introducing-sidebar' : state;
     }
 
     case DISMISS_SIDEBAR_INTRO: {


### PR DESCRIPTION
If a new user opened the "create new project" dialog but then quit the
app, their onboarding status would be updated to
"creating-first-project" and persisted to localStorage, but their
modal status would not be persisted to disk. On re-open, the app
would appear blank, because the user wasn't "brand-new" (and thus
didn't get the guppy welcome screen), but didn't have a modal
open (and thus did not get the create project modal, even though
their onboardingStatus was "creating-first-project").

There are several ways we can sidestep this; this commit is just
one possibility: consolidate the "creating first app" source of
truth into the modal status, which just reopens the Guppy welcome
page if a user quits while making their first project.