### PR TITLE
Refactor task middleware with redux-saga

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "redux-devtools": "3.4.1",
     "redux-devtools-dock-monitor": "1.1.3",
     "redux-devtools-log-monitor": "1.4.0",
+    "redux-saga": "^0.16.0",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
     "resolve": "1.6.0",

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,0 +1,6 @@
+import { all } from 'redux-saga/effects';
+import taskSaga from './task.saga';
+
+export default function*() {
+  yield all([taskSaga()]);
+}

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -1,0 +1,396 @@
+// @flow
+import { select, call, put, take, takeEvery } from 'redux-saga/effects';
+import { buffers, eventChannel, END } from 'redux-saga';
+import {
+  RUN_TASK,
+  ABORT_TASK,
+  COMPLETE_TASK,
+  LAUNCH_DEV_SERVER,
+  completeTask,
+  attachTaskMetadata,
+  receiveDataFromTaskExecution,
+  loadDependencyInfoFromDisk,
+} from '../actions';
+import { getProjectById } from '../reducers/projects.reducer';
+import { getPathForProjectId } from '../reducers/paths.reducer';
+import { isDevServerTask } from '../reducers/tasks.reducer';
+import findAvailablePort from '../services/find-available-port.service';
+import {
+  isWin,
+  formatCommandForPlatform,
+  getPathForPlatform,
+} from '../services/platform.services';
+
+import type { Task, ProjectType } from '../types';
+
+const { ipcRenderer } = window.require('electron');
+const childProcess = window.require('child_process');
+const psTree = window.require('ps-tree');
+
+function* launchDevServer({ task }) {
+  const project = yield select(getProjectById, task.projectId);
+  const projectPath = yield select(getPathForProjectId, task.projectId);
+
+  try {
+    const port = yield call(findAvailablePort);
+    const { commandArgs, commandEnv } = yield call(
+      getDevServerArguments,
+      task,
+      project.type,
+      port
+    );
+
+    /**
+     * NOTE: A quirk in Electron means we can't use `env` to supply
+     * environment variables, as you would traditionally:
+     *
+        childProcess.spawn(
+          `npm`,
+          ['run', name],
+          {
+            cwd: projectPath,
+            env: { PORT: port },
+          }
+        );
+    *
+    * If I try to run this, I get a bunch of nonsensical errors about
+    * no commands (not even built-in ones like `ls`) existing.
+    * I added a comment here:
+    * https://github.com/electron/electron/issues/3627
+    *
+    * As a workaround, I'm using "shell mode" to avoid having to
+    * specify environment variables:
+    */
+
+    const child = yield call(
+      [childProcess, 'spawn'],
+      formatCommandForPlatform('npm'),
+      commandArgs,
+      { cwd: projectPath, env: { ...commandEnv, PATH: getPathForPlatform() } }
+    );
+
+    // Now that we have a port/processId for the server, attach it to
+    // the task. The port is used for opening the app, the pid is used
+    // to kill the process
+    yield put(attachTaskMetadata(task, child.pid, port));
+
+    yield call([ipcRenderer, 'send'], 'addProcessId', child.pid);
+
+    const stdioChannel = yield call(createStdioChannel, child, {
+      stdout: emitter => data => {
+        // Ok so, unfortunately, failure-to-compile is still pushed
+        // through stdout, not stderr. We want that message specifically
+        // to trigger an error state, and so we need to parse it.
+        const text = data.toString();
+
+        const isError = text.includes('Failed to compile');
+
+        emitter({ channel: 'stdout', text, isError });
+      },
+      stderr: emitter => data => {
+        emitter({ channel: 'stderr', text: data.toString() });
+      },
+      exit: emitter => code => {
+        // For Windows Support
+        // Windows sends code 1 (I guess its because we foce kill??)
+        const successfulCode = isWin ? 1 : 0;
+        const wasSuccessful = code === successfulCode || code === null;
+        const timestamp = new Date();
+
+        emitter({ channel: 'exit', timestamp, wasSuccessful });
+        // calling emitter(END) will break out of the try block of any
+        // actively listening subscribers when they take() it
+        emitter(END);
+      },
+    });
+
+    try {
+      while (true) {
+        const message = yield take(stdioChannel);
+
+        // eslint-disable-next-line default-case
+        switch (message.channel) {
+          case 'stdout':
+            yield put(
+              receiveDataFromTaskExecution(task, message.text, message.isError)
+            );
+            break;
+          case 'stderr':
+            yield put(receiveDataFromTaskExecution(task, message.text));
+            break;
+          case 'exit':
+            yield call(displayTaskComplete, task);
+            yield put(
+              completeTask(task, message.timestamp, message.wasSuccessful)
+            );
+            break;
+        }
+      }
+    } finally {
+      /* child process has completed */
+    }
+  } catch (err) {
+    // TODO: Error handling (this can happen if the first 15 ports are occupied,
+    // or if there' s some generic Node error
+    console.error(err);
+  }
+}
+
+function* taskRun({ task }) {
+  const project = yield select(getProjectById, task.projectId);
+  const projectPath = yield select(getPathForProjectId, task.projectId);
+  const { name } = task;
+
+  // TEMPORARY HACK
+  // By default, create-react-app runs tests in interactive watch mode.
+  // This is a brilliant way to do it, but it's interactive, which won't
+  // work as-is.
+  // In the future, I expect "Tests" to get its own module on the project
+  // page, in which case we can support the interactive mode, except with
+  // descriptive buttons instead of cryptic letters!
+  // Alas, this would be mucho work, and this is an MVP. So for now, I'm
+  // disabling watch mode, and doing "just run all the tests once" mode.
+  // This is bad, and I feel bad, but it's a corner that needs to be cut,
+  // for now.
+  const additionalArgs = [];
+  if (project.type === 'create-react-app' && name === 'test') {
+    additionalArgs.push('--', '--coverage');
+  }
+
+  const child = yield call(
+    [childProcess, 'spawn'],
+    formatCommandForPlatform('npm'),
+    ['run', name, ...additionalArgs],
+    {
+      cwd: projectPath,
+      env: {
+        PATH: getPathForPlatform(),
+      },
+    }
+  );
+
+  // When this application exits, we want to kill this process.
+  // Send it up to the main process.
+  yield call([ipcRenderer, 'send'], child.pid);
+
+  // TODO: Does the renderer process still need to know about the child
+  // processId?
+  yield put(attachTaskMetadata(task, child.pid));
+
+  const stdioChannel = yield call(createStdioChannel, child, {
+    stdout: emitter => data => {
+      const isEjectPrompt = data
+        .toString()
+        .includes('Are you sure you want to eject? This action is permanent');
+
+      if (isEjectPrompt) {
+        sendCommandToProcess(child, 'y');
+      }
+
+      emitter({ channel: 'stdout', text: data.toString() });
+    },
+    stderr: emitter => data => {
+      emitter({ channel: 'stderr', text: data.toString() });
+    },
+    exit: emitter => code => {
+      const timestamp = new Date();
+
+      emitter({ channel: 'exit', timestamp, wasSuccessful: code === 0 });
+      emitter(END);
+    },
+  });
+
+  try {
+    while (true) {
+      const message = yield take(stdioChannel);
+
+      // eslint-disable-next-line default-case
+      switch (message.channel) {
+        case 'stdout':
+          yield put(receiveDataFromTaskExecution(task, message.text));
+          break;
+        case 'stderr':
+          yield put(receiveDataFromTaskExecution(task, message.text));
+          break;
+        case 'exit':
+          yield call(displayTaskComplete, task);
+          yield put(
+            completeTask(task, message.timestamp, message.wasSuccessful)
+          );
+          if (task.name === 'eject') {
+            yield put(loadDependencyInfoFromDisk(project.id, project.path));
+          }
+          break;
+      }
+    }
+  } finally {
+    /* child process has completed */
+  }
+}
+
+function* taskAbort({ task }) {
+  const { processId, name } = task;
+
+  // For Windows Support
+  // On Windows there is only one process so no need for psTree (see below)
+  // We use /f for focefully terminate process because it ask for confirmation
+  // We use /t to kill all child processes
+  // More info https://ss64.com/nt/taskkill.html
+  if (isWin) {
+    yield call([childProcess, 'spawn'], 'taskkill', [
+      '/pid',
+      processId,
+      '/f',
+      '/t',
+    ]);
+    yield call([ipcRenderer, 'send'], 'removeProcessId', processId);
+
+    const abortMessage = isDevServerTask(name)
+      ? 'Server stopped'
+      : 'Task aborted';
+
+    yield put(
+      receiveDataFromTaskExecution(task, `\u001b[31;1m${abortMessage}\u001b[0m`)
+    );
+  } else {
+    // Our child was spawned using `shell: true` to get around a quirk with
+    // electron not working when specifying environment variables the
+    // "correct" way (see comment above).
+    //
+    // Because of that, `child.pid` refers to the `sh` command that spawned
+    // the actual Node process, and so we need to use `psTree` to build a
+    // tree of descendent children and kill them that way.
+
+    // wrap psTree in a promise to facilitate use inside a saga (yield cannot
+    // be used inside a callback function, even when it's nested within a
+    // generator)
+    const promisifyPsTree = _processId =>
+      new Promise((resolve, reject) => {
+        psTree(_processId, (err, children) => {
+          if (err) return reject(err);
+          return resolve(children);
+        });
+      });
+
+    try {
+      const children = yield call(promisifyPsTree, processId);
+
+      // in the original task middleware, the below code would run regardless
+      // of psTree throwing an error, which I don't believe is correct; I imagine
+      // children would be undefined, null, or an empty array -- whichever, there
+      // doesn't seem to be any point to continue if this is the case. As such,
+      // I've kept it inside the try block.
+      const childrenPIDs = children.map(child => child.PID);
+
+      yield call([childProcess, 'spawn'], 'kill', ['-9', ...childrenPIDs]);
+
+      yield call([ipcRenderer, 'send'], 'removeProcessId', processId);
+
+      // Once the children are killed, we should dispatch a notification
+      // so that the terminal shows something about this update.
+      // My initial thought was that all tasks would have the same message,
+      // but given that we're treating `start` as its own special thing,
+      // I'm realizing that it should vary depending on the task type.
+      // TODO: Find a better place for this to live.
+      const abortMessage = isDevServerTask(name)
+        ? 'Server stopped'
+        : 'Task aborted';
+
+      yield put(
+        receiveDataFromTaskExecution(
+          task,
+          `\u001b[31;1m${abortMessage}\u001b[0m`
+        )
+      );
+    } catch (err) {
+      yield call([console, 'error'], 'Could not gather process children:', err);
+    }
+  }
+}
+
+function* displayTaskComplete(task) {
+  // Send a message to add info to the terminal about the task being done.
+  // TODO: ASCII fish art?
+
+  const message = 'Task completed';
+
+  yield put(
+    receiveDataFromTaskExecution(task, `\u001b[32;1m${message}\u001b[0m`)
+  );
+}
+
+function* taskComplete({ task }) {
+  if (task.processId) {
+    yield call([ipcRenderer, 'send'], 'removeProcessId', task.processId);
+  }
+
+  // The `eject` task is special; after running it, its dependencies will
+  // have changed.
+  // TODO: We should really have a `EJECT_PROJECT_COMPLETE` action that does
+  // this instead.
+  if (task.name === 'eject') {
+    const project = yield select(getProjectById, task.projectId);
+
+    yield put(loadDependencyInfoFromDisk(project.id, project.path));
+  }
+}
+
+const createStdioChannel = (
+  child: any,
+  handlers: {
+    stdout: (emitter: any) => (data: string) => null,
+    stderr: (emitter: any) => (data: string) => null,
+    exit: (emitter: any) => (code: number) => null,
+  }
+) => {
+  return eventChannel(emitter => {
+    child.stdout.on('data', handlers.stdout(emitter));
+    child.stderr.on('data', handlers.stderr(emitter));
+    child.on('exit', handlers.exit(emitter));
+
+    return () => {
+      /* unsubscribe any listeners */
+    };
+
+    // use an expanding buffer because we don't want to lose any information
+    // passed up by the child process. initialize it at a length of 2 because
+    // at bare minimum we expect to have 2 messages queued at some point (as
+    // the exit channel completes, it should emit the return code of the process
+    // and then immediately END
+  }, buffers.expanding(2));
+};
+
+const getDevServerArguments = (
+  task: Task,
+  projectType: ProjectType,
+  port: string
+) => {
+  switch (projectType) {
+    case 'create-react-app':
+      return { commandArgs: ['run', task.name], commandEnv: { PORT: port } };
+    case 'gatsby':
+      return {
+        commandArgs: ['run', task.name, '--', `-p ${port}`],
+        commandEnv: {},
+      };
+    default:
+      throw new Error('Unrecognized project type: ' + projectType);
+  }
+};
+
+const sendCommandToProcess = (child: any, command: string) => {
+  // Commands have to be suffixed with '\n' to signal that the command is
+  // ready to be sent. Same as a regular command + hitting the enter key.
+  child.stdin.write(`${command}\n`);
+};
+
+// $FlowFixMe
+export default function* rootSaga() {
+  yield takeEvery(LAUNCH_DEV_SERVER, launchDevServer);
+  // these saga handlers are named in reverse order (RUN_TASK => taskRun, etc.)
+  // to avoid naming conflicts with their related actions (completeTask is
+  // already an action creator).
+  yield takeEvery(RUN_TASK, taskRun);
+  yield takeEvery(ABORT_TASK, taskAbort);
+  yield takeEvery(COMPLETE_TASK, taskComplete);
+}

