### PR TITLE
Color Gradients for Storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-error.log*
 
 # because we use yarn.lock
 package-lock.json
+
+# storybook
+/storybook-static

--- a/.storybook/colors.stories.js
+++ b/.storybook/colors.stories.js
@@ -1,0 +1,39 @@
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import styled from 'styled-components';
+
+import Heading from '../src/components/Heading';
+import { contrastingColor } from '../src/utils';
+import { COLORS } from '../src/constants';
+
+storiesOf('Colors', module).add('Gradients', () => (
+  <div style={{ margin: '-1em', padding: '1em', background: '#eee' }}>
+    {Object.entries(COLORS)
+      .filter(([_, gradient]) => typeof gradient === 'object')
+      .map(([name, gradient], i) => (
+        <Fragment key={i}>
+          <Heading
+            style={{ marginTop: i === 0 ? 0 : '20px', marginBottom: '10px' }}
+          >
+            {name}
+          </Heading>
+          {Object.entries(gradient).map(([interval, color], j) => (
+            <ColorBlock key={j} color={color}>
+              {interval}
+            </ColorBlock>
+          ))}
+        </Fragment>
+      ))}
+  </div>
+));
+
+const ColorBlock = styled.div`
+  background: ${props => props.color};
+  border: 1px solid ${COLORS.gray[200]};
+  border-radius: 4px;
+  color: ${props => contrastingColor(props.color)};
+  text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 10px;
+`;

--- a/.storybook/colors.stories.js
+++ b/.storybook/colors.stories.js
@@ -1,39 +1,163 @@
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
 
 import Heading from '../src/components/Heading';
 import { contrastingColor } from '../src/utils';
-import { COLORS } from '../src/constants';
+import { COLORS as guppyColors } from '../src/constants';
+import { default as materialColors } from 'material-colors/dist/colors';
 
