### PR TITLE
Tasks middleware to saga

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "redux-devtools": "3.4.1",
     "redux-devtools-dock-monitor": "1.1.3",
     "redux-devtools-log-monitor": "1.4.0",
-    "redux-saga": "^0.16.0",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
     "resolve": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "fix-path": "2.1.0",
     "gatsby-cli": "1.1.58",
     "ps-tree": "1.1.0",
-    "yarn": "1.9.2",
-    "redux-saga": "0.16.0"
+    "redux-saga": "0.16.0",
+    "yarn": "1.9.2"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.44",
@@ -58,7 +58,7 @@
     "babel-plugin-named-asset-import": "1.0.0-next.66cc7a90",
     "babel-preset-react-app": "4.0.0-next.66cc7a90",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
-    "chalk": "2.3.0",
+    "chalk": "2.4.1",
     "color": "3.0.0",
     "cross-env": "5.2.0",
     "css-loader": "0.28.9",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "redux-devtools": "3.4.1",
     "redux-devtools-dock-monitor": "1.1.3",
     "redux-devtools-log-monitor": "1.4.0",
+    "redux-saga": "^0.16.0",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
     "resolve": "1.6.0",

--- a/src/sagas/import-project.saga.test.js
+++ b/src/sagas/import-project.saga.test.js
@@ -6,7 +6,6 @@ import rootSaga, {
   importProject,
   inferProjectType,
 } from './import-project.saga';
