### PR TITLE
Adds more tests for untested services

### DIFF
--- a/src/reducers/dependencies.reducer.test.js
+++ b/src/reducers/dependencies.reducer.test.js
@@ -57,7 +57,10 @@ Object {
       "homepage": "",
       "license": "",
       "name": "redux",
-      "repository": "",
+      "repository": Object {
+        "type": "",
+        "url": "",
+      },
       "status": "installing",
       "version": "",
     },

--- a/src/services/create-project-service.test.js
+++ b/src/services/create-project-service.test.js
@@ -1,0 +1,41 @@
+jest.mock('os', () => ({ homedir: jest.fn() }));
+
+jest.mock('../reducers/paths.reducer.js', () => ({
+  getDefaultParentPath: jest.fn(),
+}));
+
+import {
+  possibleProjectColors,
+  getColorForProject,
+  getBuildInstructions,
+} from './create-project.service';
+
+describe('getColorForProject', () => {
+  it('should pick a color from the defined project colours', () => {
+    const projectColor = getColorForProject('some-project-name');
+
+    const isKnownColor = possibleProjectColors.includes(projectColor);
+
+    expect(isKnownColor).toEqual(true);
+  });
+});
+
+describe('getBuildInstructions', () => {
+  const path = '/some/path';
+
+  it('should return the build instructions for a `create-react-app` project', () => {
+    const expectedOutput = ['npx', 'create-react-app', path];
+  });
+
+  it('should return the build instructions for a Gatsby project', () => {
+    const expectedOutput = ['npx', 'gatsby', path];
+  });
+
+  it('should throw an exception when passed an unknown project type', () => {
+    const projectType = 'some-unknown-project-type';
+
+    expect(() => getBuildInstructions(projectType, path)).toThrowError(
+      `Unrecognized project type: ${projectType}`
+    );
+  });
+});

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -107,18 +107,18 @@ export default (
   });
 };
 
-export const getColorForProject = (projectName: string) => {
-  const possibleProjectColors = [
-    COLORS.hotPink[700],
-    COLORS.pink[700],
-    COLORS.red[700],
-    COLORS.orange[700],
-    COLORS.green[700],
-    COLORS.teal[700],
-    COLORS.violet[700],
-    COLORS.purple[700],
-  ];
+export const possibleProjectColors = [
+  COLORS.hotPink[700],
+  COLORS.pink[700],
+  COLORS.red[700],
+  COLORS.orange[700],
+  COLORS.green[700],
+  COLORS.teal[700],
+  COLORS.violet[700],
+  COLORS.purple[700],
+];
 
+export const getColorForProject = (projectName: string) => {
   const projectColorIndex = random
     .create(projectName)
     .range(possibleProjectColors.length);

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -107,6 +107,7 @@ export default (
   });
 };
 
