### PR TITLE
add Edit menu

### DIFF
--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -44,6 +44,19 @@ class ApplicationMenu extends Component<Props> {
         ],
       },
       {
+        label: 'Edit',
+        submenu: [
+          { role: 'undo' },
+          { role: 'redo' },
+          { type: 'separator' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'delete' },
+          { role: 'selectall' },
+        ],
+      },
+      {
         label: 'View',
         submenu: [
           { role: 'reload' },


### PR DESCRIPTION
As referenced in #72 this ensures proper text field behavior (undo/redo, copy/paste, quick emoji picker🐠) on macOS. Do linux and windows currently show the menu?

![screen shot 2018-07-17 at 14 44 57](https://user-images.githubusercontent.com/950480/42818152-62081438-89d0-11e8-8fd6-a8ae108216cb.png)
