### PR TITLE
Check for json.dependencies when running inferProjectType

### DIFF
--- a/src/middlewares/import-project.middleware.js
+++ b/src/middlewares/import-project.middleware.js
@@ -134,23 +134,27 @@ export default (store: any) => (next: any) => (action: any) => {
 };
 
 const inferProjectType = json => {
-  const dependencyNames = Object.keys(json.dependencies);
+  // Make sure to check for the existance of dependencies
+  // because sometimes package.json only has devDependencies
+  if (json.dependencies) {
+    const dependencyNames = Object.keys(json.dependencies);
 
-  if (dependencyNames.includes('gatsby')) {
-    return 'gatsby';
-  } else if (dependencyNames.includes('react-scripts')) {
-    return 'create-react-app';
-  }
+    if (dependencyNames.includes('gatsby')) {
+      return 'gatsby';
+    } else if (dependencyNames.includes('react-scripts')) {
+      return 'create-react-app';
+    }
 
-  // An ejected create-react-app won't have `react-scripts`.
-  // So it actually becomes kinda hard to figure out what kind of project it is!
-  // One strong clue is that it will have `eslint-config-react-app` as a
-  // dependency... this isn't foolproof since a user could easily uninstall
-  // that dependency, but it'll work for now.
-  // In the future, could also check the `config` dir for the standard React
-  // scripts
-  if (dependencyNames.includes('eslint-config-react-app')) {
-    return 'create-react-app';
+    // An ejected create-react-app won't have `react-scripts`.
+    // So it actually becomes kinda hard to figure out what kind of project it is!
+    // One strong clue is that it will have `eslint-config-react-app` as a
+    // dependency... this isn't foolproof since a user could easily uninstall
+    // that dependency, but it'll work for now.
+    // In the future, could also check the `config` dir for the standard React
+    // scripts
+    if (dependencyNames.includes('eslint-config-react-app')) {
+      return 'create-react-app';
+    }
   }
 
   return null;


### PR DESCRIPTION
When testing out Import Existing, all my projects with package.json were getting the proper `Unsupported project type` error, whereas one in particular was getting `Unknown error`, despite it having a package.json.

I realized it was because this project actually didn't have a dependencies key in its package.json at all, and therefore was returning undefined.

Just added a simple check to make sure there's the `json.dependencies` key so the error message is consistent across unsupported projects with package.json.

However, we could also probably have some sort of check to cover not having a package.json at all. Not having a package.json isn't technically an `Unknown error`, right? Not having a package.json means the project by default cannot be a React or Gatsby project.

Or is that too pedantic? 🤔