### PR TITLE
Use correct package script for release build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,13 +89,13 @@ You can build an executable by running:
 
 ```
 # MacOS
-yarn package:mac
+yarn dist:mac
 
 # Windows
-yarn package:win
+yarn dist:win
 
 # Linux
-yarn package:linux
+yarn dist:linux
 ```
 
 The result will be in the `release-builds` folder.


### PR DESCRIPTION
This was discussed on Gitter while releasing 0.2.0 but somehow managed to slip through the merge. `yarn package:{platform}` builds for release, while `yarn dist:{platform}` first creates the React bundle and *then* builds for release. This PR updates the contribution guidelines to indicate the correct script.