-storiesOf('Colors', module).add('Gradients', () => (
-  <div style={{ margin: '-1em', padding: '1em', background: '#eee' }}>
-    {Object.entries(COLORS)
-      .filter(([_, gradient]) => typeof gradient === 'object')
-      .map(([name, gradient], i) => (
-        <Fragment key={i}>
-          <Heading
-            style={{ marginTop: i === 0 ? 0 : '20px', marginBottom: '10px' }}
-          >
-            {name}
-          </Heading>
-          {Object.entries(gradient).map(([interval, color], j) => (
-            <ColorBlock key={j} color={color}>
-              {interval}
-            </ColorBlock>
-          ))}
-        </Fragment>
-      ))}
-  </div>
-));
+// `material-colors` provides icon color guides as well, but
+// we don't really need them as they're just repeats of the
+// `grey` values
+delete materialColors.darkIcons;
+delete materialColors.lightIcons;
+
+const info = {
+  common: (
+    <p>
+      These colors are commonly used throughout Guppy. If you are adding a new
+      component or changing the design of an existing component, try to
+      incorporate these colors first before looking to others.
+    </p>
+  ),
+  all: (
+    <p>
+      The following colors make up Google's{' '}
+      <a href="https://material.io/tools/color/">Material Design</a> palette. If
+      you are adding a new component or changing the design of an existing
+      component, try to incorporate one of the colors listed in the{' '}
+      <strong>Common</strong> section first before resorting to these colors. If
+      you do decide to use a color from this palette that we do not currently
+      use, make sure to add it to the <code>COLORS</code> constant in{' '}
+      <code>constants.js</code> and import/reference it from there.
+    </p>
+  ),
+};
+
+const styles = {
+  container: { margin: '-1em', padding: '1em', background: '#eee' },
+  heading: { marginTop: '20px', marginBottom: '10px' },
+  colorBlock: color => ({ background: color, color: contrastingColor(color) }),
+};
+
+// `colors` will be an array of the regular and alternate interval values
+const SplitColorSwatch = ({ colors, interval }) => (
+  <SplitColorBlock>
+    <ColorBlock style={styles.colorBlock(colors[0])}>{interval}</ColorBlock>
+    <ColorBlock style={styles.colorBlock(colors[1])}>
+      {interval} (alternate)
+    </ColorBlock>
+  </SplitColorBlock>
+);
+
+class ColorSwatches extends Component {
+  // `material-colors` provides color gradients in the following
+  // format:
+  //
+  //   {
+  //     100: '...',
+  //     a100: '...'
+  //   }
+  //
+  // where `a100` is the alternate shade of `100`. In order
+  // to display them in a useful way, we replace the regular
+  // interval entry with an array that contains both the regular
+  // entry and the alternate entry, and then display them side-
+  // by-side using a SplitColorSwatch
+  combineAlternates = gradient => {
+    const combinedGradient = {};
+
+    Object.keys(gradient).forEach(alternateInterval => {
+      if (alternateInterval.charAt(0) !== 'a') {
+        combinedGradient[alternateInterval] = gradient[alternateInterval];
+        return;
+      }
+
+      const regularInterval = alternateInterval.substring(1);
+      combinedGradient[regularInterval] = [
+        gradient[regularInterval],
+        gradient[alternateInterval],
+      ];
+    });
+
+    return combinedGradient;
+  };
+
+  // Combine regular and alternate entries in the gradient
+  // and then render them with a SplitColorSwatch
+  renderWithAlternates = gradient => {
+    gradient = this.combineAlternates(gradient);
+
+    return Object.entries(gradient).map(
+      ([interval, color], i) =>
+        Array.isArray(color) ? (
+          <SplitColorSwatch key={i} colors={color} interval={interval} />
+        ) : (
+          <ColorBlock key={i} style={styles.colorBlock(color)}>
+            {interval}
+          </ColorBlock>
+        )
+    );
+  };
+
+  // A couple colors (white and black) simply provide a single
+  // color value instead of a gradient, so just render them as
+  // a single swatch
+  renderSection = gradientOrColor => {
+    return typeof gradientOrColor === 'string' ? (
+      <ColorBlock style={styles.colorBlock(gradientOrColor)}>
+        {gradientOrColor}
+      </ColorBlock>
+    ) : (
+      this.renderWithAlternates(gradientOrColor)
+    );
+  };
+
+  render() {
+    const { colors, info } = this.props;
+    return (
+      <div style={styles.container}>
+        <InfoBlock>{info}</InfoBlock>
+        {Object.entries(colors).map(([name, gradientOrColor], i) => (
+          <Fragment key={i}>
+            <Heading style={styles.heading}>{name}</Heading>
+            {this.renderSection(gradientOrColor)}
+          </Fragment>
+        ))}
+      </div>
+    );
+  }
+}
+
+const InfoBlock = styled.div`
+  font-size: 18px;
+
+  code {
+    background: ${materialColors.grey[400]};
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 16px;
+  }
+`;
+
+const SplitColorBlock = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
 
 const ColorBlock = styled.div`
-  background: ${props => props.color};
-  border: 1px solid ${COLORS.gray[200]};
+  flex: 1;
+  border: 1px solid ${guppyColors.gray[200]};
   border-radius: 4px;
-  color: ${props => contrastingColor(props.color)};
   text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
   width: 100%;
   padding: 10px;
   margin-bottom: 10px;
 `;
+
+storiesOf('Colors', module)
+  .add('Common', () => (
+    <ColorSwatches colors={guppyColors} info={info.common} />
+  ))
+  .add('All', () => <ColorSwatches colors={materialColors} info={info.all} />);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -15,6 +15,7 @@ addDecorator(WrapperDecorator);
 const components = require.context('../src/components', true, /.stories.js$/);
 
 function loadStories() {
+  require('./colors.stories.js');
   components.keys().forEach(filename => components(filename));
 }
 

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,10 @@
+<style type="text/css">
+  /**
+  * By default, Storybook has the preview panel set to `overflow: auto`.
+  * For whatever reason, this causes two scrollbars to show up for all
+  * content. This removes the outer scrollbar.
+  */
+  .SplitPane > .Pane.Pane1.horizontal {
+    overflow: hidden !important;
+  }
+</style>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "prettier --write",
     "detect-port": "cross-env ./node_modules/detect-port-alt/bin/detect-port 3000",
     "precommit": "yarn run flow && lint-staged",
