### PR TITLE
Remove console.log calls

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -63,11 +63,11 @@ function runElectronApp(port) {
   electronProcess.stdout.on('data', data => {
     // dont log blank output or empty newlines
     const output = data.toString().trim();
-    if (output.length) console.log(chalk.green('[ELECTRON]'), output);
+    if (output.length) console.info(chalk.green('[ELECTRON]'), output);
   });
   electronProcess.stderr.on('data', data => {
     const output = data.toString();
-    console.log(chalk.red(`[ELECTRON] ${output}`));
+    console.error(chalk.red(`[ELECTRON] ${output}`));
   });
 
   // close webpack server when electron quits

--- a/src/main.js
+++ b/src/main.js
@@ -58,7 +58,7 @@ function createWindow() {
     try {
       installExtension(extension);
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }
 


### PR DESCRIPTION
This super-tiny change just removes `console.log` calls from around the codebase.

My philosophy is that `console.log` should only be used for temporary debugging statements. That way, when you're ready to open a PR, you can do a project-wide search for `console.log` and quickly clean them up.

`console.info` works just the same way as `console.log`, and feels a bit more semantic to boot. I also switched to `console.error` when the output was an error.