### PR TITLE
Improve start up script - run electron after webpack compiles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "src/electron-starter.js",
   "homepage": "./",
   "scripts": {
-    "start": "concurrently --kill-others \"npm run start:react\" \"npm run start:electron\"",
-    "start:react": "PORT=5678 BROWSER=none node scripts/start.js",
+    "start": "PORT=5678 node scripts/start.js",
     "start:electron": "ELECTRON_START_URL=http://localhost:5678 electron .",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=node",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -14,6 +14,7 @@ process.on('unhandledRejection', err => {
 // Ensure environment variables are read.
 require('../config/env');
 
+const { exec } = require('child_process');
 const chalk = require('chalk');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
@@ -104,8 +105,32 @@ checkBrowsers(paths.appPath)
       openBrowser(urls.localUrlForBrowser);
     });
 
-    ['SIGINT', 'SIGTERM'].forEach(function(sig) {
-      process.on(sig, function() {
+    // "done" event fires when compilation is finish
+    compiler.plugin('done', stats => {
+      process.stdout.write('\x1bc'); // clear the console
+      console.log(
+        chalk.cyan('Development server ready. ') + chalk.green('Running electron...\n')
+      );
+
+      // Run electron
+      exec(
+        'npm run start:electron',
+        (err, stdout, stderr) => {
+          if (err) {
+            process.stdout.write('\x1bc'); // clear the console
+            console.log(chalk.red('Electron failed: \n') + stderr);
+            return;
+          }
+
+          // electron run successful
+          process.stdout.write('\x1bc'); // clear the console
+          console.log(stdout);
+        }
+      );
+    });
+
+    ['SIGINT', 'SIGTERM'].forEach(function (sig) {
+      process.on(sig, function () {
         devServer.close();
         process.exit();
       });


### PR DESCRIPTION
This changes 'fire-up' electron after WebPack builds and compiles the necessary files along with the dev-server. I achieved this by hooking on to the 'done' event of the webpack compiler. Guppy now starts up smoothly.