+    "build-storybook": "build-storybook -c .storybook -o storybook-static",
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "2.3.0",
     "color": "3.0.0",
+    "color-convert": "1.9.2",
     "cross-env": "5.2.0",
     "css-loader": "0.28.9",
     "dotenv": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "jest": "23.3",
     "lint-staged": "7.2.0",
     "loader-utils": "1.1.0",
+    "material-colors": "1.2.6",
     "moment": "2.22.2",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import convert from 'color-convert';
+import Color from 'color';
 
 // TODO: Modernize
 /* eslint-disable */
@@ -248,7 +248,7 @@ export const safeEscapeString = (val: string) =>
 // given a hex/rgb/hsl color value, determine the most
 // visible color to use to display text in front
 const LUMA_THRESHOLD = 165;
-const BASE_STACK_COLOR = 'rgb(255,255,255)';
+const BASE_STACK_COLOR = { r: 255, g: 255, b: 255, alpha: 1 };
 
 // weightings taken from SMPTE C, Rec. 709
 // see http://en.wikipedia.org/wiki/Luma_%28video%29 for more info
@@ -257,113 +257,52 @@ const G_WEIGHT = 0.7152;
 const B_WEIGHT = 0.0722;
 const luma = ({ r, g, b }) => r * R_WEIGHT + g * G_WEIGHT + b * B_WEIGHT;
 
-// input: #000 or #000000
-const getRgbFromHex = hex => {
-  const [r, g, b] = convert.hex.rgb(hex);
-  return { r, g, b };
-};
-
-// input: hsl(0,0%,0%)
-const getRgbFromHsl = hsl => {
-  const values = hsl
-    .substring(4, hsl.length - 1)
-    .replace(/%/g, '')
-    .split(',');
-  const [r, g, b] = convert.hsl.rgb(...values);
-  return { r, g, b };
-};
-
-// input: rgb(0,0,0)
-const getRgbFromRgb = rgb => {
-  const values = rgb.substring(4, rgb.length - 1).split(',');
-  return {
-    r: values[0],
-    g: values[1],
-    b: values[2],
-  };
-};
-
-// input: rgb(0,0,0) or rgba(0,0,0,0)
-const getRgbaFromRgba = rgba => {
-  if (rgba.charAt(3) !== 'a') {
-    return {
-      ...getRgbFromRgb(rgba),
-      a: 1,
-    };
-  }
-
-  const values = rgba.substring(5, rgba.length - 1).split(',');
-  return {
-    r: values[0],
-    g: values[1],
-    b: values[2],
-    a: values[3],
-  };
-};
-
-const rgbCodeFromRgbValues = ({ r, g, b }) => `rgb(${r},${g},${b})`;
-
-// Given a stack of RGB(A) values, calculate the effective
+// Given a stack of RGBA channels, calculate the effective
 // color when displayed in a browser.
 //
 // The first argument is the "bottom" of the stack, the second
 // is the next color up from the bottom, and so on.