--- a/src/store/configure-store.dev.js
+++ b/src/store/configure-store.dev.js
@@ -1,14 +1,17 @@
 // @flow
 import { createStore, compose, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+import createSagaMiddleware from 'redux-saga';
 
 import rootReducer from '../reducers';
 import { handleReduxUpdates } from '../services/redux-persistence.service';
-import taskMiddleware from '../middlewares/task.middleware';
 import dependencyMiddleware from '../middlewares/dependency.middleware';
 import importProjectMiddleware from '../middlewares/import-project.middleware';
+import rootSaga from '../sagas';
 
 import DevTools from '../components/DevTools';
+
+const sagaMiddleware = createSagaMiddleware();
 
 export default function configureStore(initialState: any) {
   const store = createStore(
@@ -17,13 +20,15 @@ export default function configureStore(initialState: any) {
     compose(
       applyMiddleware(
         thunk,
-        taskMiddleware,
         dependencyMiddleware,
-        importProjectMiddleware
+        importProjectMiddleware,
+        sagaMiddleware
       ),
       DevTools.instrument()
     )
   );
+
+  sagaMiddleware.run(rootSaga);
 
   // Allow direct access to the store, for debugging/testing
   window.store = store;

--- a/src/store/configure-store.prod.js
+++ b/src/store/configure-store.prod.js
@@ -1,12 +1,15 @@
 // @flow
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+import createSagaMiddleware from 'redux-saga';
 
 import rootReducer from '../reducers';
 import { handleReduxUpdates } from '../services/redux-persistence.service';
-import taskMiddleware from '../middlewares/task.middleware';
 import dependencyMiddleware from '../middlewares/dependency.middleware';
 import importProjectMiddleware from '../middlewares/import-project.middleware';
+import rootSaga from '../sagas';
+
+const sagaMiddleware = createSagaMiddleware();
 
 export default function configureStore(initialState: any) {
   const store = createStore(
@@ -14,11 +17,13 @@ export default function configureStore(initialState: any) {
     initialState,
     applyMiddleware(
       thunk,
-      taskMiddleware,
       dependencyMiddleware,
-      importProjectMiddleware
+      importProjectMiddleware,
+      sagaMiddleware
     )
   );
+
+  sagaMiddleware.run(rootSaga);
 
   // Allow direct access to the store, for debugging/testing
   // Doing this in production as well for the simple reason that this app is

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,6 +2203,13 @@ create-react-app@1.5.2:
     tmp "0.0.31"
     validate-npm-package-name "^3.0.0"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2216,6 +2223,16 @@ cross-spawn@^4.0.0:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@3.x.x:
@@ -2486,6 +2503,10 @@ decompress-zip@0.3.0:
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -4880,7 +4901,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -6149,6 +6170,10 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -6691,7 +6716,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -7690,6 +7715,16 @@ redux-devtools@3.4.1:
     lodash "^4.2.0"
     prop-types "^15.5.7"
     redux-devtools-instrument "^1.0.1"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
+
+redux-saga@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
 
 redux-thunk@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Thanks for your contribution!

Please fill out the following template with details about your pull request:

**Related Issue** #97 

**Summary**
With @mik639's permission, I've refactored the task middleware to use redux-saga. I'm developing from a Windows machine, so I had to use @bennygenel's `windows-support` fork, and there are a few artifacts of that remaining in this code, but I figure the full redux-saga refactor is still a little ways off and with any luck we'll have Windows support merged into the master by then. If you'd like to run this yourself, it should be sufficient to just pull in `src/services/platform.services.js` from @bennygenel's repo [here](https://raw.githubusercontent.com/bennygenel/guppy/windows-support/src/services/platform.services.js). 

When reviewing, specifically look for my usage of raw synchronous function calls vs `yield call(...)` within generators, I'm fairly certain I used them correctly but could use some reassurance. In addition, I had to take an interesting approach to handling stdio channels within generator functions, so I'm curious if my `createStdioChannel` approach is the best way to go about this.
