### PR TITLE
Use comments in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,22 @@
-<!-- 
+<!--
 Thanks for your contribution!
 
-Please fill out the following template with details about your pull request: 
+Please fill out the following template with details about your pull request:
 -->
 
 
 **Related Issue:**
-<!-- 
+<!--
 Please provide the related issue #. Note that in most cases, you should only be opening a pull request that implements a solution discussed in an issue. See our contribution guidelines for more info
+-->
 
 **Summary:**
-<!-- 
+<!--
 Please describe the change, and any high-level information about why the implementation is the way it is.
 -->
 
 **Screenshots/GIFs:**
-<!-- 
+<!--
 For changes that affect the UI, please include a screenshot of the change. If the change is related to part of a flow, please include a GIF screen recording.
 
 Free software to create screen-recording GIFs:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,25 @@
+<!-- 
 Thanks for your contribution!
 
-Please fill out the following template with details about your pull request:
+Please fill out the following template with details about your pull request: 
+-->
 
-**Related Issue**
+
+**Related Issue:**
+<!-- 
 Please provide the related issue #. Note that in most cases, you should only be opening a pull request that implements a solution discussed in an issue. See our contribution guidelines for more info
 
-**Summary**
+**Summary:**
+<!-- 
 Please describe the change, and any high-level information about why the implementation is the way it is.
+-->
 
-**Screenshots/GIFs**
+**Screenshots/GIFs:**
+<!-- 
 For changes that affect the UI, please include a screenshot of the change. If the change is related to part of a flow, please include a GIF screen recording.
 
 Free software to create screen-recording GIFs:
 - Giphy Capture (MacOS only): https://giphy.com/apps/giphycapture
 - Licecap (MacOS / Win): https://www.cockos.com/licecap/
 - Peek (Linux): https://github.com/phw/peek
+-->


### PR DESCRIPTION
@j-f1 suggested we use HTML comments in our issue templates, and I thought it'd be good to follow that pattern in PRs.