### PR TITLE
Fix bad links under 'Help' in application menu

### DIFF
--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -135,11 +135,11 @@ class ApplicationMenu extends Component<Props> {
   }
 
   openGettingStartedDocs = () => {
-    shell.openExternal(`${baseRepoUrl}/docs/getting-started.md`);
+    shell.openExternal(`${baseRepoUrl}/blob/master/docs/getting-started.md`);
   };
 
   openReportIssue = () => {
-    shell.openExternal(`${baseRepoUrl}/issues/new`);
+    shell.openExternal(`${baseRepoUrl}/issues/new/choose`);
   };
 
   render() {


### PR DESCRIPTION
**Related Issue:**
N/A

**Summary:**
Super small fix identified in review of PR #144. `openGettingStartedDocs` was returning 'Not Found' and `openReportIssue` should probably direct the user to the choose url.