### PR TITLE
Bi directional communication

### DIFF
--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -57,14 +57,9 @@ class TaskRunnerPane extends Component<Props, State> {
     const { selectedTaskId } = this.state;
 
     // It's possible that this task is deleted while the modal is open;
-    // This can happen when ejecting the project while viewing the output,
-    // since the CRA 'eject' task removes itself after completing (a project can
-    // only be ejected once)
-    // TODO: Remove this logic once 'eject' has its own module, and isn't
-    // considered a generic task.
-    const selectedTaskExists = tasks.find(task => task.id === selectedTaskId);
-
-    console.log({ selectedTaskExists, tasks, selectedTaskId });
+    // For example, This can happen when ejecting the project, since the
+    // create-react-app "eject" task removes itself upon completion.
+    const selectedTaskExists = tasks.some(task => task.id === selectedTaskId);
 
     return (
       <Module

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -27,6 +27,21 @@ class TaskRunnerPane extends Component<Props, State> {
     selectedTaskId: null,
   };
 
+  static getDerivedStateFromProps(props, state) {
+    // It's possible that this task is deleted while the modal is open;
+    // For example, This can happen when ejecting the project, since the
+    // create-react-app "eject" task removes itself upon completion.
+    const selectedTaskExists = props.tasks.some(
+      task => task.id === state.selectedTaskId
+    );
+
+    if (!selectedTaskExists) {
+      return { selectedTaskId: null };
+    }
+
+    return null;
+  }
+
   handleToggleTask = taskId => {
     const { tasks, runTask, abortTask } = this.props;
 
@@ -56,11 +71,6 @@ class TaskRunnerPane extends Component<Props, State> {
     const { tasks } = this.props;
     const { selectedTaskId } = this.state;
 
-    // It's possible that this task is deleted while the modal is open;
-    // For example, This can happen when ejecting the project, since the
-    // create-react-app "eject" task removes itself upon completion.
-    const selectedTaskExists = tasks.some(task => task.id === selectedTaskId);
-
     return (
       <Module
         title="Tasks"
@@ -79,13 +89,11 @@ class TaskRunnerPane extends Component<Props, State> {
           />
         ))}
 
-        {selectedTaskExists && (
-          <TaskDetailsModal
-            taskId={selectedTaskId}
-            isVisible={!!selectedTaskId}
-            onDismiss={this.handleDismissTaskDetails}
-          />
-        )}
+        <TaskDetailsModal
+          taskId={selectedTaskId}
+          isVisible={!!selectedTaskId}
+          onDismiss={this.handleDismissTaskDetails}
+        />
       </Module>
     );
   }

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -56,6 +56,16 @@ class TaskRunnerPane extends Component<Props, State> {
     const { tasks } = this.props;
     const { selectedTaskId } = this.state;
 
+    // It's possible that this task is deleted while the modal is open;
+    // This can happen when ejecting the project while viewing the output,
+    // since the CRA 'eject' task removes itself after completing (a project can
+    // only be ejected once)
+    // TODO: Remove this logic once 'eject' has its own module, and isn't
+    // considered a generic task.
+    const selectedTaskExists = tasks.find(task => task.id === selectedTaskId);
+
+    console.log({ selectedTaskExists, tasks, selectedTaskId });
+
     return (
       <Module
         title="Tasks"
@@ -74,11 +84,13 @@ class TaskRunnerPane extends Component<Props, State> {
           />
         ))}
 
-        <TaskDetailsModal
-          taskId={selectedTaskId}
-          isVisible={!!selectedTaskId}
-          onDismiss={this.handleDismissTaskDetails}
-        />
+        {selectedTaskExists && (
+          <TaskDetailsModal
+            taskId={selectedTaskId}
+            isVisible={!!selectedTaskId}
+            onDismiss={this.handleDismissTaskDetails}
+          />
+        )}
       </Module>
     );
   }

--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -132,16 +132,8 @@ export default (store: any) => (next: any) => (action: any) => {
         additionalArgs.push('--', '--coverage');
       }
 
-      /* Bypasses 'Are you sure?' check when ejecting CRA
-       *
-       * TODO: add windows support
-       */
-      const command =
-        project.type === 'create-react-app' && name === 'eject'
-          ? 'echo yes | npm'
-          : 'npm';
       const child = childProcess.spawn(
-        command,
+        'npm',
         ['run', name, ...additionalArgs],
         {
           cwd: projectPath,
@@ -158,6 +150,20 @@ export default (store: any) => (next: any) => (action: any) => {
       next(attachTaskMetadata(task, child.pid));
 
       child.stdout.on('data', data => {
+        // The 'eject' task prompts the user, to ask if they're sure.
+        // We can bypass this prompt, as our UI already has an alert that
+        // confirms this action.
+        // TODO: Eject deserves its own Redux action, to avoid cluttering up
+        // this generic "RUN_TASK" action.
+        // TODO: Is there a way to "future-proof" this, in case the CRA
+        // confirmation copy changes?
+        const isEjectPrompt = data
+          .toString()
+          .includes('Are you sure you want to eject? This action is permanent');
+
+        if (isEjectPrompt) {
+          sendCommandToProcess(child, 'y');
+        }
         next(receiveDataFromTaskExecution(task, data.toString()));
       });
 
@@ -269,4 +275,10 @@ const getDevServerCommand = (
     default:
       throw new Error('Unrecognized project type: ' + projectType);
   }
+};
+
+const sendCommandToProcess = (child: any, command) => {
+  // Commands have to be suffixed with '\n' to signal that the command is
+  // ready to be sent. Same as a regular command + hitting the enter key.
+  child.stdin.write(`${command}\n`);
 };

--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -277,7 +277,7 @@ const getDevServerCommand = (
   }
 };
 
-const sendCommandToProcess = (child: any, command) => {
+const sendCommandToProcess = (child: any, command: string) => {
   // Commands have to be suffixed with '\n' to signal that the command is
   // ready to be sent. Same as a regular command + hitting the enter key.
   child.stdin.write(`${command}\n`);


### PR DESCRIPTION
Thanks for your contribution!

Please fill out the following template with details about your pull request:

**Related Issue**
#25 

**Summary**
Thanks to @superhawk610's great suggestion, we no longer have to rely on `echo` to send a command to the running process. Yay unblocking windows support!

Incidentally, fixing this issue exposed a bug, which is that Guppy crashes when ejecting a project while the "View Details" modal is open. This is because the modal assumes a `task` will be provided, but the eject task removes itself. 

The fix is simply to unset the `selectedTaskId` state when the task is deleted. This feels like maybe it should move to Redux, since deriving state from props like this is discouraged... but I'm happy enough with this solution for now.