### PR TITLE
Add action to make unsupported project errors fail gracefully

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -45,6 +45,7 @@ export const DELETE_DEPENDENCY_FINISH = 'DELETE_DEPENDENCY_FINISH';
 export const SHOW_IMPORT_EXISTING_PROJECT_PROMPT =
   'SHOW_IMPORT_EXISTING_PROJECT_PROMPT';
 export const IMPORT_EXISTING_PROJECT_START = 'IMPORT_EXISTING_PROJECT_START';
+export const IMPORT_EXISTING_PROJECT_ERROR = 'IMPORT_EXISTING_PROJECT_ERROR';
 export const IMPORT_EXISTING_PROJECT_FINISH = 'IMPORT_EXISTING_PROJECT_FINISH';
 
 //
@@ -273,6 +274,10 @@ export const showImportExistingProjectPrompt = () => ({
 export const importExistingProjectStart = (path: string) => ({
   type: IMPORT_EXISTING_PROJECT_START,
   path,
+});
+
+export const importExistingProjectError = () => ({
+  type: IMPORT_EXISTING_PROJECT_ERROR,
 });
 
 export const importExistingProjectFinish = (

--- a/src/middlewares/import-project.middleware.js
+++ b/src/middlewares/import-project.middleware.js
@@ -4,6 +4,7 @@ import {
   IMPORT_EXISTING_PROJECT_START,
   importExistingProjectStart,
   importExistingProjectFinish,
+  importExistingProjectError,
 } from '../actions';
 import { getInternalProjectById } from '../reducers/projects.reducer';
 import {
@@ -119,6 +120,8 @@ export default (store: any) => (next: any) => (action: any) => {
               break;
             }
           }
+
+          next(importExistingProjectError());
         });
 
       return;

--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -5,6 +5,7 @@ import {
   DISMISS_SIDEBAR_INTRO,
   ADD_PROJECT,
   IMPORT_EXISTING_PROJECT_START,
+  IMPORT_EXISTING_PROJECT_ERROR,
   IMPORT_EXISTING_PROJECT_FINISH,
   REFRESH_PROJECTS,
   SELECT_PROJECT,
@@ -32,6 +33,7 @@ export default (state: State = initialState, action: Action) => {
       return state === 'brand-new' ? 'creating-first-project' : state;
     }
 
+    case IMPORT_EXISTING_PROJECT_ERROR:
     case CREATE_NEW_PROJECT_CANCEL: {
       return state === 'creating-first-project' ? 'brand-new' : state;
     }


### PR DESCRIPTION
This attempts to fix #62 where importing unsupported projects was throwing you into a blank screen. 

My solution was to add an action that handles the error (basically just mimicking CREATE_NEW_PROJECT_CANCEL). This keeps onboarding status to 'brand new' so when you exit out of the error prompt, you're kept on the start screen.