### PR TITLE
fix crash when deleting last dependency in list

### DIFF
--- a/src/components/DependencyManagementPane/DependencyManagementPane.js
+++ b/src/components/DependencyManagementPane/DependencyManagementPane.js
@@ -61,6 +61,17 @@ class DependencyManagementPane extends PureComponent<Props, State> {
       this.setState({ selectedDependencyIndex: newDependencyIndex });
     }
 
+    // If the last dependency was deleted, we need to shift focus to the new last dependency
+    // in the list.
+    if (
+      this.state.selectedDependencyIndex ===
+      nextProps.project.dependencies.length
+    ) {
+      this.setState({
+        selectedDependencyIndex: nextProps.project.dependencies.length - 1,
+      });
+    }
+
     // TODO: when a selected dependency is deleted, the focus shifts to the
     // next one in the list. This is great!
     // However, if the user clicks a different dependency while the focused one


### PR DESCRIPTION
If the last dependency in DependencyManagePane is deleted, the application will crash as it doesn't update selectedDependencyIndex to be in range for the newly shortened list.