### PR TITLE
Add 'clear' button to TerminalOutput, tweak styles

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -6,7 +6,7 @@ import { COLORS } from '../../constants';
 
 import CircularOutline from '../CircularOutline';
 
-type Size = 'small' | 'medium' | 'large';
+type Size = 'xsmall' | 'small' | 'medium' | 'large';
 type Type = 'fill' | 'stroke';
 
 type Props = {
@@ -38,6 +38,8 @@ class Button extends Component<Props, State> {
 
   getButtonElem = (size: Size) => {
     switch (size) {
+      case 'xsmall':
+        return XSmallButton;
       case 'small':
         return SmallButton;
       default:
@@ -120,6 +122,13 @@ const ButtonBase = styled.button`
       ${COLORS.gray[300]}
     ) !important`};
   }
+`;
+
+const XSmallButton = styled(ButtonBase)`
+  padding: ${props => (props.noPadding ? '0px' : '0px 12px')};
+  height: ${props => (props.noPadding ? 'auto' : '22px')};
+  border-radius: 15px;
+  font-size: 12px;
 `;
 
 const SmallButton = styled(ButtonBase)`

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -10,7 +10,7 @@ import Button from './Button';
 
 const targetAction = decorateAction([args => [args[0].target]]);
 
-const SIZES = ['small', 'medium', 'large'];
+const SIZES = ['xsmall', 'small', 'medium', 'large'];
 
 storiesOf('Button', module)
   .add(

--- a/src/components/DevelopmentServerPane/DevelopmentServerPane.js
+++ b/src/components/DevelopmentServerPane/DevelopmentServerPane.js
@@ -3,17 +3,15 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { launchDevServer, clearConsole, abortTask } from '../../actions';
+import { launchDevServer, abortTask } from '../../actions';
 import { getSelectedProject } from '../../reducers/projects.reducer';
 import { getDevServerTaskForProjectId } from '../../reducers/tasks.reducer';
 import { getDocumentationLink } from '../../services/project-type-specifics';
-import { BREAKPOINTS, COLORS } from '../../constants';
+import { BREAKPOINTS } from '../../constants';
 
 import Module from '../Module';
 import Card from '../Card';
 import Toggle from '../Toggle';
-import Button from '../Button';
-import Heading from '../Heading';
 import Spacer from '../Spacer';
 import TerminalOutput from '../TerminalOutput';
 import ExternalLink from '../ExternalLink';
@@ -25,7 +23,6 @@ import type { Project, Task } from '../../types';
 type Props = {
   project: Project,
   task: ?Task,
-  clearConsole: (task: Task) => void,
   launchDevServer: (task: Task, timestamp: Date) => void,
   abortTask: (task: Task, timestamp: Date) => void,
 };
@@ -47,16 +44,6 @@ class DevelopmentServerPane extends PureComponent<Props> {
     } else {
       abortTask(task, timestamp);
     }
-  };
-
-  handleClear = () => {
-    const { task, clearConsole } = this.props;
-
-    if (!task) {
-      return;
-    }
-
-    clearConsole(task);
   };
 
   render() {
@@ -105,21 +92,7 @@ class DevelopmentServerPane extends PureComponent<Props> {
               {docLink}
             </InfoWrapper>
             <TerminalWrapper>
-              <PanelHeading size="small">
-                <Title>Server Logs</Title>
-                <ButtonStrip>
-                  <Button
-                    size="small"
-                    color1={COLORS.red[700]}
-                    color2={COLORS.red[500]}
-                    textColor={COLORS.red[700]}
-                    onClick={this.handleClear}
-                  >
-                    Clear
-                  </Button>
-                </ButtonStrip>
-              </PanelHeading>
-              <TerminalOutput height={300} logs={task.logs} />
+              <TerminalOutput height={300} title="Server Logs" task={task} />
             </TerminalWrapper>
           </Wrapper>
         </OnlyOn>
@@ -134,7 +107,7 @@ class DevelopmentServerPane extends PureComponent<Props> {
               </SmallInfoWrapper>
             </InfoWrapper>
             <TerminalWrapper>
-              <TerminalOutput height={300} logs={task.logs} />
+              <TerminalOutput height={300} task={task} />
             </TerminalWrapper>
           </Wrapper>
         </OnlyOn>
@@ -182,25 +155,10 @@ const Description = styled.div`
 `;
 
 const TerminalWrapper = styled.div`
-  overflow: auto;
-
   @media ${BREAKPOINTS.mdMin} {
     flex: 11;
     padding-left: 20px;
   }
-`;
-
-const PanelHeading = styled(Heading)`
-  display: flex;
-`;
-
-const ButtonStrip = styled.div`
-  padding: 5px;
-  margin-left: auto;
-`;
-
-const Title = styled.div`
-  line-height: 45px;
 `;
 
 const mapStateToProps = state => {
@@ -220,7 +178,7 @@ const mapStateToProps = state => {
   };
 };
 
-const mapDispatchToProps = { launchDevServer, abortTask, clearConsole };
+const mapDispatchToProps = { launchDevServer, abortTask };
 
 export default connect(
   mapStateToProps,

--- a/src/components/DevelopmentServerPane/DevelopmentServerPane.js
+++ b/src/components/DevelopmentServerPane/DevelopmentServerPane.js
@@ -158,6 +158,13 @@ const TerminalWrapper = styled.div`
   @media ${BREAKPOINTS.mdMin} {
     flex: 11;
     padding-left: 20px;
+    /*
+      overflow: hidden is needed so that the column won't expand when the
+      terminal output is really long. This way, it will be scrollable.
+    */
+    overflow: hidden;
+    /* Offset by the Card padding amount. */
+    margin-top: -15px;
   }
 `;
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -126,6 +126,11 @@ const Wrapper = styled.div.attrs({
   display: flex;
   justify-content: center;
   align-items: center;
+  /*
+    If items are too large to fit in the modal, we want them to be
+    scrollable.
+  */
+  overflow: auto;
 `;
 
 const Backdrop = styled.div`

--- a/src/components/PixelShifter/PixelShifter.js
+++ b/src/components/PixelShifter/PixelShifter.js
@@ -5,13 +5,21 @@ type Props = {
   x?: number,
   y?: number,
   reason: string,
+  style?: Object,
   children: React$Node,
 };
 
-const PixelShifter = ({ x = 0, y = 0, reason, children }: Props) => (
+const PixelShifter = ({
+  x = 0,
+  y = 0,
+  reason,
+  style = {},
+  children,
+}: Props) => (
   <div
     style={{
       transform: `translate(${x}px, ${y}px)`,
+      ...style,
     }}
   >
     {children}

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -15,7 +15,6 @@ import Toggle from '../Toggle';
 import LargeLED from '../LargeLED';
 import EjectButton from '../EjectButton';
 import TerminalOutput from '../TerminalOutput';
-import Spacer from '../Spacer';
 
 import type { Task } from '../../types';
 
@@ -40,61 +39,70 @@ class TaskDetailsModal extends PureComponent<Props> {
     isRunning ? abortTask(task, timestamp) : runTask(task, timestamp);
   };
 
-  getStatusText = () => {
-    const { status, timeSinceStatusChange } = this.props.task;
+  renderPrimaryStatusText = () => {
+    const { status } = this.props.task;
 
     switch (status) {
-      case 'idle': {
+      case 'idle':
         return (
-          <span>
+          <PrimaryStatusText>
             Task is <strong>idle</strong>.
-            {timeSinceStatusChange && (
-              <LastRunText>
-                Last run:{' '}
-                {moment(timeSinceStatusChange).format(
-                  'MMMM Do, YYYY [at] h:mm a'
-                )}
-              </LastRunText>
-            )}
-          </span>
+          </PrimaryStatusText>
         );
-      }
-      case 'pending': {
+
+      case 'pending':
         return (
-          <span>
+          <PrimaryStatusText>
             Task is{' '}
             <strong style={{ color: COLORS.orange[500] }}>running</strong>...
-          </span>
+          </PrimaryStatusText>
         );
-      }
 
-      case 'success': {
+      case 'success':
         return (
-          <span>
+          <PrimaryStatusText>
             Task{' '}
             <strong style={{ color: COLORS.green[700] }}>
               completed successfully
             </strong>.
-            <LastRunText>
-              {moment(timeSinceStatusChange).calendar()}
-            </LastRunText>
-          </span>
+          </PrimaryStatusText>
         );
-      }
 
-      case 'failed': {
+      case 'failed':
         return (
-          <span>
+          <PrimaryStatusText>
             Task <strong>failed</strong>.
-            <LastRunText>
-              {moment(timeSinceStatusChange).calendar()}
-            </LastRunText>
-          </span>
+          </PrimaryStatusText>
         );
-      }
+
+      default:
+        throw new Error('Unrecognized status in TaskDetailsModal.');
+    }
+  };
+
+  renderTimestamp = () => {
+    const { status, timeSinceStatusChange } = this.props.task;
+
+    switch (status) {
+      case 'idle':
+        return (
+          <LastRunText>
+            Last run:{' '}
+            {moment(timeSinceStatusChange).format('MMMM Do, YYYY [at] h:mm a')}
+          </LastRunText>
+        );
+
+      case 'pending':
+        return null;
+
+      case 'success':
+      case 'failed':
+        return (
+          <LastRunText>{moment(timeSinceStatusChange).calendar()}</LastRunText>
+        );
 
       default: {
-        throw new Error('Unrecognized status in TaskDetailsModal');
+        throw new Error('Unrecognized status in TaskDetailsModal.');
       }
     }
   };
@@ -106,7 +114,7 @@ class TaskDetailsModal extends PureComponent<Props> {
       return null;
     }
 
-    const { name, description, status, processId, logs } = task;
+    const { name, description, status, processId } = task;
 
     const isRunning = !!processId;
 
@@ -136,13 +144,16 @@ class TaskDetailsModal extends PureComponent<Props> {
 
         <MainContent>
           <Status>
-            <LargeLED size={32} status={status} />
-            <StatusLabel>{this.getStatusText()}</StatusLabel>
+            <LargeLED size={48} status={status} />
+            <StatusLabel>
+              {this.renderPrimaryStatusText()}
+              {this.renderTimestamp()}
+            </StatusLabel>
           </Status>
 
-          <Spacer size={25} />
+          <HorizontalRule />
 
-          <TerminalOutput height={425} logs={logs} />
+          <TerminalOutput height={425} title="Output" task={task} />
         </MainContent>
       </Fragment>
     );
@@ -171,16 +182,26 @@ const Description = styled.div`
 const Status = styled.div`
   display: flex;
   align-items: center;
-  font-size: 20px;
 `;
 
 const StatusLabel = styled.div`
   margin-left: 10px;
 `;
 
-const LastRunText = styled.span`
-  margin-left: 10px;
+const PrimaryStatusText = styled.div`
+  font-size: 20px;
+`;
+
+const LastRunText = styled.div`
   color: ${COLORS.gray[400]};
+  font-size: 16px;
+`;
+
+const HorizontalRule = styled.div`
+  height: 0px;
+  margin-top: 25px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid ${COLORS.gray[200]};
 `;
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -15,6 +15,7 @@ import Toggle from '../Toggle';
 import LargeLED from '../LargeLED';
 import EjectButton from '../EjectButton';
 import TerminalOutput from '../TerminalOutput';
+import WindowDimensions from '../WindowDimensions';
 
 import type { Task } from '../../types';
 
@@ -118,6 +119,15 @@ class TaskDetailsModal extends PureComponent<Props> {
 
     const isRunning = !!processId;
 
+    // HACK: So, we want the terminal to occupy as much height as it can.
+    // To do this, we set it to the window height, minus the height of all the
+    // other stuff added together.
+    // I can't simply use a flex column because the available modal height is
+    // unknown.
+    // It doesn't have to be perfect, so I'm not worried about small changes to
+    // the header or status indicators.
+    const APPROXIMATE_NON_TERMINAL_HEIGHT = 380;
+
     return (
       <Fragment>
         <ModalHeader
@@ -153,7 +163,15 @@ class TaskDetailsModal extends PureComponent<Props> {
 
           <HorizontalRule />
 
-          <TerminalOutput height={425} title="Output" task={task} />
+          <WindowDimensions>
+            {({ height }) => (
+              <TerminalOutput
+                height={height - APPROXIMATE_NON_TERMINAL_HEIGHT}
+                title="Output"
+                task={task}
+              />
+            )}
+          </WindowDimensions>
         </MainContent>
       </Fragment>
     );
@@ -200,7 +218,6 @@ const LastRunText = styled.div`
 const HorizontalRule = styled.div`
   height: 0px;
   margin-top: 25px;
-  margin-bottom: 15px;
   border-bottom: 1px solid ${COLORS.gray[200]};
 `;
 

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -84,6 +84,10 @@ class TaskDetailsModal extends PureComponent<Props> {
   renderTimestamp = () => {
     const { status, timeSinceStatusChange } = this.props.task;
 
+    if (!timeSinceStatusChange) {
+      return null;
+    }
+
     switch (status) {
       case 'idle':
         return (

--- a/src/components/TerminalOutput/TerminalOutput.js
+++ b/src/components/TerminalOutput/TerminalOutput.js
@@ -65,11 +65,6 @@ class TerminalOutput extends PureComponent<Props> {
   render() {
     const { width, height, title, task } = this.props;
 
-    // TODO: Check if `task` is actually always defined.
-    const logs = task ? task.logs : [];
-
-    console.log(task);
-
     return (
       <Fragment>
         <Header>
@@ -101,7 +96,7 @@ class TerminalOutput extends PureComponent<Props> {
         >
           <TableWrapper height={height}>
             <LogWrapper>
-              {logs.map(log => (
+              {task.logs.map(log => (
                 <LogRow
                   key={log.id}
                   dangerouslySetInnerHTML={{
@@ -122,8 +117,6 @@ const Header = styled.header`
   justify-content: space-between;
   align-items: center;
   height: 50px;
-  /* Offset by the Card padding amount. */
-  margin-top: -15px;
 `;
 
 const Wrapper = styled.div`

--- a/src/components/TerminalOutput/TerminalOutput.js
+++ b/src/components/TerminalOutput/TerminalOutput.js
@@ -1,10 +1,16 @@
 // @flow
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
+import { connect } from 'react-redux';
 import styled from 'styled-components';
 
+import { clearConsole } from '../../actions';
 import { COLORS } from '../../constants';
 
-import type { Log } from '../../types';
+import Button from '../Button';
+import Heading from '../Heading';
+import PixelShifter from '../PixelShifter';
+
+import type { Task } from '../../types';
 
 var Convert = require('ansi-to-html');
 var convert = new Convert();
@@ -12,12 +18,13 @@ var convert = new Convert();
 type Props = {
   width?: number,
   height?: number,
-  logs: Array<Log>,
+  title: string,
+  task: Task,
+  clearConsole: (task: Task) => void,
 };
 
 class TerminalOutput extends PureComponent<Props> {
   static defaultProps = {
-    logs: [],
     width: '100%',
     height: 200,
   };
@@ -45,31 +52,79 @@ class TerminalOutput extends PureComponent<Props> {
     this.node.scrollTop = maxScrollTop > 0 ? maxScrollTop : 0;
   };
 
+  handleClear = () => {
+    const { task, clearConsole } = this.props;
+
+    if (!task) {
+      return;
+    }
+
+    clearConsole(task);
+  };
+
   render() {
-    const { width, height, logs } = this.props;
+    const { width, height, title, task } = this.props;
+
+    // TODO: Check if `task` is actually always defined.
+    const logs = task ? task.logs : [];
+
+    console.log(task);
 
     return (
-      <Wrapper
-        width={width}
-        height={height}
-        innerRef={node => (this.node = node)}
-      >
-        <TableWrapper height={height}>
-          <LogWrapper>
-            {logs.map(log => (
-              <LogRow
-                key={log.id}
-                dangerouslySetInnerHTML={{
-                  __html: convert.toHtml(log.text),
-                }}
-              />
-            ))}
-          </LogWrapper>
-        </TableWrapper>
-      </Wrapper>
+      <Fragment>
+        <Header>
+          <Heading size="xsmall">{title}</Heading>
+          <PixelShifter
+            x={-1}
+            style={{ display: 'inherit' }}
+            reason={`
+              Buttons have a slightly-extruding stroke we want to
+              offset.
+            `}
+          >
+            <Button
+              size="xsmall"
+              type="fill"
+              color1={COLORS.red[700]}
+              color2={COLORS.red[500]}
+              textColor={COLORS.white}
+              onClick={this.handleClear}
+            >
+              Clear
+            </Button>
+          </PixelShifter>
+        </Header>
+        <Wrapper
+          width={width}
+          height={height}
+          innerRef={node => (this.node = node)}
+        >
+          <TableWrapper height={height}>
+            <LogWrapper>
+              {logs.map(log => (
+                <LogRow
+                  key={log.id}
+                  dangerouslySetInnerHTML={{
+                    __html: convert.toHtml(log.text),
+                  }}
+                />
+              ))}
+            </LogWrapper>
+          </TableWrapper>
+        </Wrapper>
+      </Fragment>
     );
   }
 }
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 50px;
+  /* Offset by the Card padding amount. */
+  margin-top: -15px;
+`;
 
 const Wrapper = styled.div`
   width: ${props =>
@@ -106,4 +161,7 @@ const LogRow = styled.div`
   white-space: pre;
 `;
 
-export default TerminalOutput;
+export default connect(
+  null,
+  { clearConsole }
+)(TerminalOutput);

--- a/src/components/WindowDimensions/WindowDimensions.js
+++ b/src/components/WindowDimensions/WindowDimensions.js
@@ -1,0 +1,40 @@
+// @flow
+import React, { Component } from 'react';
+
+import { throttle } from '../../utils';
+
+type State = {
+  width: Number,
+  height: Number,
+};
+type Props = {
+  children: (dimensions: State) => React$Node,
+};
+
+class WindowDimensions extends Component<Props, State> {
+  state = {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  handleResize = throttle(() => {
+    this.setState({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  }, 500);
+
+  render() {
+    return this.props.children(this.state);
+  }
+}
+
+export default WindowDimensions;

--- a/src/components/WindowDimensions/WindowDimensions.js
+++ b/src/components/WindowDimensions/WindowDimensions.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react';
+import { Component } from 'react';
 
 import { throttle } from '../../utils';
 

--- a/src/components/WindowDimensions/index.js
+++ b/src/components/WindowDimensions/index.js
@@ -1,0 +1,1 @@
+export { default } from './WindowDimensions';


### PR DESCRIPTION
**Summary:**
Earlier today, #57 was merged in. I had a couple extra things I wanted to do:

- Tweak the styling, because I'm nitpicky like that 😅Among some spacing tweaks, I set the button to be "filled" (the rough dichotomy in my head is that filled buttons mutate something / perform an action, whereas stroke buttons are just for showing information / opening modals).
- Add "clear" behaviour to the other terminal outputs, in the task detail modals.
- Tweak the "TaskDetailsModal" now that there's more stuff in it



**Screenshots/GIFs:**

Before: 
<img width="1117" alt="screen shot 2018-08-21 at 12 39 18 pm" src="https://user-images.githubusercontent.com/6692932/44421583-fdddbe00-a54e-11e8-9bfa-5988cf0f8658.png">

After: 
<img width="1117" alt="screen shot 2018-08-21 at 2 32 20 pm" src="https://user-images.githubusercontent.com/6692932/44421641-29f93f00-a54f-11e8-8b56-85f46d2990bc.png">

New details modal:
<img width="1117" alt="screen shot 2018-08-21 at 2 33 29 pm" src="https://user-images.githubusercontent.com/6692932/44421668-3bdae200-a54f-11e8-8055-9903c8ef889d.png">