### PR TITLE
Add 'reason' to PixelShifter

### DIFF
--- a/src/components/DeleteDependencyButton/DeleteDependencyButton.js
+++ b/src/components/DeleteDependencyButton/DeleteDependencyButton.js
@@ -61,7 +61,10 @@ class DeleteDependencyButton extends PureComponent<Props> {
         style={{ width: 75 }}
       >
         {isBeingDeleted ? (
-          <PixelShifter y={2}>
+          <PixelShifter
+            y={2}
+            reason="visually center the spinner within the button"
+          >
             <Spinner size={18} color={COLORS.white} />
           </PixelShifter>
         ) : (

--- a/src/components/DependencyDetails/DependencyDetails.js
+++ b/src/components/DependencyDetails/DependencyDetails.js
@@ -27,7 +27,10 @@ class DependencyDetails extends PureComponent<Props> {
         {({ name, latestVersion, lastUpdatedAt, isLoading }: NpmResult) => (
           <Fragment>
             <Header>
-              <PixelShifter y={-4}>
+              <PixelShifter
+                y={-4}
+                reason="Optical symmetry between top and left edge of parent"
+              >
                 <HeaderText>
                   <Name size="small">{dependency.name}</Name>
                   <Description>{dependency.description}</Description>

--- a/src/components/ModalHeader/ModalHeader.js
+++ b/src/components/ModalHeader/ModalHeader.js
@@ -29,8 +29,11 @@ class ModalHeader extends Component<Props> {
 
     return (
       <Wrapper colors={colors}>
-        <PixelShifter y={-5}>
-          <PixelShifter x={-1}>
+        <PixelShifter y={-5} reason="line-height fix">
+          <PixelShifter
+            x={-1}
+            reason="Align left edge of header with subheader"
+          >
             <Heading
               style={{
                 color: theme === 'standard' ? COLORS.gray[900] : COLORS.white,

--- a/src/components/PixelShifter/PixelShifter.js
+++ b/src/components/PixelShifter/PixelShifter.js
@@ -1,6 +1,21 @@
-import styled from 'styled-components';
+// @flow
+import React from 'react';
 
-export default styled.div`
-  width: 100%;
-  transform: translate(${props => props.x || 0}px, ${props => props.y || 0}px);
-`;
+type Props = {
+  x?: number,
+  y?: number,
+  reason: string,
+  children: React$Node,
+};
+
+const PixelShifter = ({ x = 0, y = 0, reason, children }: Props) => (
+  <div
+    style={{
+      transform: `translate(${x}px, ${y}px)`,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export default PixelShifter;

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -70,7 +70,10 @@ class ProjectPage extends Component<Props> {
     return (
       <FadeIn>
         <MainContentWrapper>
-          <PixelShifter x={-2}>
+          <PixelShifter
+            x={-2}
+            reason="Align left edge of title with the modules on page"
+          >
             <Heading size="xlarge" style={{ color: COLORS.purple[500] }}>
               {project.name}
             </Heading>


### PR DESCRIPTION
**Summary:**
While responding to a comment in #28, I saw a `<PixelShifter>` component, and it wasn't immediately clear to me what it was doing.

I added `<PixelShifter>` as a low-effort way to make subtle pixel tweaks for alignment, but I hadn't realized how inscrutable they'd be after a few weeks/months.

This PR adds a mandatory "reason" prop that can be used essentially as a comment (but because it's an actual prop, we can insist that it's supplied*)

* Weirdly, Flow doesn't seem to mind if it's omitted :/ it tells me "No errors" when I don't add it. It also says "No errors" when I do something totally wrong like `y="hello"`. So Flow appears to not be working properly on this component?

Both files (the `PixelShifter` component and its callsite) have `// @flow` enabled, so I'm completely befuddled. If anyone has any idea about this, would be greatly appreciated!