### PR TITLE
fix typo in CONTRIBUTING.md: change clone url example from redux to g…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Visit the [issue tracker](https://github.com/joshwcomeau/guppy/issues) to find a
 Fork, then clone the repo:
 
 ```
-git clone https://github.com/your-username/redux.git
+git clone https://github.com/your-username/guppy.git
 ```
 
 ### Running


### PR DESCRIPTION
…uppy

so uh apparently that title was too long?