### PR TITLE
setup proper target for webpack and use import everywhere

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -13,6 +13,9 @@ const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent')
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 
+// List of packages not to bundle and just fall back to `require()`
+const externals = ['ps-tree', 'electron-store'];
+
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
 const publicPath = '/';
@@ -347,14 +350,14 @@ module.exports = {
   // Set the target as `electron-renderer` so that packages provided by electron
   // such as fs, path, electron are ignored by webpack
   target: 'electron-renderer',
-  externals: {
-    'ps-tree': {
-      commonjs: 'ps-tree',
-    },
-    'electron-store': {
-      commonjs: 'electron-store',
-    },
-  },
+  externals: [
+    function(context, request, callback) {
+      if (externals.indexOf(request) !== -1) {
+        return callback(null, 'commonjs ' + request);
+      }
+      callback();
+    }
+  ],
   // Turn off performance hints during development because we don't do any
   // splitting or minification in interest of speed. These warnings become
   // cumbersome.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -125,7 +125,6 @@ module.exports = {
     // for React Native Web.
     extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
-      
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
@@ -158,7 +157,6 @@ module.exports = {
               baseConfig: {
                 extends: [require.resolve('eslint-config-react-app')],
               },
-              
             },
             loader: require.resolve('eslint-loader'),
           },