-export const effectiveColorFromRgbaStack = (...layers) => {
+const effectiveColorFromRgbaStack = (...layers) => {
   // remove falsey values
-  layers = layers.filter(val => !!val && val);
+  layers = layers.filter(val => !!val);
 
-  // convert to { r, g, b } format and remove fully
-  // transparent values
-  layers = layers.map(getRgbaFromRgba).filter(rgba => rgba.a > 0);
+  // remove fully transparent values
+  layers = layers.filter(rgba => rgba.alpha);
 
-  if (!layers.length) return 'rgba(255,255,255,1)';
-  if (layers.length === 1) return rgbCodeFromRgbValues(layers[0]);
+  if (!layers.length) return BASE_STACK_COLOR;
+  if (layers.length === 1) return layers[0];
 
-  let base = layers[0];
+  let base = { ...layers[0] };
   layers.slice(1).forEach(layer => {
-    base.a = 1 - (1 - layer.a) * (1 - base.a);
+    base.alpha = 1 - (1 - layer.alpha) * (1 - base.alpha);
     base.r = Math.round(
-      (layer.r * layer.a) / base.a + (base.r * base.a * (1 - layer.a)) / base.a
+      (layer.r * layer.alpha) / base.alpha +
+        (base.r * base.alpha * (1 - layer.alpha)) / base.alpha
     );
     base.g = Math.round(
-      (layer.g * layer.a) / base.a + (base.g * base.a * (1 - layer.a)) / base.a
+      (layer.g * layer.alpha) / base.alpha +
+        (base.g * base.alpha * (1 - layer.alpha)) / base.alpha
     );
     base.b = Math.round(
-      (layer.b * layer.a) / base.a + (base.b * base.a * (1 - layer.a)) / base.a
+      (layer.b * layer.alpha) / base.alpha +
+        (base.b * base.alpha * (1 - layer.alpha)) / base.alpha
     );
   });
 
-  return rgbCodeFromRgbValues(base);
+  return base;
 };
 
-const parseRgb = colorCode => {
-  // strip whitespace
-  colorCode = colorCode.replace(/\s/g, '');
+const getEffectiveRgb = color => {
+  const channels = {
+    alpha: 1,
+    ...Color(color)
+      .rgb()
+      .object(),
+  };
 
-  // because I'm too lazy to write a HEXA -> RGBA converter
-  if (colorCode.charAt(0) === '#' && colorCode.length === 9) {
-    throw new Error(`HEXA is not supported ('${colorCode}')`);
-  }
-
-  if (colorCode.substring(0, 4) === 'rgba') {
-    return getRgbFromRgb(
-      effectiveColorFromRgbaStack(BASE_STACK_COLOR, colorCode)
-    );
-  }
-
-  if (colorCode.substring(0, 3) === 'rgb') {
-    return getRgbFromRgb(colorCode);
-  }
-
-  if (colorCode.charAt(0) === '#') {
-    return getRgbFromHex(colorCode);
-  }
-
-  if (colorCode.substring(0, 3) === 'hsl') {
-    return getRgbFromHsl(colorCode);
-  }
-
-  throw new Error(`Unrecognized color code: '${colorCode}'`);
+  if (channels.alpha !== 1)
+    return effectiveColorFromRgbaStack(BASE_STACK_COLOR, channels);
+  return channels;
 };
 
 export const contrastingColor = (
@@ -371,7 +310,9 @@ export const contrastingColor = (
   threshold = LUMA_THRESHOLD
 ) => {
   try {
-    return luma(parseRgb(backgroundColor)) >= LUMA_THRESHOLD ? '#000' : '#fff';
+    return luma(getEffectiveRgb(backgroundColor)) >= LUMA_THRESHOLD
+      ? '#000'
+      : '#fff';
   } catch (e) {
     console.warn(e + ', defaulting to #fff');
     return '#fff';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3079,11 +3079,21 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
+color-convert@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
 color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 color-name@^1.0.0, color-name@^1.1.1:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7398,6 +7398,10 @@ marksy@^6.0.3:
     he "^1.1.1"
     marked "^0.3.9"
 
+material-colors@1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"


### PR DESCRIPTION
**Related Issue:** #130 
**Related PR:** #136 

**Summary:**
While Storybook is generally used for displaying full Components, I've used it in personal projects as a style guide for newcomers. With this in mind, I think having an easy overview of all available colors in Guppy's palette is a great tool for new contributors and experienced users alike.

I took a page from @j-f1's book and deployed this to Netlify for easy demoing - link [here](https://happy-sinoussi-976836.netlify.com/).

**Screenshots/GIFs:**
![storybook-colors](https://user-images.githubusercontent.com/18172185/44297040-5899c000-a298-11e8-9175-bbee365c9339.gif)