-import electron from 'electron';
 import {
   importExistingProjectStart,
   importExistingProjectError,
@@ -22,7 +21,10 @@ import { getInternalProjectById } from '../reducers/projects.reducer';
 import { getColorForProject } from '../services/create-project.service';
 
 jest.mock('electron', () => ({
-  remote: { dialog: { showOpenDialog: jest.fn(), showErrorBox: jest.fn() } },
+  remote: {
+    app: { getAppPath: () => '' },
+    dialog: { showOpenDialog: jest.fn(), showErrorBox: jest.fn() },
+  },
 }));
 
 describe('import-project saga', () => {

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -5,3 +5,4 @@ import taskSaga from './task.saga';
 
 export default function*() {
   yield all([dependencySaga(), importProjectSaga(), taskSaga()]);
+}

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,7 +1,7 @@
 import { all } from 'redux-saga/effects';
 import dependencySaga from './dependency.saga';
 import importProjectSaga from './import-project.saga';
+import taskSaga from './task.saga';
 
 export default function*() {
-  yield all([dependencySaga(), importProjectSaga()]);
-}
+  yield all([dependencySaga(), importProjectSaga(), taskSaga()]);

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -1,0 +1,396 @@
+// @flow
+import { select, call, put, take, takeEvery } from 'redux-saga/effects';
+import { buffers, eventChannel, END } from 'redux-saga';
+import {
+  RUN_TASK,
+  ABORT_TASK,
+  COMPLETE_TASK,
+  LAUNCH_DEV_SERVER,
+  completeTask,
+  attachTaskMetadata,
+  receiveDataFromTaskExecution,
+  loadDependencyInfoFromDisk,
+} from '../actions';
+import { getProjectById } from '../reducers/projects.reducer';
+import { getPathForProjectId } from '../reducers/paths.reducer';
+import { isDevServerTask } from '../reducers/tasks.reducer';
+import findAvailablePort from '../services/find-available-port.service';
+import {
+  isWin,
+  formatCommandForPlatform,
+  getPathForPlatform,
+} from '../services/platform.services';
+
+import type { Task, ProjectType } from '../types';
+
+const { ipcRenderer } = window.require('electron');
+const childProcess = window.require('child_process');
+const psTree = window.require('ps-tree');
+
+function* launchDevServer({ task }) {
+  const project = yield select(getProjectById, task.projectId);
+  const projectPath = yield select(getPathForProjectId, task.projectId);
+
+  try {
+    const port = yield call(findAvailablePort);
+    const { commandArgs, commandEnv } = yield call(
+      getDevServerArguments,
+      task,
+      project.type,
+      port
+    );
+
+    /**
+     * NOTE: A quirk in Electron means we can't use `env` to supply
+     * environment variables, as you would traditionally:
+     *
+        childProcess.spawn(
+          `npm`,
+          ['run', name],
+          {
+            cwd: projectPath,
+            env: { PORT: port },
+          }
+        );
+    *
+    * If I try to run this, I get a bunch of nonsensical errors about
+    * no commands (not even built-in ones like `ls`) existing.
+    * I added a comment here:
+    * https://github.com/electron/electron/issues/3627
+    *
+    * As a workaround, I'm using "shell mode" to avoid having to
+    * specify environment variables:
+    */
+
+    const child = yield call(
+      [childProcess, 'spawn'],
+      formatCommandForPlatform('npm'),
+      commandArgs,
+      { cwd: projectPath, env: { ...commandEnv, PATH: getPathForPlatform() } }
+    );
+
+    // Now that we have a port/processId for the server, attach it to
+    // the task. The port is used for opening the app, the pid is used
+    // to kill the process
+    yield put(attachTaskMetadata(task, child.pid, port));
+
+    yield call([ipcRenderer, 'send'], 'addProcessId', child.pid);
+
+    const stdioChannel = yield call(createStdioChannel, child, {
+      stdout: emitter => data => {
+        // Ok so, unfortunately, failure-to-compile is still pushed
+        // through stdout, not stderr. We want that message specifically
+        // to trigger an error state, and so we need to parse it.
+        const text = data.toString();
+
+        const isError = text.includes('Failed to compile');
+
+        emitter({ channel: 'stdout', text, isError });
+      },
+      stderr: emitter => data => {
+        emitter({ channel: 'stderr', text: data.toString() });
+      },
+      exit: emitter => code => {
+        // For Windows Support
+        // Windows sends code 1 (I guess its because we foce kill??)
+        const successfulCode = isWin ? 1 : 0;
+        const wasSuccessful = code === successfulCode || code === null;
+        const timestamp = new Date();
+
+        emitter({ channel: 'exit', timestamp, wasSuccessful });
+        // calling emitter(END) will break out of the try block of any
+        // actively listening subscribers when they take() it
+        emitter(END);
+      },
+    });
+
+    try {
+      while (true) {
+        const message = yield take(stdioChannel);
+
+        // eslint-disable-next-line default-case
+        switch (message.channel) {
+          case 'stdout':
+            yield put(
+              receiveDataFromTaskExecution(task, message.text, message.isError)
+            );
+            break;
+          case 'stderr':
+            yield put(receiveDataFromTaskExecution(task, message.text));
+            break;
+          case 'exit':
+            yield call(displayTaskComplete, task);
+            yield put(
+              completeTask(task, message.timestamp, message.wasSuccessful)
+            );
+            break;
+        }
+      }
+    } finally {
+      /* child process has completed */
+    }
+  } catch (err) {
+    // TODO: Error handling (this can happen if the first 15 ports are occupied,
+    // or if there' s some generic Node error
+    console.error(err);
+  }
+}
+
+function* taskRun({ task }) {
+  const project = yield select(getProjectById, task.projectId);
+  const projectPath = yield select(getPathForProjectId, task.projectId);
+  const { name } = task;
+
+  // TEMPORARY HACK
+  // By default, create-react-app runs tests in interactive watch mode.
+  // This is a brilliant way to do it, but it's interactive, which won't
+  // work as-is.
+  // In the future, I expect "Tests" to get its own module on the project
+  // page, in which case we can support the interactive mode, except with
+  // descriptive buttons instead of cryptic letters!
+  // Alas, this would be mucho work, and this is an MVP. So for now, I'm
+  // disabling watch mode, and doing "just run all the tests once" mode.
+  // This is bad, and I feel bad, but it's a corner that needs to be cut,
+  // for now.
+  const additionalArgs = [];
+  if (project.type === 'create-react-app' && name === 'test') {
+    additionalArgs.push('--', '--coverage');
+  }
+
+  const child = yield call(
+    [childProcess, 'spawn'],
+    formatCommandForPlatform('npm'),
+    ['run', name, ...additionalArgs],
+    {
+      cwd: projectPath,
+      env: {
+        PATH: getPathForPlatform(),
+      },
+    }
+  );
+
+  // When this application exits, we want to kill this process.
+  // Send it up to the main process.
+  yield call([ipcRenderer, 'send'], child.pid);
+
+  // TODO: Does the renderer process still need to know about the child
+  // processId?
+  yield put(attachTaskMetadata(task, child.pid));
+
+  const stdioChannel = yield call(createStdioChannel, child, {
+    stdout: emitter => data => {
+      const isEjectPrompt = data
+        .toString()
+        .includes('Are you sure you want to eject? This action is permanent');
+
+      if (isEjectPrompt) {
+        sendCommandToProcess(child, 'y');
+      }
+
+      emitter({ channel: 'stdout', text: data.toString() });
+    },
+    stderr: emitter => data => {
+      emitter({ channel: 'stderr', text: data.toString() });
+    },
+    exit: emitter => code => {
+      const timestamp = new Date();
+
+      emitter({ channel: 'exit', timestamp, wasSuccessful: code === 0 });
+      emitter(END);
+    },
+  });
+
+  try {
+    while (true) {
+      const message = yield take(stdioChannel);
+
+      // eslint-disable-next-line default-case
+      switch (message.channel) {
+        case 'stdout':
+          yield put(receiveDataFromTaskExecution(task, message.text));
+          break;
+        case 'stderr':
+          yield put(receiveDataFromTaskExecution(task, message.text));
+          break;
+        case 'exit':
+          yield call(displayTaskComplete, task);
+          yield put(
+            completeTask(task, message.timestamp, message.wasSuccessful)
+          );
+          if (task.name === 'eject') {
+            yield put(loadDependencyInfoFromDisk(project.id, project.path));
+          }
+          break;
+      }
+    }
+  } finally {
+    /* child process has completed */
+  }
+}
+
+function* taskAbort({ task }) {
+  const { processId, name } = task;
+
+  // For Windows Support
+  // On Windows there is only one process so no need for psTree (see below)
+  // We use /f for focefully terminate process because it ask for confirmation
+  // We use /t to kill all child processes
+  // More info https://ss64.com/nt/taskkill.html
+  if (isWin) {
+    yield call([childProcess, 'spawn'], 'taskkill', [
+      '/pid',
+      processId,
+      '/f',
+      '/t',
+    ]);
+    yield call([ipcRenderer, 'send'], 'removeProcessId', processId);
+
+    const abortMessage = isDevServerTask(name)
+      ? 'Server stopped'
+      : 'Task aborted';
+
+    yield put(
+      receiveDataFromTaskExecution(task, `\u001b[31;1m${abortMessage}\u001b[0m`)
+    );
+  } else {
+    // Our child was spawned using `shell: true` to get around a quirk with
+    // electron not working when specifying environment variables the
+    // "correct" way (see comment above).
+    //
+    // Because of that, `child.pid` refers to the `sh` command that spawned
+    // the actual Node process, and so we need to use `psTree` to build a
+    // tree of descendent children and kill them that way.
+
+    // wrap psTree in a promise to facilitate use inside a saga (yield cannot
+    // be used inside a callback function, even when it's nested within a
+    // generator)
+    const promisifyPsTree = _processId =>
+      new Promise((resolve, reject) => {
+        psTree(_processId, (err, children) => {
+          if (err) return reject(err);
+          return resolve(children);
+        });
+      });
+
+    try {
+      const children = yield call(promisifyPsTree, processId);
+
+      // in the original task middleware, the below code would run regardless
+      // of psTree throwing an error, which I don't believe is correct; I imagine
+      // children would be undefined, null, or an empty array -- whichever, there
+      // doesn't seem to be any point to continue if this is the case. As such,
+      // I've kept it inside the try block.
+      const childrenPIDs = children.map(child => child.PID);
+
+      yield call([childProcess, 'spawn'], 'kill', ['-9', ...childrenPIDs]);
+
+      yield call([ipcRenderer, 'send'], 'removeProcessId', processId);
+
+      // Once the children are killed, we should dispatch a notification
+      // so that the terminal shows something about this update.
+      // My initial thought was that all tasks would have the same message,
+      // but given that we're treating `start` as its own special thing,
+      // I'm realizing that it should vary depending on the task type.
+      // TODO: Find a better place for this to live.
+      const abortMessage = isDevServerTask(name)
+        ? 'Server stopped'
+        : 'Task aborted';
+
+      yield put(
+        receiveDataFromTaskExecution(
+          task,
+          `\u001b[31;1m${abortMessage}\u001b[0m`
+        )
+      );
+    } catch (err) {
+      yield call([console, 'error'], 'Could not gather process children:', err);
+    }
+  }
+}
+
+function* displayTaskComplete(task) {
+  // Send a message to add info to the terminal about the task being done.
+  // TODO: ASCII fish art?
+
+  const message = 'Task completed';
+
+  yield put(
+    receiveDataFromTaskExecution(task, `\u001b[32;1m${message}\u001b[0m`)
+  );
+}
+
+function* taskComplete({ task }) {
+  if (task.processId) {
+    yield call([ipcRenderer, 'send'], 'removeProcessId', task.processId);
+  }
+
+  // The `eject` task is special; after running it, its dependencies will
+  // have changed.
+  // TODO: We should really have a `EJECT_PROJECT_COMPLETE` action that does
+  // this instead.
+  if (task.name === 'eject') {
+    const project = yield select(getProjectById, task.projectId);
+
+    yield put(loadDependencyInfoFromDisk(project.id, project.path));
+  }
+}
+
+const createStdioChannel = (
+  child: any,
+  handlers: {
+    stdout: (emitter: any) => (data: string) => null,
+    stderr: (emitter: any) => (data: string) => null,
+    exit: (emitter: any) => (code: number) => null,
+  }
+) => {
+  return eventChannel(emitter => {
+    child.stdout.on('data', handlers.stdout(emitter));
+    child.stderr.on('data', handlers.stderr(emitter));
+    child.on('exit', handlers.exit(emitter));
+
+    return () => {
+      /* unsubscribe any listeners */
+    };
+
+    // use an expanding buffer because we don't want to lose any information
+    // passed up by the child process. initialize it at a length of 2 because
+    // at bare minimum we expect to have 2 messages queued at some point (as
+    // the exit channel completes, it should emit the return code of the process
+    // and then immediately END
+  }, buffers.expanding(2));
+};
+
+const getDevServerArguments = (
+  task: Task,
+  projectType: ProjectType,
+  port: string
+) => {
+  switch (projectType) {
+    case 'create-react-app':
+      return { commandArgs: ['run', task.name], commandEnv: { PORT: port } };
+    case 'gatsby':
+      return {
+        commandArgs: ['run', task.name, '--', `-p ${port}`],
+        commandEnv: {},
+      };
+    default:
+      throw new Error('Unrecognized project type: ' + projectType);
+  }
+};
+
+const sendCommandToProcess = (child: any, command: string) => {
+  // Commands have to be suffixed with '\n' to signal that the command is
+  // ready to be sent. Same as a regular command + hitting the enter key.
+  child.stdin.write(`${command}\n`);
+};
+
+// $FlowFixMe
+export default function* rootSaga() {
+  yield takeEvery(LAUNCH_DEV_SERVER, launchDevServer);
+  // these saga handlers are named in reverse order (RUN_TASK => taskRun, etc.)
+  // to avoid naming conflicts with their related actions (completeTask is
+  // already an action creator).
+  yield takeEvery(RUN_TASK, taskRun);
+  yield takeEvery(ABORT_TASK, taskAbort);
+  yield takeEvery(COMPLETE_TASK, taskComplete);
+}

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -24,7 +24,7 @@ import { isWin, PACKAGE_MANAGER_CMD } from '../services/platform.service';
 import type { Task, ProjectType } from '../types';
 import type { Saga } from 'redux-saga';
 
-export function* launchDevServer({ task }): Saga<void> {
+export function* launchDevServer({ task }: { task: Task }): Saga<void> {
   const project = yield select(getProjectById, task.projectId);
   const projectPath = yield select(getPathForProjectId, task.projectId);
 
@@ -36,8 +36,6 @@ export function* launchDevServer({ task }): Saga<void> {
       project.type,
       port
     );
-
-    console.log({ ...getBaseProjectEnvironment(projectPath), ...env }.PATH);
 
     const child = yield call(
       [childProcess, childProcess.spawn],
@@ -116,7 +114,7 @@ export function* launchDevServer({ task }): Saga<void> {
   }
 }
 
-export function* taskRun({ task }): Saga<void> {
+export function* taskRun({ task }: { task: Task }): Saga<void> {
   const project = yield select(getProjectById, task.projectId);
   const projectPath = yield select(getPathForProjectId, task.projectId);
   const { name } = task;
@@ -213,7 +211,7 @@ export function* taskRun({ task }): Saga<void> {
   }
 }
 
-export function* taskAbort({ task }): Saga<void> {
+export function* taskAbort({ task }: { task: Task }): Saga<void> {
   const { processId, name } = task;
 
   yield call(killProcessId, processId);
@@ -234,7 +232,7 @@ export function* taskAbort({ task }): Saga<void> {
   );
 }
 
-export function* displayTaskComplete(task): Saga<void> {
+export function* displayTaskComplete(task: Task): Saga<void> {
   // Send a message to add info to the terminal about the task being done.
   // TODO: ASCII fish art?
 
@@ -245,7 +243,7 @@ export function* displayTaskComplete(task): Saga<void> {
   );
 }
 
-export function* taskComplete({ task }): Saga<void> {
+export function* taskComplete({ task }: { task: Task }): Saga<void> {
   if (task.processId) {
     yield call(
       [ipcRenderer, ipcRenderer.send],

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -1,0 +1,152 @@
+import { call, put, select } from 'redux-saga/effects';
+import { cloneableGenerator } from 'redux-saga/utils';
+import * as childProcess from 'child_process';
+import rootSaga, {
+  launchDevServer,
+  taskRun,
+  taskAbort,
+  displayTaskComplete,
+  taskComplete,
+  getBaseProjectEnvironment,
+  getDevServerCommand,
+} from './task.saga';
+import {
+  attachTaskMetadata,
+  receiveDataFromTaskExecution,
+  completeTask,
+  loadDependencyInfoFromDisk,
+} from '../actions';
+import { getProjectById } from '../reducers/projects.reducer';
+import { getPathForProjectId } from '../reducers/paths.reducer';
+import findAvailablePort from '../services/find-available-port.service';
+import { PACKAGE_MANAGER_CMD } from '../services/platform.service';
+import { EventEmitter } from 'events';
+import { ipcRenderer } from 'electron';
+
+// we want to watch and ensure that caught errors
+// are logged to the error log
+global.console = { error: jest.fn() };
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    send: jest.fn(),
+  },
+  remote: {
+    app: { getAppPath: () => '' },
+  },
+}));
+
+jest.mock('uuid/v1', () => () => 'mocked-uuid-v1');
+
+// we don't actually need to run these commands through
+// the terminal, so an object with similar shape to that
+// returned by `child_process.spawn` should be sufficient
+const mockSpawn = processId => {
+  const mockProcess = new EventEmitter();
+  mockProcess.stdout = new EventEmitter();
+  mockProcess.stderr = new EventEmitter();
+  mockProcess.pid = processId;
+
+  return mockProcess;
+};
+
+describe('task saga', () => {
+  beforeEach(() => {
+    window.process = { env: {} };
+  });
+
+  describe('launchDevServer saga', () => {
+    it('should throw if no task is provided', () => {
+      expect(() => launchDevServer()).toThrow();
+    });
+
+    const task = { projectId: 'pickled-tulip' };
+    const saga = cloneableGenerator(launchDevServer)({ task });
+    const project = { type: 'create-react-app' };
+    const projectPath = '/path/to/project';
+    const port = 3000;
+    const { args, env } = getDevServerCommand(task, project.type, port);
+    const processId = 12345;
+    const mockProcess = mockSpawn(processId);
+
+    it('should find project and projectPath', () => {
+      expect(saga.next().value).toEqual(select(getProjectById, task.projectId));
+      expect(saga.next(project).value).toEqual(
+        select(getPathForProjectId, task.projectId)
+      );
+    });
+
+    it('should find a port', () => {
+      expect(saga.next(projectPath).value).toEqual(call(findAvailablePort));
+    });
+
+    it('should log to console.error on error', () => {
+      const clone = saga.clone();
+      clone.next(port);
+      // destructuring undefined should throw
+      clone.next(undefined);
+      expect(console.error).toBeCalled();
+    });
+
+    it('should spawn a child process', () => {
+      expect(saga.next(port).value).toEqual(
+        call(getDevServerCommand, task, project.type, port)
+      );
+      expect(saga.next({ args, env }).value).toEqual(
+        call([childProcess, childProcess.spawn], PACKAGE_MANAGER_CMD, args, {
+          cwd: projectPath,
+          env: { ...getBaseProjectEnvironment(projectPath), ...env },
+        })
+      );
+    });
+
+    it('should attach task metadata and notify renderer', () => {
+      expect(saga.next(mockProcess).value).toEqual(
+        put(attachTaskMetadata(task, processId, port))
+      );
+      expect(saga.next().value).toEqual(
+        call([ipcRenderer, ipcRenderer.send], 'addProcessId', processId)
+      );
+    });
+
+    it('should display an error on compile failure', () => {
+      const clone = saga.clone();
+      const text = 'Uh-oh! Failed to compile!';
+
+      // `take` a log message
+      clone.next();
+
+      expect(
+        clone.next({ channel: 'stdout', text, isError: true }).value
+      ).toEqual(put(receiveDataFromTaskExecution(task, text, true)));
+    });
+
+    it('should display logs from stderr', () => {
+      const clone = saga.clone();
+      const text = "Oops, something went wrong but it's probably not fatal";
+
+      // `take` a log message
+      clone.next();
+
+      expect(clone.next({ channel: 'stdout', text }).value).toEqual(
+        put(receiveDataFromTaskExecution(task, text))
+      );
+    });
+
+    it('should complete on exit', () => {
+      const clone = saga.clone();
+      const timestamp = new Date();
+
+      // `take` a log message
+      clone.next();
+
+      expect(
+        clone.next({ channel: 'exit', timestamp, wasSuccessful: true }).value
+      ).toEqual(call(displayTaskComplete, task));
+
+      expect(clone.next().value).toEqual(
+        put(completeTask(task, timestamp, true))
+      );
+    });
+  });
+});

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -1,6 +1,9 @@
 import { call, put, select } from 'redux-saga/effects';
 import { cloneableGenerator } from 'redux-saga/utils';
 import * as childProcess from 'child_process';
+import * as path from 'path';
+import chalkRaw from 'chalk';
+
 import rootSaga, {
   launchDevServer,
   taskRun,
@@ -16,12 +19,14 @@ import {
   completeTask,
   loadDependencyInfoFromDisk,
 } from '../actions';
+import killProcessId from '../services/kill-process-id.service';
 import { getProjectById } from '../reducers/projects.reducer';
 import { getPathForProjectId } from '../reducers/paths.reducer';
 import findAvailablePort from '../services/find-available-port.service';
 import { PACKAGE_MANAGER_CMD } from '../services/platform.service';
-import { EventEmitter } from 'events';
 import { ipcRenderer } from 'electron';
+
+const chalk = new chalkRaw.constructor({ level: 3 });
 
 // we want to watch and ensure that caught errors
 // are logged to the error log
@@ -40,15 +45,25 @@ jest.mock('uuid/v1', () => () => 'mocked-uuid-v1');
 
 // we don't actually need to run these commands through
 // the terminal, so an object with similar shape to that
-// returned by `child_process.spawn` should be sufficient
-const mockSpawn = processId => {
-  const mockProcess = new EventEmitter();
-  mockProcess.stdout = new EventEmitter();
-  mockProcess.stderr = new EventEmitter();
-  mockProcess.pid = processId;
-
-  return mockProcess;
-};
+// returned by `child_process.spawn` should be sufficient.
+// Mock the relevant methods so they can be spied on.
+const mockSpawn = processId => ({
+  pid: processId,
+  write: jest.fn(),
+  on: jest.fn(),
+  stdin: {
+    write: jest.fn(),
+    on: jest.fn(),
+  },
+  stdout: {
+    write: jest.fn(),
+    on: jest.fn(),
+  },
+  stderr: {
+    write: jest.fn(),
+    on: jest.fn(),
+  },
+});
 
 describe('task saga', () => {
   beforeEach(() => {
@@ -147,6 +162,221 @@ describe('task saga', () => {
       expect(clone.next().value).toEqual(
         put(completeTask(task, timestamp, true))
       );
+    });
+  });
+
+  describe('taskRun saga', () => {
+    const task = { name: 'eject', projectId: 'pickled-tulip' };
+    const saga = cloneableGenerator(taskRun)({ task });
+    const projectReact = { type: 'create-react-app' };
+    const projectGatsby = { type: 'gatsby' };
+    const projectPath = '/path/to/project';
+    const processId = 12345;
+    const mockProcess = mockSpawn(processId);
+
+    // select project
+    saga.next();
+
+    it('should add --coverage arg to create-react-app tests', () => {
+      const name = 'test';
+      const saga = taskRun({ task: { name, projectId: '' } });
+      saga.next();
+      saga.next(projectReact);
+
+      expect(saga.next(projectPath).value).toEqual(
+        call(
+          [childProcess, childProcess.spawn],
+          PACKAGE_MANAGER_CMD,
+          ['run', name, '--coverage'],
+          {
+            cwd: projectPath,
+            env: getBaseProjectEnvironment(projectPath),
+          }
+        )
+      );
+    });
+
+    it('should run without additionalArgs for gatsby', () => {
+      const name = 'test';
+      const saga = taskRun({ task: { name, projectId: '' } });
+      saga.next();
+      saga.next(projectGatsby);
+
+      expect(saga.next(projectPath).value).toEqual(
+        call(
+          [childProcess, childProcess.spawn],
+          PACKAGE_MANAGER_CMD,
+          ['run', name],
+          {
+            cwd: projectPath,
+            env: getBaseProjectEnvironment(projectPath),
+          }
+        )
+      );
+    });
+
+    it('should run without additional args for create-react-app non-test tasks', () => {
+      const name = 'not-test';
+      const saga = taskRun({ task: { name, projectId: '' } });
+      saga.next();
+      saga.next(projectReact);
+
+      expect(saga.next(projectPath).value).toEqual(
+        call(
+          [childProcess, childProcess.spawn],
+          PACKAGE_MANAGER_CMD,
+          ['run', name],
+          {
+            cwd: projectPath,
+            env: getBaseProjectEnvironment(projectPath),
+          }
+        )
+      );
+    });
+
+    it('should attach task metadata and notify renderer', () => {
+      saga.next(projectReact);
+      saga.next(projectPath);
+
+      expect(saga.next(mockProcess).value).toEqual(
+        put(attachTaskMetadata(task, processId))
+      );
+      expect(saga.next().value).toEqual(
+        call([ipcRenderer, ipcRenderer.send], 'addProcessId', processId)
+      );
+    });
+
+    it('should display logs from stderr', () => {
+      const clone = saga.clone();
+      const text = "Oops, something went wrong but it's probably not fatal";
+
+      // `take` a log message
+      clone.next();
+
+      expect(clone.next({ channel: 'stdout', text }).value).toEqual(
+        put(receiveDataFromTaskExecution(task, text))
+      );
+    });
+
+    it('should complete on exit', () => {
+      const timestamp = new Date();
+
+      // `take` a log message
+      saga.next();
+
+      expect(
+        saga.next({ channel: 'exit', timestamp, wasSuccessful: true }).value
+      ).toEqual(call(displayTaskComplete, task));
+
+      expect(saga.next().value).toEqual(
+        put(completeTask(task, timestamp, true))
+      );
+    });
+
+    it('should reload dependencies after eject', () => {
+      // `loadDependencyInfoFromDisk` is a thunk, thus two copies
+      // constructed with identical arguments will return unique
+      // copies of the same anonymous function. As such, their JSON
+      // stringified representations are used for testing equality.
+      expect(JSON.stringify(saga.next().value)).toEqual(
+        JSON.stringify(
+          put(loadDependencyInfoFromDisk(task.projectId, projectPath))
+        )
+      );
+    });
+  });
+
+  describe('taskAbort saga', () => {
+    it('should kill process and notify renderer', () => {
+      const processId = 12345;
+      const saga = taskAbort({ task: { name: 'start', processId } });
+
+      expect(saga.next().value).toEqual(call(killProcessId, processId));
+      expect(saga.next().value).toEqual(
+        call([ipcRenderer, ipcRenderer.send], 'removeProcessId', processId)
+      );
+    });
+
+    it('should display correct message for dev server task', () => {
+      const task = { name: 'start', processId: 12345 }; // react
+      let saga = taskAbort({ task });
+      saga.next();
+      saga.next();
+
+      expect(saga.next().value).toEqual(
+        put(
+          receiveDataFromTaskExecution(task, chalk.bold.red('Server stopped'))
+        )
+      );
+
+      task.name = 'develop'; // gatsby
+      saga = taskAbort({ task });
+      saga.next();
+      saga.next();
+
+      expect(saga.next().value).toEqual(
+        put(
+          receiveDataFromTaskExecution(task, chalk.bold.red('Server stopped'))
+        )
+      );
+    });
+
+    it('should display correct message for non dev server task', () => {
+      const task = { name: 'test', processId: 12345 };
+      const saga = taskAbort({ task });
+      saga.next();
+      saga.next();
+
+      expect(saga.next().value).toEqual(
+        put(receiveDataFromTaskExecution(task, chalk.bold.red('Task aborted')))
+      );
+    });
+  });
+
+  describe('taskComplete saga', () => {
+    it('should do nothing if the task has no process id', () => {
+      const saga = taskComplete({ task: {} });
+
+      expect(saga.next().done).toBe(true);
+    });
+
+    it('should remove the process id from the renderer', () => {
+      const processId = 12345;
+      const saga = taskComplete({ task: { processId } });
+
+      expect(saga.next().value).toEqual(
+        call([ipcRenderer, ipcRenderer.send], 'removeProcessId', processId)
+      );
+    });
+
+    it('should reload dependency info if the task was an eject', () => {
+      const processId = 12345;
+      const project = { id: 'tangy-blueberry', path: '/path/to/project' };
+      const task = { processId, name: 'eject', projectId: project.id };
+      const saga = taskComplete({ task });
+      saga.next();
+
+      expect(saga.next().value).toEqual(select(getProjectById, task.projectId));
+      // stringify to avoid deep equal inconsistencies from thunk
+      expect(JSON.stringify(saga.next(project).value)).toEqual(
+        JSON.stringify(
+          put(loadDependencyInfoFromDisk(project.id, project.path))
+        )
+      );
+    });
+  });
+
+  describe('getBaseProjectEnvironment', () => {
+    it('should append project .bin directory to PATH', () => {
+      const projectPath = path.join('path', 'to', 'project');
+      const projectBinDirectory = path.join(
+        projectPath,
+        'node_modules',
+        '.bin'
+      );
+      const generatedEnv = getBaseProjectEnvironment(projectPath);
+
+      expect(generatedEnv.PATH).toContain(projectBinDirectory);
     });
   });
 });

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -35,6 +35,6 @@ export const formatCommandForPlatform = (command: string): string =>
 
 export const PACKAGE_MANAGER_CMD = path.join(
   remote.app.getAppPath(),
-  './node_modules/yarn/bin',
+  'node_modules/yarn/bin',
   formatCommandForPlatform(PACKAGE_MANAGER)
 );

--- a/src/store/configure-store.dev.js
+++ b/src/store/configure-store.dev.js
@@ -5,7 +5,6 @@ import createSagaMiddleware from 'redux-saga';
 
 import rootReducer from '../reducers';
 import { handleReduxUpdates } from '../services/redux-persistence.service';
-import taskMiddleware from '../middlewares/task.middleware';
 import rootSaga from '../sagas';
 
 import DevTools from '../components/DevTools';
@@ -17,7 +16,7 @@ export default function configureStore(initialState: any) {
     rootReducer,
     initialState,
     compose(
-      applyMiddleware(thunk, taskMiddleware, sagaMiddleware),
+      applyMiddleware(thunk, sagaMiddleware),
       DevTools.instrument()
     )
   );

--- a/src/store/configure-store.prod.js
+++ b/src/store/configure-store.prod.js
@@ -5,7 +5,6 @@ import createSagaMiddleware from 'redux-saga';
 
 import rootReducer from '../reducers';
 import { handleReduxUpdates } from '../services/redux-persistence.service';
-import taskMiddleware from '../middlewares/task.middleware';
 import rootSaga from '../sagas';
 
 const sagaMiddleware = createSagaMiddleware();
@@ -14,7 +13,7 @@ export default function configureStore(initialState: any) {
   const store = createStore(
     rootReducer,
     initialState,
-    applyMiddleware(thunk, taskMiddleware, sagaMiddleware)
+    applyMiddleware(thunk, sagaMiddleware)
   );
 
   sagaMiddleware.run(rootSaga);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,7 +2207,7 @@ create-react-app@1.5.2:
     tmp "0.0.31"
     validate-npm-package-name "^3.0.0"
 
-cross-env@5.2.0:
+cross-env@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   dependencies:
@@ -2238,10 +2238,6 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cross-unzip@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -2511,6 +2507,10 @@ decompress-zip@0.3.0:
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -7760,6 +7760,12 @@ redux-devtools@3.4.1:
     lodash "^4.2.0"
     prop-types "^15.5.7"
     redux-devtools-instrument "^1.0.1"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
 
 redux-saga@^0.16.0:
   version "0.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,7 +2207,7 @@ create-react-app@1.5.2:
     tmp "0.0.31"
     validate-npm-package-name "^3.0.0"
 
-cross-env@^5.2.0:
+cross-env@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   dependencies:
@@ -2238,6 +2238,10 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-unzip@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -2507,10 +2511,6 @@ decompress-zip@0.3.0:
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -7761,13 +7761,7 @@ redux-devtools@3.4.1:
     prop-types "^15.5.7"
     redux-devtools-instrument "^1.0.1"
 
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  dependencies:
-    deep-diff "^0.3.5"
-
-redux-saga@^0.16.0:
+redux-saga@0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
 


### PR DESCRIPTION
**Related PR:**
#111

**Summary:**
> I'm developing from a Windows machine, so I had to use @bennygenel's `windows-support` fork, and there are a few artifacts of that remaining in this code, but I figure the full redux-saga refactor is still a little ways off and with any luck we'll have Windows support merged into the master by then. If you'd like to run this yourself, it should be sufficient to just pull in `src/services/platform.services.js` from @bennygenel's repo [here](https://raw.githubusercontent.com/bennygenel/guppy/windows-support/src/services/platform.services.js). 

> I had to take an interesting approach to handling stdio channels within generator functions, so I'm curious if my `createStdioChannel` approach is the best way to go about this.

This PR takes the place of #111, and is only work-in-progress until I can update the `yield call` function signatures to match the format discussed in the final few comments on #117.