### PR TITLE
Fix html display in dependency search, and styling tweaks for results

### DIFF
--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -132,7 +132,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
       <Wrapper>
         <Header>
           <Title>
-            <ExternalLink href={npmLink}>
+            <ExternalLink display={'inline'} href={npmLink}>
               <Name size="small">{hit.name}</Name>
             </ExternalLink>
             <Spacer inline size={15} />
@@ -246,9 +246,7 @@ injectGlobal`
     transform: translateX(-50%);
     cursor: pointer;
     &--disabled {
-      color: #ccc;
-      border-color: #ccc;
-      cursor: default;
+      display: none;
     }
   }
   .ais-Highlight-highlighted {

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -175,7 +175,7 @@ const Wrapper = styled.div`
 const Header = styled.header`
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-start;
 `;
 
 const Title = styled.div``;
@@ -245,6 +245,11 @@ injectGlobal`
     font-size: 18px;
     transform: translateX(-50%);
     cursor: pointer;
+    &--disabled {
+      color: #ccc;
+      border-color: #ccc;
+      cursor: default;
+    }
   }
   .ais-Highlight-highlighted {
     background: none;

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -132,7 +132,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
       <Wrapper>
         <Header>
           <Title>
-            <ExternalLink display={'inline'} href={npmLink}>
+            <ExternalLink display="inline" href={npmLink}>
               <Name size="small">{hit.name}</Name>
             </ExternalLink>
             <Spacer inline size={15} />

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -105,6 +105,7 @@ const ButtonBase = styled.button`
   cursor: pointer;
   outline: none;
   color: ${COLORS.gray[900]};
+  white-space: nowrap;
 
   &:not(:disabled):active rect {
     stroke-width: 4;

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -45,7 +45,6 @@ class ExternalLink extends Component<Props> {
 
 const Anchor = styled.a`
   position: relative;
-  display: inline-block;
   text-decoration: none;
   color: ${props => props.color};
 

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -12,6 +12,7 @@ type Props = {
   color: string,
   hoverColor?: string,
   showUnderline: boolean,
+  display: string,
 };
 
 class ExternalLink extends Component<Props> {
@@ -28,10 +29,11 @@ class ExternalLink extends Component<Props> {
   };
 
   render() {
-    const { href, color, hoverColor, children } = this.props;
+    const { href, color, hoverColor, children, display } = this.props;
 
     return (
       <Anchor
+        style={{ display }}
         href={href}
         color={color}
         hoverColor={hoverColor}
@@ -45,6 +47,7 @@ class ExternalLink extends Component<Props> {
 
 const Anchor = styled.a`
   position: relative;
+  display: inline-block;
   text-decoration: none;
   color: ${props => props.color};
 

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -19,6 +19,7 @@ class ExternalLink extends Component<Props> {
   static defaultProps = {
     color: COLORS.blue[700],
     hoverColor: COLORS.blue[500],
+    display: 'inline-block',
   };
 
   handleClick = (ev: SyntheticMouseEvent<*>) => {
@@ -47,7 +48,6 @@ class ExternalLink extends Component<Props> {
 
 const Anchor = styled.a`
   position: relative;
-  display: inline-block;
   text-decoration: none;
   color: ${props => props.color};
 


### PR DESCRIPTION
Fixes 1 and 2 from the list in #80

- ~Unescapes the package description with `dangerouslySetInnerHTML`. I'm a bit unsure about this due to the obvious security concerns. What do people think?~
- Fixed the formatting issues inside the <Header> (wrapping, positioning etc).
- Added styling for `.ais-InfiniteHits-loadMore--disabled` so there's no confusion about it not loading more when there's no more results to load.

## Before:

<img width="599" alt="screen shot 2018-07-20 at 4 59 00 pm" src="https://user-images.githubusercontent.com/17421347/43029790-5a6cefe4-8c3e-11e8-92fc-4ba74432b313.png">

## After:

<img width="600" alt="screen shot 2018-07-20 at 5 00 27 pm" src="https://user-images.githubusercontent.com/17421347/43029805-7130dd58-8c3e-11e8-88e3-aeec3b44ac04.png">

## New button disabled style

<img width="192" alt="screen shot 2018-07-20 at 5 02 58 pm" src="https://user-images.githubusercontent.com/17421347/43029844-ce5c9f08-8c3e-11e8-9b79-098c39f8f057.png">