+// Exported so that getColorForProject can be tested
 export const possibleProjectColors = [
   COLORS.hotPink[700],
   COLORS.pink[700],

--- a/src/services/location.service.test.js
+++ b/src/services/location.service.test.js
@@ -12,7 +12,7 @@ describe('Location Service', () => {
   };
 
   describe('extractProjectIdFromUrl', () => {
-    test('should extract the project ID from the URL', () => {
+    it('should extract the project ID from the URL', () => {
       expect(extractProjectIdFromUrl(stubLocation)).toEqual('some-project-id');
     });
 
@@ -54,14 +54,14 @@ describe('Location Service', () => {
   });
 
   describe('buildUrlForProjectId', () => {
-    test('should return the correct project url based on the project ID', () => {
+    it('should return the correct project url based on the project ID', () => {
       expect(buildUrlForProjectId('some-project-id')).toEqual(
         '/project/some-project-id'
       );
     });
   });
   describe('buildUrlForProjectTask', () => {
-    test('should return the correct task url based on the project ID and task name', () => {
+    it('should return the correct task url based on the project ID and task name', () => {
       expect(
         buildUrlForProjectTask('some-project-id', 'some-task-name')
       ).toEqual('/project/some-project-id/tasks/some-task-name');

--- a/src/services/project-name-service.test.js
+++ b/src/services/project-name-service.test.js
@@ -1,11 +1,26 @@
-import { generateRandomName } from './project-name.service'
+import { generateRandomName, prefixes, suffixes } from './project-name.service';
 
 describe('generateRandomName', () => {
+  const projectName = generateRandomName();
+  const tokens = projectName.split(' ');
+
   it('should capitalize the first letter of each word in the project name', () => {
-    const projectName = generateRandomName()
+    tokens.map(token => () => expect(token.charAt(0)).stringMatching(/[A-Z]/));
+  });
 
-    const tokens = projectName.split(' ')
+  it('should put together a prefix and a suffix to generate a project name', () => {
+    // The list of words are lowercase, therefore we need to make sure our comparison is the same
+    // If the list ever changes to not be all lowercase, then this test will need to be changed/rewritten
+    const firstWord = tokens[0].toLowerCase();
+    const lastWord = tokens[tokens.length - 1].toLowerCase();
 
-    tokens.map(token => () => expect(token.charAt(0)).stringMatching(/[A-Z]/))
-  })
-})
+    // We're assuming there are only two words per project name
+    // If there are more, we're only testing if the first word is contained within prefix list
+    // and if the last word is contained in suffix list
+    const isFirstWordAPrefix = prefixes.includes(firstWord);
+    const isLastWordASuffix = suffixes.includes(lastWord);
+
+    expect(isFirstWordAPrefix).toEqual(true);
+    expect(isLastWordASuffix).toEqual(true);
+  });
+});

--- a/src/services/project-name-service.test.js
+++ b/src/services/project-name-service.test.js
@@ -1,0 +1,11 @@
+import { generateRandomName } from './project-name.service'
+
+describe('generateRandomName', () => {
+  it('should capitalize the first letter of each word in the project name', () => {
+    const projectName = generateRandomName()
+
+    const tokens = projectName.split(' ')
+
+    tokens.map(token => () => expect(token.charAt(0)).stringMatching(/[A-Z]/))
+  })
+})

--- a/src/services/project-name.service.js
+++ b/src/services/project-name.service.js
@@ -63,6 +63,7 @@ const pseudoAdjectives = [
   'ice',
 ];
 
+// Exported so we can test the generation of the project name (generateRandomName())
 export const prefixes = [...adjectives, ...pseudoAdjectives];
 
 const animalNames = [
@@ -176,4 +177,5 @@ const miscNouns = [
   'thing',
 ];
 
+// Exported so we can test the generation of the project name (generateRandomName())
 export const suffixes = [...animalNames, ...objects, ...miscNouns];

--- a/src/services/project-name.service.js
+++ b/src/services/project-name.service.js
@@ -63,7 +63,7 @@ const pseudoAdjectives = [
   'ice',
 ];
 
-const prefixes = [...adjectives, ...pseudoAdjectives];
+export const prefixes = [...adjectives, ...pseudoAdjectives];
 
 const animalNames = [
   'cat',
@@ -176,4 +176,4 @@ const miscNouns = [
   'thing',
 ];
 
-const suffixes = [...animalNames, ...objects, ...miscNouns];
+export const suffixes = [...animalNames, ...objects, ...miscNouns];

--- a/src/services/project-type-specifics.test.js
+++ b/src/services/project-type-specifics.test.js
@@ -1,18 +1,25 @@
-import { getDocumentationLink } from './project-type-specifics'
+import { getDocumentationLink } from './project-type-specifics';
 
 import type { ProjectType } from '../types';
 
 describe('getDocumentationLink', () => {
-  it("should get the documentation link for React", () => {
-    expect(getDocumentationLink('create-react-app')).toEqual('https://github.com/facebook/create-react-app#user-guide')
-  })
+  it('should get the documentation link for React', () => {
+    expect(getDocumentationLink('create-react-app')).toEqual(
+      'https://github.com/facebook/create-react-app#user-guide'
+    );
+  });
 
   it('should get the documentation link for Gatsby', () => {
-    expect(getDocumentationLink('gatsby')).toEqual('https://www.gatsbyjs.org/docs/')
-  })
+    expect(getDocumentationLink('gatsby')).toEqual(
+      'https://www.gatsbyjs.org/docs/'
+    );
+  });
 
   it('should throw an exception if passed a project type that is not defined', () => {
-    const unknownProjectType = 'some-unknown-project-type'
-    expect(() => getDocumentationLink(unknownProjectType)).toThrowError(`Unrecognized project type: ${unknownProjectType}`)
-  })
-})
+    const unknownProjectType = 'some-unknown-project-type';
+
+    expect(() => getDocumentationLink(unknownProjectType)).toThrowError(
+      `Unrecognized project type: ${unknownProjectType}`
+    );
+  });
+});

--- a/src/services/project-type-specifics.test.js
+++ b/src/services/project-type-specifics.test.js
@@ -1,0 +1,18 @@
+import { getDocumentationLink } from './project-type-specifics'
+
+import type { ProjectType } from '../types';
+
+describe('getDocumentationLink', () => {
+  it("should get the documentation link for React", () => {
+    expect(getDocumentationLink('create-react-app')).toEqual('https://github.com/facebook/create-react-app#user-guide')
+  })
+
+  it('should get the documentation link for Gatsby', () => {
+    expect(getDocumentationLink('gatsby')).toEqual('https://www.gatsbyjs.org/docs/')
+  })
+
+  it('should throw an exception if passed a project type that is not defined', () => {
+    const unknownProjectType = 'some-unknown-project-type'
+    expect(() => getDocumentationLink(unknownProjectType)).toThrowError(`Unrecognized project type: ${unknownProjectType}`)
+  })
+})

--- a/src/services/project-type-specifics.test.js
+++ b/src/services/project-type-specifics.test.js
@@ -3,16 +3,14 @@ import { getDocumentationLink } from './project-type-specifics';
 import type { ProjectType } from '../types';
 
 describe('getDocumentationLink', () => {
-  it('should get the documentation link for React', () => {
-    expect(getDocumentationLink('create-react-app')).toEqual(
-      'https://github.com/facebook/create-react-app#user-guide'
-    );
-  });
+  it('should get the documentation links by project type', () => {
+    const gatsbyString = getDocumentationLink('gatsby');
+    const createReactAppString = getDocumentationLink('create-react-app');
 
-  it('should get the documentation link for Gatsby', () => {
-    expect(getDocumentationLink('gatsby')).toEqual(
-      'https://www.gatsbyjs.org/docs/'
-    );
+    expect(typeof gatsbyString).toEqual('string');
+    expect(typeof createReactAppString).toEqual('string');
+
+    expect(gatsbyString).not.toBe(createReactAppString);
   });
 
   it('should throw an exception if passed a project type that is not defined', () => {
@@ -20,6 +18,10 @@ describe('getDocumentationLink', () => {
 
     expect(() => getDocumentationLink(unknownProjectType)).toThrowError(
       `Unrecognized project type: ${unknownProjectType}`
+    );
+
+    expect(() => getDocumentationLink()).toThrowError(
+      'Unrecognized project type: undefined'
     );
   });
 });

--- a/src/services/project-type-specifics.test.js
+++ b/src/services/project-type-specifics.test.js
@@ -19,9 +19,5 @@ describe('getDocumentationLink', () => {
     expect(() => getDocumentationLink(unknownProjectType)).toThrowError(
       `Unrecognized project type: ${unknownProjectType}`
     );
-
-    expect(() => getDocumentationLink()).toThrowError(
-      'Unrecognized project type: undefined'
-    );
   });
 });


### PR DESCRIPTION
**Related Issue**
#41 @joshwcomeau requested some tests to be written for the more important files/functions

**Summary**

Adding tests for some of the services/modules:

* [x] Project Name Service
* [x] Project Type Specifics

For the Project Name service, I had to export the prefixes and suffixes array to test against this list given the format we output. Let me know if you guys think this is an appropriate way to test this.

I did also add some tests for the `create-project.service.js`, but it doesn't test all of the contained functions (just the easy ones 😝). I did have to mock a few things, but maybe this mocking should live somewhere else, instead. WDYT?

There was a test that was failing for me locally in the `dependencies.reducer.test.js`, so I updated it. If that's not okay, I can revert that change.