### PR TITLE
Add support for highlighting results

### DIFF
--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import styled, { injectGlobal } from 'styled-components';
 import moment from 'moment';
 import IconBase from 'react-icons-kit';
+import { connectHighlight } from 'react-instantsearch/connectors';
 import { u1F4C8 as barGraphIcon } from 'react-icons-kit/noto_emoji_regular/u1F4C8';
 import { u1F553 as clockIcon } from 'react-icons-kit/noto_emoji_regular/u1F553';
 import { check } from 'react-icons-kit/feather/check';
@@ -127,12 +128,36 @@ class AddDependencySearchResult extends PureComponent<Props> {
 
     const downloadNumColor = getColorForDownloadNumber(hit.downloadsLast30Days);
 
+    const CustomHighlight = connectHighlight(
+      ({ highlight, attribute, hit, highlightProperty }) => {
+        const highlights = highlight({
+          highlightProperty: '_highlightResult',
+          attribute,
+          hit,
+        });
+
+        return highlights.map(
+          part =>
+            part.isHighlighted ? (
+              <mark
+                className="ais-Highlight-highlighted"
+                dangerouslySetInnerHTML={{ __html: part.value }}
+              />
+            ) : (
+              <span dangerouslySetInnerHTML={{ __html: part.value }} />
+            )
+        );
+      }
+    );
+
     return (
       <Wrapper>
         <Header>
           <Title>
             <ExternalLink href={npmLink}>
-              <Name size="small">{hit.name}</Name>
+              <Name size="small">
+                <CustomHighlight attribute="name" hit={hit} />
+              </Name>
             </ExternalLink>
             <Spacer inline size={15} />
             <Version>v{hit.version}</Version>
@@ -140,7 +165,9 @@ class AddDependencySearchResult extends PureComponent<Props> {
           {this.renderActionArea()}
         </Header>
 
-        <Description>{hit.description}</Description>
+        <Description>
+          <CustomHighlight attribute="description" hit={hit} />
+        </Description>
         <Spacer size={20} />
 
         <StatsRow>
@@ -242,6 +269,9 @@ injectGlobal`
     font-size: 18px;
     transform: translateX(-50%);
     cursor: pointer;
+  }
+  .ais-Highlight-highlighted {
+    background: orange;
   }
 `;
 

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -141,7 +141,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
         return highlights.map((part, i) => {
           // Run the parser on each of the parts
           const unescaped = (new DOMParser().parseFromString(
-            part.value,
+            `<span>${part.value}</span>`,
             'text/html'
           ): any).body.textContent;
 
@@ -281,9 +281,7 @@ injectGlobal`
   .ais-Highlight-highlighted {
     background: none;
     color: inherit;
-    font-style: italic;
     font-weight: 700;
-    margin-right: 4px;
   }
 `;
 

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -136,17 +136,18 @@ class AddDependencySearchResult extends PureComponent<Props> {
           hit,
         });
 
-        return highlights.map(
-          part =>
-            part.isHighlighted ? (
-              <mark
-                className="ais-Highlight-highlighted"
-                dangerouslySetInnerHTML={{ __html: part.value }}
-              />
-            ) : (
-              <span dangerouslySetInnerHTML={{ __html: part.value }} />
-            )
-        );
+        return highlights.map(part => {
+          const unescaped = (new DOMParser().parseFromString(
+            part.value,
+            'text/html'
+          ): any).body.textContent;
+
+          return part.isHighlighted ? (
+            <mark className="ais-Highlight-highlighted">{unescaped}</mark>
+          ) : (
+            <span>{unescaped}</span>
+          );
+        });
       }
     );
 
@@ -155,9 +156,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
         <Header>
           <Title>
             <ExternalLink href={npmLink}>
-              <Name size="small">
-                <CustomHighlight attribute="name" hit={hit} />
-              </Name>
+              <Name size="small">{hit.name}</Name>
             </ExternalLink>
             <Spacer inline size={15} />
             <Version>v{hit.version}</Version>
@@ -271,7 +270,9 @@ injectGlobal`
     cursor: pointer;
   }
   .ais-Highlight-highlighted {
-    background: orange;
+    background: none;
+    color: inherit;
+    font-weight: 700;
   }
 `;
 

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -128,6 +128,8 @@ class AddDependencySearchResult extends PureComponent<Props> {
 
     const downloadNumColor = getColorForDownloadNumber(hit.downloadsLast30Days);
 
+    // We have to use a custom highlight
+    // to unescape the html
     const CustomHighlight = connectHighlight(
       ({ highlight, attribute, hit, highlightProperty }) => {
         const highlights = highlight({
@@ -136,16 +138,21 @@ class AddDependencySearchResult extends PureComponent<Props> {
           hit,
         });
 
-        return highlights.map(part => {
+        return highlights.map((part, i) => {
+          // Run the parser on each of the parts
           const unescaped = (new DOMParser().parseFromString(
             part.value,
             'text/html'
           ): any).body.textContent;
 
+          // If the part is highlighted, wrap in <mark> for the highlight
+          // Otherwise just render the part in a <span>
           return part.isHighlighted ? (
-            <mark className="ais-Highlight-highlighted">{unescaped}</mark>
+            <mark key={i} className="ais-Highlight-highlighted">
+              {unescaped}
+            </mark>
           ) : (
-            <span>{unescaped}</span>
+            <span key={i}>{unescaped}</span>
           );
         });
       }
@@ -156,7 +163,9 @@ class AddDependencySearchResult extends PureComponent<Props> {
         <Header>
           <Title>
             <ExternalLink href={npmLink}>
-              <Name size="small">{hit.name}</Name>
+              <Name size="small">
+                <CustomHighlight attribute="name" hit={hit} />
+              </Name>
             </ExternalLink>
             <Spacer inline size={15} />
             <Version>v{hit.version}</Version>
@@ -272,7 +281,9 @@ injectGlobal`
   .ais-Highlight-highlighted {
     background: none;
     color: inherit;
+    font-style: italic;
     font-weight: 700;
+    margin-right: 4px;
   }
 `;
 

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import styled, { injectGlobal } from 'styled-components';
 import moment from 'moment';
 import IconBase from 'react-icons-kit';
-import { connectHighlight } from 'react-instantsearch/connectors';
 import { u1F4C8 as barGraphIcon } from 'react-icons-kit/noto_emoji_regular/u1F4C8';
 import { u1F553 as clockIcon } from 'react-icons-kit/noto_emoji_regular/u1F553';
 import { check } from 'react-icons-kit/feather/check';
@@ -23,6 +22,7 @@ import ExternalLink from '../ExternalLink';
 import License from '../License';
 import Middot from '../Middot';
 import Button from '../Button';
+import CustomHighlight from '../CustomHighlight';
 
 import type { DependencyStatus } from '../../types';
 
@@ -128,44 +128,12 @@ class AddDependencySearchResult extends PureComponent<Props> {
 
     const downloadNumColor = getColorForDownloadNumber(hit.downloadsLast30Days);
 
-    // We have to use a custom highlight
-    // to unescape the html
-    const CustomHighlight = connectHighlight(
-      ({ highlight, attribute, hit, highlightProperty }) => {
-        const highlights = highlight({
-          highlightProperty: '_highlightResult',
-          attribute,
-          hit,
-        });
-
-        return highlights.map((part, i) => {
-          // Run the parser on each of the parts
-          const unescaped = (new DOMParser().parseFromString(
-            `<span>${part.value}</span>`,
-            'text/html'
-          ): any).body.textContent;
-
-          // If the part is highlighted, wrap in <mark> for the highlight
-          // Otherwise just render the part in a <span>
-          return part.isHighlighted ? (
-            <mark key={i} className="ais-Highlight-highlighted">
-              {unescaped}
-            </mark>
-          ) : (
-            <span key={i}>{unescaped}</span>
-          );
-        });
-      }
-    );
-
     return (
       <Wrapper>
         <Header>
           <Title>
             <ExternalLink href={npmLink}>
-              <Name size="small">
-                <CustomHighlight attribute="name" hit={hit} />
-              </Name>
+              <Name size="small">{hit.name}</Name>
             </ExternalLink>
             <Spacer inline size={15} />
             <Version>v{hit.version}</Version>

--- a/src/components/CustomHighlight/CustomHighlight.js
+++ b/src/components/CustomHighlight/CustomHighlight.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { connectHighlight } from 'react-instantsearch/connectors';
+
+import { safeEscapeString } from '../../utils';
+
+type Props = any;
+
+// A CustomHighlight component to use with react-instantsearch
+// to ensure elements are properly unescaped and spaced on output
+const CustomHighlight = ({
+  highlight,
+  attribute,
+  hit,
+  highlightProperty,
+}: Props) => {
+  const highlights = highlight({
+    highlightProperty: '_highlightResult',
+    attribute,
+    hit,
+  });
+
+  return highlights.map((part, i) => {
+    // Run the DOMParser on each of the parts of text
+    const unescaped = safeEscapeString(part.value);
+
+    // If the text is highlighted, wrap in <mark> for the highlight
+    // Otherwise just render the part in a <span>
+    return part.isHighlighted ? (
+      <mark key={i} className="ais-Highlight-highlighted">
+        {unescaped}
+      </mark>
+    ) : (
+      <span key={i}>{unescaped}</span>
+    );
+  });
+};
+
+export default connectHighlight(CustomHighlight);

--- a/src/components/CustomHighlight/index.js
+++ b/src/components/CustomHighlight/index.js
@@ -1,0 +1,1 @@
+export { default } from './CustomHighlight';

--- a/src/utils.js
+++ b/src/utils.js
@@ -229,3 +229,14 @@ export const hasPropChanged = (oldProps, newProps, key) => {
 };
 
 export const flatten = arr => Array.prototype.concat(...arr);
+
+// This function takes a string input and parses the output
+// to ensure to all html is rendered safely to the dom,
+// and any trailing spaces are preserved from their original text
+export const safeEscapeString = (val: string) =>
+  (new DOMParser().parseFromString(
+    // Wrapping the text in a span ensures textContent keeps the spaces
+    // from the original text intact (span isn't rendered in the DOM)
+    `<span>${val}</span>`,
+    'text/html'
+  ): any).body.textContent;


### PR DESCRIPTION
I wanted to create a separate branch and open this for discussion. This attempts to address item 4 in #80

I was able to get highlighting working by creating a CustomHighlight with the `_highlightResult` key, however it appears that dangerouslySetInnerHTML is still needed to actually render the HTML (rather than leaving it escaped per item 1 in #80). So the question still remains if dangerouslySetInnerHTML is the way to go here?