### PR TITLE
fix #48: get the repo url from package.json

### DIFF
--- a/src/components/DependencyDetailsTable/DependencyDetailsTable.js
+++ b/src/components/DependencyDetailsTable/DependencyDetailsTable.js
@@ -25,9 +25,15 @@ class DependencyDetailsTable extends Component<Props> {
     const { projectId, dependency, lastUpdatedAt } = this.props;
 
     const packageHref = `https://www.npmjs.org/package/${dependency.name}`;
-    const githubHref =
-      dependency.repository &&
-      `https://www.github.com/${dependency.repository}`;
+    let githubHref;
+    try {
+      let githubURL = new URL(dependency.repository.url);
+      githubURL.protocol = 'https';
+      githubHref = githubURL.href;
+    } catch (e) {
+      // If no repo URL is specified in package.json or parsing failed for another reason.
+      // Nothing needs to be done because githubHref will be undefined, hiding the link.
+    }
 
     return (
       <Table>
@@ -60,8 +66,10 @@ class DependencyDetailsTable extends Component<Props> {
             </Cell>
             <Cell>
               <ExternalLink href={packageHref}>NPM</ExternalLink>
-              <Middot />
-              <ExternalLink href={githubHref}>GitHub</ExternalLink>
+              {githubHref && <Middot />}
+              {githubHref && (
+                <ExternalLink href={githubHref}>GitHub</ExternalLink>
+              )}
               {dependency.homepage && <Middot />}
               {dependency.homepage && (
                 <ExternalLink href={dependency.homepage}>

--- a/src/reducers/dependencies.reducer.js
+++ b/src/reducers/dependencies.reducer.js
@@ -49,7 +49,7 @@ export default (state: State = initialState, action: Action) => {
           version: '',
           homepage: '',
           license: '',
-          repository: '',
+          repository: { type: '', url: '' },
         };
       });
     }

--- a/src/types.js
+++ b/src/types.js
@@ -32,6 +32,11 @@ export type Task = {
   logs: Array<Log>,
 };
 
+export type Repository = {
+  type: string,
+  url: string,
+};
+
 export type Dependency = {
   name: string,
   description: string,
@@ -39,7 +44,7 @@ export type Dependency = {
   version: string,
   homepage: string,
   license: string,
-  repository: string,
+  repository: Repository,
   // All of the above fields are straight from the dependency's package.json.
   // The status field is separate, and used to show loading indicators while
   // performing actions on the dependency.


### PR DESCRIPTION
I thought this would be a simple case of changing the reference from repository to repository.url but since some packages (like Gatsby) have a url with git+https protocol it wasn't quite so simple.

I'm not super experienced with react and I have a feeling I'm doing too much at the top of the render function here. Should this be a utility function instead? In the module top level or on the class? Something like this:

```javascript
  parseRepositoryURL = dependency => {
    try {
      let githubURL = new URL(dependency.repository.url);
      githubURL.protocol = 'https';
      return githubURL.href;
    } catch (e) {
      return null;
    }
  };
//...
  render () {
    const githubHref = parseRepositoryURL(dependency);
//...
```

I also changed the  repository type from string to a {type: ..., url: ...} object in the flow types and updated the reducer to return an object with empty values instead of an empty string. Maybe somewhere in there is a more appropriate place for dealing with the missing url instead of try{} catch{} in the render()?