### PR TITLE
Fix issue with long-running task failure

### DIFF
--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -2,6 +2,7 @@
 import { ipcRenderer } from 'electron';
 import * as childProcess from 'child_process';
 import * as path from 'path';
+
 import {
   RUN_TASK,
   ABORT_TASK,

--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -2,6 +2,7 @@
 import { ipcRenderer } from 'electron';
 import * as childProcess from 'child_process';
 import * as path from 'path';
+import chalkRaw from 'chalk';
 
 import {
   RUN_TASK,
@@ -21,6 +22,8 @@ import killProcessId from '../services/kill-process-id.service';
 import { isWin, PACKAGE_MANAGER_CMD } from '../services/platform.service';
 
 import type { Task, ProjectType } from '../types';
+
+const chalk = new chalkRaw.constructor({ level: 3 });
 
 export default (store: any) => (next: any) => (action: any) => {
   if (!action.task) {
@@ -185,12 +188,7 @@ export default (store: any) => (next: any) => (action: any) => {
         ? 'Server stopped'
         : 'Task aborted';
 
-      next(
-        receiveDataFromTaskExecution(
-          task,
-          `\u001b[31;1m${abortMessage}\u001b[0m`
-        )
-      );
+      next(receiveDataFromTaskExecution(task, chalk.bold.red(abortMessage)));
 
       break;
     }
@@ -201,11 +199,9 @@ export default (store: any) => (next: any) => (action: any) => {
       // Send a message to add info to the terminal about the task being done.
       // TODO: ASCII fish art?
 
-      /* eslint-disable no-useless-concat */
       const message = wasSuccessful
-        ? '\u001b[32;1m' + 'Task Completed' + '\u001b[0m'
-        : '\u001b[31;1m' + 'Task Failed' + '\u001b[0m';
-      /* eslint-enable */
+        ? chalk.bold.green('Task completed')
+        : chalk.bold.red('Task failed');
 
       next(receiveDataFromTaskExecution(task, message));
 

--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -195,16 +195,16 @@ export default (store: any) => (next: any) => (action: any) => {
     }
 
     case COMPLETE_TASK: {
-      const { task } = action;
+      const { task, wasSuccessful } = action;
 
       // Send a message to add info to the terminal about the task being done.
       // TODO: ASCII fish art?
 
-      const message = 'Task completed';
+      const message = wasSuccessful
+        ? '\u001b[32;1m' + 'Task Completed' + '\u001b[0m'
+        : '\u001b[31;1m' + 'Task Failed' + '\u001b[0m';
 
-      next(
-        receiveDataFromTaskExecution(task, `\u001b[32;1m${message}\u001b[0m`)
-      );
+      next(receiveDataFromTaskExecution(task, message));
 
       if (task.processId) {
         ipcRenderer.send('removeProcessId', task.processId);

--- a/src/middlewares/task.middleware.js
+++ b/src/middlewares/task.middleware.js
@@ -200,9 +200,11 @@ export default (store: any) => (next: any) => (action: any) => {
       // Send a message to add info to the terminal about the task being done.
       // TODO: ASCII fish art?
 
+      /* eslint-disable no-useless-concat */
       const message = wasSuccessful
         ? '\u001b[32;1m' + 'Task Completed' + '\u001b[0m'
         : '\u001b[31;1m' + 'Task Failed' + '\u001b[0m';
+      /* eslint-enable */
 
       next(receiveDataFromTaskExecution(task, message));
 

--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -132,14 +132,24 @@ export default (state: State = initialState, action: Action) => {
           return;
         }
 
-        const nextStatus = !wasSuccessful
-          ? 'failed'
-          : task.type === 'short-term'
-            ? 'success'
-            : 'idle';
+        // For short-term tasks like building for production, we want to show
+        // either a success or failed status.
+        // For long-running tasks, though, once a task is completed, it goes
+        // back to being "idle" regardless of whether it was successful or not.
+        // Long-running tasks reserve "failed" for cases where the task is
+        // still running, it's just hit an error.
+        //
+        // TODO: Come up with a better model for all of this :/
+        let nextStatus;
+        if (task.type === 'short-term') {
+          nextStatus = wasSuccessful ? 'success' : 'failed';
+        } else {
+          nextStatus = 'idle';
+        }
 
         draftState[task.id].status = nextStatus;
         draftState[task.id].timeSinceStatusChange = timestamp;
+
         delete draftState[task.id].processId;
       });
     }

--- a/src/reducers/tasks.reducer.test.js
+++ b/src/reducers/tasks.reducer.test.js
@@ -295,7 +295,7 @@ describe('Tasks reducer', () => {
   });
 
   describe(COMPLETE_TASK, () => {
-    test('marks a sustained task as idle, on success', () => {
+    test('marks a sustained task as idle, when it was successful', () => {
       const mainTask = {
         id: 'foo-start',
         projectId: 'foo',
@@ -347,7 +347,7 @@ describe('Tasks reducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('marks a sustained task as idle, on failure', () => {
+    test('marks a sustained task as idle, when it fails', () => {
       const mainTask = {
         id: 'foo-start',
         projectId: 'foo',
@@ -399,7 +399,7 @@ describe('Tasks reducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('marks a short-term task as idle, on success', () => {
+    test('marks a short-term task as success, when it was successful', () => {
       const mainTask = {
         id: 'foo-start',
         projectId: 'foo',
@@ -451,7 +451,7 @@ describe('Tasks reducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('marks a short-term task as idle, on failure', () => {
+    test('marks a short-term task as failed, when it fails', () => {
       const mainTask = {
         id: 'foo-start',
         projectId: 'foo',

--- a/src/reducers/tasks.reducer.test.js
+++ b/src/reducers/tasks.reducer.test.js
@@ -295,7 +295,7 @@ describe('Tasks reducer', () => {
   });
 
   describe(COMPLETE_TASK, () => {
-    test('marks a task as idle, on success', () => {
+    test('marks a sustained task as idle, on success', () => {
       const mainTask = {
         id: 'foo-start',
         projectId: 'foo',
@@ -331,13 +331,14 @@ describe('Tasks reducer', () => {
         type: COMPLETE_TASK,
         task: mainTask,
         timestamp,
+        wasSuccessful: true,
       };
 
       const actualState = reducer(initialState, action);
       const expectedState = {
         'foo-start': {
           ...mainTask,
-          status: 'failed',
+          status: 'idle',
           timeSinceStatusChange: timestamp,
         },
         'foo-build': otherTask,
@@ -346,7 +347,7 @@ describe('Tasks reducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('marks a task as failed, on failure', () => {
+    test('marks a sustained task as idle, on failure', () => {
       const mainTask = {
         id: 'foo-start',
         projectId: 'foo',
@@ -382,6 +383,111 @@ describe('Tasks reducer', () => {
         type: COMPLETE_TASK,
         task: mainTask,
         timestamp,
+        wasSuccessful: false,
+      };
+
+      const actualState = reducer(initialState, action);
+      const expectedState = {
+        'foo-start': {
+          ...mainTask,
+          status: 'idle',
+          timeSinceStatusChange: timestamp,
+        },
+        'foo-build': otherTask,
+      };
+
+      expect(actualState).toEqual(expectedState);
+    });
+
+    test('marks a short-term task as idle, on success', () => {
+      const mainTask = {
+        id: 'foo-start',
+        projectId: 'foo',
+        name: 'start',
+        command: 'react-scripts start',
+        description: getTaskDescription('start'),
+        status: 'success',
+        timeSinceStatusChange: null,
+        logs: [],
+        type: 'short-term',
+      };
+
+      const otherTask = {
+        id: 'foo-build',
+        projectId: 'foo',
+        name: 'build',
+        command: 'react-scripts build',
+        description: getTaskDescription('build'),
+        status: 'pending',
+        timeSinceStatusChange: null,
+        logs: [],
+        type: 'short-term',
+      };
+
+      const initialState = {
+        'foo-start': mainTask,
+        'foo-build': otherTask,
+      };
+
+      const timestamp = new Date();
+
+      const action = {
+        type: COMPLETE_TASK,
+        task: mainTask,
+        timestamp,
+        wasSuccessful: true,
+      };
+
+      const actualState = reducer(initialState, action);
+      const expectedState = {
+        'foo-start': {
+          ...mainTask,
+          status: 'success',
+          timeSinceStatusChange: timestamp,
+        },
+        'foo-build': otherTask,
+      };
+
+      expect(actualState).toEqual(expectedState);
+    });
+
+    test('marks a short-term task as idle, on failure', () => {
+      const mainTask = {
+        id: 'foo-start',
+        projectId: 'foo',
+        name: 'start',
+        command: 'react-scripts start',
+        description: getTaskDescription('start'),
+        status: 'success',
+        timeSinceStatusChange: null,
+        logs: [],
+        type: 'short-term',
+      };
+
+      const otherTask = {
+        id: 'foo-build',
+        projectId: 'foo',
+        name: 'build',
+        command: 'react-scripts build',
+        description: getTaskDescription('build'),
+        status: 'pending',
+        timeSinceStatusChange: null,
+        logs: [],
+        type: 'short-term',
+      };
+
+      const initialState = {
+        'foo-start': mainTask,
+        'foo-build': otherTask,
+      };
+
+      const timestamp = new Date();
+
+      const action = {
+        type: COMPLETE_TASK,
+        task: mainTask,
+        timestamp,
+        wasSuccessful: false,
       };
 
       const actualState = reducer(initialState, action);


### PR DESCRIPTION
**Related Issue:** #143

**Summary:**
There are two different potential states that we were treating the same:
- The server hit an error but is still running (eg. syntax error in userland code)
- Server crash (eg. can't find babel modules)

The bug was because we assume that "failed" for long-running tasks means that the server is still running, it's just waiting for the user to fix the issue and save the file. In this case, though, the server had crashed and was no longer running.

I feel pretty icky about how we're managing statuses, the difference between short-term and sustained tasks, etc. The whole thing could use an overhaul, but I still don't know exactly what the mental model should be... Maybe we should have an `isRunning` boolean in addition to states like `success`, `idle`, `aborted`, `crashed`, `error`? I don't like the idea of having 2 different variables because of how many possible states it introduces (eg. how would `{ isRunning: true, status: 'crashed' }` work?), but maybe we could work around that somehow...

TL:DR; I think there's a better way to do this, and I'm totally up for chatting about possible better implementations, but I don't expect to have the time to tear it all up, so I think this "quick fix" is probably sufficient for now.

**Screenshots/GIFs:**
![failure](https://user-images.githubusercontent.com/6692932/44465578-ff10f880-a5eb-11e8-8716-2689ea33dd8d.gif)