@@ -195,7 +193,6 @@ module.exports = {
               {
                 loader: require.resolve('babel-loader'),
                 options: {
-                  
                   presets: [require.resolve('babel-preset-react-app')],
                   plugins: [
                     [
@@ -347,14 +344,16 @@ module.exports = {
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
   ],
-  // Some libraries import Node modules but don't use them in the browser.
-  // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    dgram: 'empty',
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-    child_process: 'empty',
+  // Set the target as `electron-renderer` so that packages provided by electron
+  // such as fs, path, electron are ignored by webpack
+  target: 'electron-renderer',
+  externals: {
+    'ps-tree': {
+      commonjs: 'ps-tree',
+    },
+    'electron-store': {
+      commonjs: 'electron-store',
+    },
   },
   // Turn off performance hints during development because we don't do any
   // splitting or minification in interest of speed. These warnings become

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -470,13 +470,15 @@ module.exports = {
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
   ],
-  // Some libraries import Node modules but don't use them in the browser.
-  // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    dgram: 'empty',
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-    child_process: 'empty',
+  // Set the target as `electron-renderer` so that packages provided by electron
+  // such as fs, path, electron are ignored by webpack
+  target: 'electron-renderer',
+  externals: {
+    'ps-tree': {
+      commonjs: 'ps-tree',
+    },
+    'electron-store': {
+      commonjs: 'electron-store',
+    },
   },
 };

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -15,6 +15,9 @@ const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent')
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 
+// List of packages not to bundle and just fall back to `require()`
+const externals = ['ps-tree', 'electron-store'];
+
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
 const publicPath = paths.servedPath;
@@ -473,12 +476,12 @@ module.exports = {
   // Set the target as `electron-renderer` so that packages provided by electron
   // such as fs, path, electron are ignored by webpack
   target: 'electron-renderer',
-  externals: {
-    'ps-tree': {
-      commonjs: 'ps-tree',
-    },
-    'electron-store': {
-      commonjs: 'electron-store',
-    },
-  },
+  externals: [
+    function(context, request, callback) {
+      if (externals.indexOf(request) !== -1) {
+        return callback(null, 'commonjs ' + request);
+      }
+      callback();
+    }
+  ],
 };

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -4,14 +4,14 @@
  */
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { shell, remote } from 'electron';
 
 import {
   createNewProjectStart,
   showImportExistingProjectPrompt,
 } from '../../actions';
 
-const { shell } = window.require('electron');
-const { app, process, Menu } = window.require('electron').remote;
+const { app, process, Menu } = remote;
 
 type Props = {
   createNewProjectStart: () => any,

--- a/src/components/DeleteDependencyButton/DeleteDependencyButton.js
+++ b/src/components/DeleteDependencyButton/DeleteDependencyButton.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { remote } from 'electron';
 
 import { deleteDependencyStart } from '../../actions';
 import { COLORS } from '../../constants';
@@ -10,7 +11,7 @@ import Button from '../Button';
 import Spinner from '../Spinner';
 import PixelShifter from '../PixelShifter';
 
-const { dialog } = window.require('electron').remote;
+const { dialog } = remote;
 
 type Props = {
   projectId: string,

--- a/src/components/EjectButton/EjectButton.js
+++ b/src/components/EjectButton/EjectButton.js
@@ -2,12 +2,13 @@
 import React, { PureComponent } from 'react';
 import IconBase from 'react-icons-kit';
 import { ic_eject as ejectIcon } from 'react-icons-kit/md/ic_eject';
+import { remote } from 'electron';
 
 import { COLORS } from '../../constants';
 
 import BigClickableButton from '../BigClickableButton';
 
-const { dialog } = window.require('electron').remote;
+const { dialog } = remote;
 
 type Props = {
   width: number,

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -1,10 +1,9 @@
 // @flow
 import React, { Component } from 'react';
 import styled from 'styled-components';
+import { shell } from 'electron';
 
 import { COLORS } from '../../constants';
-
-const { shell } = window.require('electron');
 
 type Props = {
   href: string,

--- a/src/components/HelpButton/HelpButton.js
+++ b/src/components/HelpButton/HelpButton.js
@@ -3,10 +3,9 @@ import React from 'react';
 import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { u2753 as questionMarkIcon } from 'react-icons-kit/noto_emoji_regular/u2753';
+import { shell } from 'electron';
 
 import { COLORS } from '../../constants';
-
-const { shell } = window.require('electron');
 
 type Props = {
   size?: number,

--- a/src/middlewares/import-project.middleware.js
+++ b/src/middlewares/import-project.middleware.js
@@ -1,4 +1,5 @@
 // @flow
+import { remote } from 'electron';
 import {
   SHOW_IMPORT_EXISTING_PROJECT_PROMPT,
   IMPORT_EXISTING_PROJECT_START,
@@ -13,7 +14,7 @@ import {
 } from '../services/read-from-disk.service';
 import { getColorForProject } from '../services/create-project.service';
 
-const { dialog } = window.require('electron').remote;
+const { dialog } = remote;
 
 // TODO: Flow types
 export default (store: any) => (next: any) => (action: any) => {

--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -1,4 +1,7 @@
 // @flow
+import { ipcRenderer } from 'electron';
+import * as childProcess from 'child_process';
+import psTree from 'ps-tree';
 import {
   RUN_TASK,
   ABORT_TASK,
@@ -15,10 +18,6 @@ import { isDevServerTask } from '../reducers/tasks.reducer';
 import findAvailablePort from '../services/find-available-port.service';
 
 import type { Task, ProjectType } from '../types';
-
-const { ipcRenderer } = window.require('electron');
-const childProcess = window.require('child_process');
-const psTree = window.require('ps-tree');
 
 export default (store: any) => (next: any) => (action: any) => {
   if (!action.task) {

--- a/src/reducers/paths.reducer.js
+++ b/src/reducers/paths.reducer.js
@@ -9,11 +9,10 @@
  * to be tied to a specific project (the same project might exist at different
  * paths on different computers!).
  */
+import * as os from 'os';
 import { ADD_PROJECT, IMPORT_EXISTING_PROJECT_FINISH } from '../actions';
 
 import type { Action } from 'redux';
-
-const os = window.require('os');
 
 type State = {
   [projectId: string]: string,

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -1,6 +1,8 @@
 // @flow
 import slug from 'slug';
 import random from 'random-seed';
+import * as fs from 'fs';
+import * as childProcess from 'child_process';
 
 import { COLORS } from '../constants';
 import { getDefaultParentPath } from '../reducers/paths.reducer';
@@ -8,9 +10,6 @@ import { getDefaultParentPath } from '../reducers/paths.reducer';
 import { FAKE_CRA_PROJECT } from './create-project.fixtures';
 
 import type { ProjectType } from '../types';
-
-const fs = window.require('fs');
-const childProcess = window.require('child_process');
 
 // Change this boolean flag to skip project creation.
 // Useful when working on the flow, to avoid having to wait for a real project

--- a/src/services/dependencies.service.js
+++ b/src/services/dependencies.service.js
@@ -1,5 +1,5 @@
 // @flow
-const childProcess = window.require('child_process');
+import * as childProcess from 'child_process';
 
 export const installDependency = (
   projectPath: string,

--- a/src/services/find-available-port.service.js
+++ b/src/services/find-available-port.service.js
@@ -11,7 +11,7 @@
  * this'd work if we port this app to Windows :( but hopefully it won't be too
  * hard of a problem!
  */
-const childProcess = window.require('child_process');
+import * as childProcess from 'child_process';
 
 const MAX_ATTEMPTS = 15;
 

--- a/src/services/read-from-disk.service.js
+++ b/src/services/read-from-disk.service.js
@@ -1,13 +1,12 @@
 // @flow
 import asyncMap from 'async/map';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import { pick } from '../utils';
 import { getDefaultParentPath } from '../reducers/paths.reducer';
 
 import type { DependencyLocation, ProjectInternal } from '../types';
-
-const fs = window.require('fs');
-const path = window.require('path');
 
 const DEFAULT_PARENT_PATH = getDefaultParentPath();
 

--- a/src/services/redux-persistence.service.js
+++ b/src/services/redux-persistence.service.js
@@ -1,4 +1,4 @@
-const ElectronStore = window.require('electron-store');
+import ElectronStore from 'electron-store';
 
 const electronStore = new ElectronStore();
 


### PR DESCRIPTION
**Summary:**
Webpack has a option to specify the target of the bundle as `electron` so that it knows that the nodejs built-in modules are ignored.
I also changed all the `window.require` to `import` so that flow knows how to deal with it.