### PR TITLE
Fix modal header styling

### DIFF
--- a/src/components/ModalHeader/ModalHeader.js
+++ b/src/components/ModalHeader/ModalHeader.js
@@ -29,22 +29,24 @@ class ModalHeader extends Component<Props> {
 
     return (
       <Wrapper colors={colors}>
-        <PixelShifter y={-5} reason="line-height fix">
-          <PixelShifter
-            x={-1}
-            reason="Align left edge of header with subheader"
-          >
-            <Heading
-              style={{
-                color: theme === 'standard' ? COLORS.gray[900] : COLORS.white,
-              }}
+        <MainContent>
+          <PixelShifter y={-5} reason="line-height fix">
+            <PixelShifter
+              x={-1}
+              reason="Align left edge of header with subheader"
             >
-              {title}
-            </Heading>
-          </PixelShifter>
+              <Heading
+                style={{
+                  color: theme === 'standard' ? COLORS.gray[900] : COLORS.white,
+                }}
+              >
+                {title}
+              </Heading>
+            </PixelShifter>
 
-          {children}
-        </PixelShifter>
+            {children}
+          </PixelShifter>
+        </MainContent>
 
         <ActionWrapper>{action}</ActionWrapper>
       </Wrapper>
@@ -58,6 +60,10 @@ const Wrapper = styled.header`
   padding: 25px 25px 15px 25px;
   background-image: linear-gradient(15deg, ${props => props.colors.join(', ')});
   border-radius: 8px 8px 0 0;
+`;
+
+const MainContent = styled.div`
+  flex: 1;
 `;
 
 const ActionWrapper = styled.div`

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -197,8 +197,8 @@ const MainContent = styled.section`
 `;
 
 const Description = styled.div`
-  font-size: 24px;
-  color: ${COLORS.gray[600]};
+  font-size: 21px;
+  color: ${COLORS.gray[500]};
 `;
 
 const Status = styled.div`


### PR DESCRIPTION
**Summary:**
Two style tweaks that were bugging me:
- TaskDetailsModal now has smaller/lighter sub-headers. Felt way too prominent.
- The AddDependencyModal search input was too narrow, it ought to stretch the entire header.

I know these are really nitpicky / not high-priority, but whatever 🤷‍♀️ I really wanted to fix it!

**Screenshots/GIFs:**
TaskDetailsModal, before/after:
<img width="1119" alt="screen shot 2018-08-22 at 3 44 53 pm" src="https://user-images.githubusercontent.com/6692932/44486849-ba548400-a622-11e8-8602-5076a9cc6238.png">

<img width="1120" alt="screen shot 2018-08-22 at 3 45 40 pm" src="https://user-images.githubusercontent.com/6692932/44486855-be80a180-a622-11e8-9cdc-4d68cff6f050.png">


AddDependencyModal, before/after:
<img width="1119" alt="screen shot 2018-08-22 at 3 45 26 pm" src="https://user-images.githubusercontent.com/6692932/44486848-ba548400-a622-11e8-8466-e7c0b4d3d70e.png">
<img width="1120" alt="screen shot 2018-08-22 at 3 45 52 pm" src="https://user-images.githubusercontent.com/6692932/44486854-be80a180-a622-11e8-805c-eec27ebc118d.png">

