### PR TITLE
Smooth out app open (Part 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "redux-devtools": "3.4.1",
     "redux-devtools-dock-monitor": "1.1.3",
     "redux-devtools-log-monitor": "1.4.0",
+    "redux-saga": "0.16.0",
     "redux-storage": "4.1.2",
     "redux-storage-decorator-debounce": "1.1.3",
     "redux-storage-decorator-filter": "1.1.8",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,13 +1,10 @@
 // @flow
 import uuid from 'uuid/v1';
 
-import {
-  loadGuppyProjects,
-  loadAllProjectDependencies,
-} from '../services/read-from-disk.service';
+import { loadAllProjectDependencies } from '../services/read-from-disk.service';
 import { getInternalProjectById } from '../reducers/projects.reducer';
 
-import type { Project, Task, Dependency } from '../types';
+import type { Project, ProjectsMap, Task, Dependency } from '../types';
 
 //
 //
@@ -15,7 +12,9 @@ import type { Project, Task, Dependency } from '../types';
 // TODO: Do this with Flow
 // https://flow.org/en/docs/react/redux/
 //
-export const REFRESH_PROJECTS = 'REFRESH_PROJECTS';
+export const REFRESH_PROJECTS_START = 'REFRESH_PROJECTS_START';
+export const REFRESH_PROJECTS_ERROR = 'REFRESH_PROJECTS_ERROR';
+export const REFRESH_PROJECTS_FINISH = 'REFRESH_PROJECTS_FINISH';
 export const CREATE_NEW_PROJECT_START = 'CREATE_NEW_PROJECT_START';
 export const CREATE_NEW_PROJECT_CANCEL = 'CREATE_NEW_PROJECT_CANCEL';
 export const CREATE_NEW_PROJECT_FINISH = 'CREATE_NEW_PROJECT_FINISH';
@@ -69,25 +68,19 @@ export const finishDeletingProjectFromDisk = (projectId: string) => ({
   projectId,
 });
 
-export const refreshProjects = () => {
-  return (dispatch: any, getState: any) => {
-    const { paths } = getState();
+export const refreshProjectsStart = () => ({
+  type: REFRESH_PROJECTS_START,
+});
 
-    // I wish Flow would let me use Object.values =(
-    const pathValues = Object.keys(paths).map(pathKey => paths[pathKey]);
+export const refreshProjectsError = (error: string) => ({
+  type: REFRESH_PROJECTS_ERROR,
+  error,
+});
 
-    loadGuppyProjects(pathValues)
-      .then((projects: { [id: string]: Project }) => {
-        dispatch({
-          type: REFRESH_PROJECTS,
-          projects,
-        });
-      })
-      .catch(err => {
-        console.error('Could not load guppy projects', err);
-      });
-  };
-};
+export const refreshProjectsFinish = (projects: ProjectsMap) => ({
+  type: REFRESH_PROJECTS_FINISH,
+  projects,
+});
 
 /**
  * This action figures out what dependencies are installed for a given

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -88,6 +88,9 @@ export const refreshProjectsFinish = (projects: ProjectsMap) => ({
  *
  * TODO: This should really have a "START" and "COMPLETE" action pair, so that
  * we can show some loading UI while it works.
+ *
+ * TODO: This is our last thunk! We should convert it to a saga, so we can
+ * be rid of thunks altogether.
  */
 
 export const loadDependencyInfoFromDisk = (
@@ -298,21 +301,3 @@ export const importExistingProjectFinish = (
   path,
   project,
 });
-
-// export const ejectProjectStart = (task: Task, timestamp: Date) => ({
-//   type: EJECT_PROJECT_START,
-//   task,
-//   timestamp,
-// });
-
-// export const ejectProjectError = (task: Task, timestamp: Date) => ({
-//   type: EJECT_PROJECT_ERROR,
-//   task,
-//   timestamp,
-// });
-
-// export const ejectProjectFinish = (task: Task, timestamp: Date) => ({
-//   type: EJECT_PROJECT_START,
-//   task,
-//   timestamp,
-// });

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import styled, { keyframes } from 'styled-components';
 
 import { COLORS } from '../../constants';
 import { getSelectedProject } from '../../reducers/projects.reducer';
+import { getAppLoaded } from '../../reducers/app-loaded.reducer';
 
 import IntroScreen from '../IntroScreen';
 import Sidebar from '../Sidebar';
@@ -16,25 +17,28 @@ import CreateNewProjectWizard from '../CreateNewProjectWizard';
 import type { Project } from '../../types';
 
 type Props = {
+  isAppLoaded: boolean,
   selectedProject: ?Project,
 };
 
 class App extends Component<Props> {
   render() {
-    const { selectedProject } = this.props;
+    const { isAppLoaded, selectedProject } = this.props;
 
     return (
       <Fragment>
         <Titlebar />
         <ApplicationMenu />
 
-        <Wrapper>
-          <Sidebar />
+        {isAppLoaded && (
+          <Wrapper>
+            <Sidebar />
 
-          <MainContent>
-            {selectedProject ? <ProjectPage /> : <IntroScreen />}
-          </MainContent>
-        </Wrapper>
+            <MainContent>
+              {selectedProject ? <ProjectPage /> : <IntroScreen />}
+            </MainContent>
+          </Wrapper>
+        )}
 
         <CreateNewProjectWizard />
       </Fragment>
@@ -64,6 +68,7 @@ const MainContent = styled.div`
 
 const mapStateToProps = state => ({
   selectedProject: getSelectedProject(state),
+  isAppLoaded: getAppLoaded(state),
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,13 +3,8 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import styled, { keyframes } from 'styled-components';
 
-import { refreshProjects, selectProject } from '../../actions';
 import { COLORS } from '../../constants';
-import {
-  getProjectsArray,
-  getSelectedProject,
-} from '../../reducers/projects.reducer';
-import { getOnboardingStatus } from '../../reducers/onboarding-status.reducer';
+import { getSelectedProject } from '../../reducers/projects.reducer';
 
 import IntroScreen from '../IntroScreen';
 import Sidebar from '../Sidebar';
@@ -18,16 +13,10 @@ import ApplicationMenu from '../ApplicationMenu';
 import ProjectPage from '../ProjectPage';
 import CreateNewProjectWizard from '../CreateNewProjectWizard';
 
-import type { Action } from 'redux';
 import type { Project } from '../../types';
-import type { State as OnboardingStatus } from '../../reducers/onboarding-status.reducer';
 
 type Props = {
-  onboardingStatus: OnboardingStatus,
   selectedProject: ?Project,
-  projects: Array<Project>,
-  refreshProjects: Action,
-  selectProject: Action,
 };
 
 class App extends Component<Props> {
@@ -74,12 +63,7 @@ const MainContent = styled.div`
 `;
 
 const mapStateToProps = state => ({
-  onboardingStatus: getOnboardingStatus(state),
-  projects: getProjectsArray(state),
   selectedProject: getSelectedProject(state),
 });
 
-export default connect(
-  mapStateToProps,
-  { refreshProjects, selectProject }
-)(App);
+export default connect(mapStateToProps)(App);

--- a/src/components/DevelopmentServerPane/DevelopmentServerPane.js
+++ b/src/components/DevelopmentServerPane/DevelopmentServerPane.js
@@ -50,13 +50,10 @@ class DevelopmentServerPane extends PureComponent<Props> {
     const { project, task } = this.props;
 
     if (!task) {
-      // For the initial paint, there won't be any tasks, as tasks aren't
-      // persisted and need to be read from the disk.
-      // TODO: Differentiate between "the tasks haven't loaded" and "there
-      // are no tasks"
-      // TODO: Add "skeleton" structure to make it clear it's loading,
-      // and to prevent content from jumping around.
-      return null;
+      // If the package.json is missing a server task (as defined by the
+      // `getDevServerTaskForProjectId` selector), we can't show this module.
+      // TODO: Better errors
+      return 'This project does not appear to have a development server task';
     }
 
     // TODO: There's currently no DevelopmentServerStatus for smaller windows.

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -47,10 +47,6 @@ class ProjectPage extends Component<Props> {
   render() {
     const { project } = this.props;
 
-    if (!project) {
-      return null;
-    }
-
     return (
       <FadeIn>
         <MainContentWrapper>
@@ -89,7 +85,7 @@ const fadeIn = keyframes`
 `;
 
 const FadeIn = styled.div`
-  animation: ${fadeIn} 400ms;
+  animation: ${fadeIn} 1ms;
 `;
 
 const mapStateToProps = state => ({

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -85,7 +85,7 @@ const fadeIn = keyframes`
 `;
 
 const FadeIn = styled.div`
-  animation: ${fadeIn} 1ms;
+  animation: ${fadeIn} 400ms;
 `;
 
 const mapStateToProps = state => ({

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -71,12 +71,9 @@ class TaskRunnerPane extends Component<Props, State> {
     const { selectedTaskId } = this.state;
 
     if (tasks.length === 0) {
-      // For the initial paint, there won't be any tasks, as tasks aren't
-      // persisted and need to be read from the disk.
-      // TODO: Differentiate between "the tasks haven't loaded" and "there
-      // are no tasks"
-      // TODO: Add "skeleton" structure to make it clear it's loading,
-      // and to prevent content from jumping around.
+      // If the user deletes all `scripts` from their package.json, we don't
+      // need to show this module.
+      // (this shouldn't really ever happen)
       return null;
     }
 

--- a/src/reducers/app-loaded.reducer.js
+++ b/src/reducers/app-loaded.reducer.js
@@ -1,0 +1,39 @@
+// @flow
+/**
+ * There is a certain amount of initialization that needs to happen before
+ * it makes sense to show anything to the user.
+ *
+ * Specifically:
+ *
+ * - We need to load persisted redux state, to know if the user is onboarding,
+ *   what their projects are, etc.
+ * - We want to parse the projects on disk to get up-to-date info, because
+ *   the persisted redux state is incomplete; doesn't have info about tasks.
+ *
+ * This simple boolean reducer defaults to `false` and is toggled to `true`
+ * once enough state has been loaded for us to show the user some UI.
+ */
+
+import { REFRESH_PROJECTS_FINISH } from '../actions';
+
+import type { Action } from 'redux';
+
+type State = boolean;
+
+const initialState = false;
+
+export default (state: State = initialState, action: Action) => {
+  switch (action.type) {
+    case REFRESH_PROJECTS_FINISH:
+      return true;
+
+    default:
+      return state;
+  }
+};
+
+//
+//
+//
+// Selectors
+export const getAppLoaded = (state: any) => state.appLoaded;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+import appLoaded from './app-loaded.reducer';
 import projects from './projects.reducer';
 import tasks from './tasks.reducer';
 import dependencies from './dependencies.reducer';
@@ -9,6 +10,7 @@ import packageJsonLocked from './package-json-locked.reducer';
 import paths from './paths.reducer';
 
 export default combineReducers({
+  appLoaded,
   projects,
   tasks,
   dependencies,

--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -7,7 +7,6 @@ import {
   IMPORT_EXISTING_PROJECT_START,
   IMPORT_EXISTING_PROJECT_ERROR,
   IMPORT_EXISTING_PROJECT_FINISH,
-  REFRESH_PROJECTS,
   SELECT_PROJECT,
 } from '../actions';
 
@@ -46,18 +45,6 @@ export default (state: State = initialState, action: Action) => {
     case DISMISS_SIDEBAR_INTRO:
     case SELECT_PROJECT: {
       return state === 'introducing-sidebar' ? 'done' : state;
-    }
-
-    case REFRESH_PROJECTS: {
-      // If the disk reveals that this user already has guppy projects, we
-      // should assume that the onboarding has been completed previously.
-      // This can happen when Guppy has to rebuild the local storage from
-      // disk (which might happen after the app updates?)
-      if (Object.keys(action.projects).length) {
-        return 'done';
-      }
-
-      return state;
     }
 
     default:

--- a/src/reducers/package-json-locked.reducer.js
+++ b/src/reducers/package-json-locked.reducer.js
@@ -20,7 +20,7 @@
  * So this is on a per-project basis.
  */
 import {
-  REFRESH_PROJECTS,
+  REFRESH_PROJECTS_FINISH,
   ADD_PROJECT,
   ADD_DEPENDENCY_START,
   ADD_DEPENDENCY_ERROR,
@@ -43,7 +43,7 @@ const initialState = {};
 
 export default (state: State = initialState, action: Action) => {
   switch (action.type) {
-    case REFRESH_PROJECTS:
+    case REFRESH_PROJECTS_FINISH:
       return Object.keys(action.projects).reduce(
         (acc, projectId) => ({
           ...acc,

--- a/src/reducers/paths.reducer.js
+++ b/src/reducers/paths.reducer.js
@@ -58,5 +58,6 @@ export const getDefaultPath = (projectId: string) =>
 //
 //
 // Selectors
+export const getPathsArray = (state: State) => Object.values(state.paths);
 export const getPathForProjectId = (state: any, projectId: string) =>
   state.paths[projectId] || getDefaultPath(projectId);

--- a/src/reducers/paths.reducer.js
+++ b/src/reducers/paths.reducer.js
@@ -58,6 +58,6 @@ export const getDefaultPath = (projectId: string) =>
 //
 //
 // Selectors
-export const getPathsArray = (state: State) => Object.values(state.paths);
+export const getPathsArray = (state: any) => Object.values(state.paths);
 export const getPathForProjectId = (state: any, projectId: string) =>
   state.paths[projectId] || getDefaultPath(projectId);

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -7,7 +7,7 @@ import {
   IMPORT_EXISTING_PROJECT_FINISH,
   FINISH_DELETING_PROJECT_FROM_DISK,
   ADD_DEPENDENCY_FINISH,
-  REFRESH_PROJECTS,
+  REFRESH_PROJECTS_FINISH,
   SELECT_PROJECT,
 } from '../actions';
 import { getTasksForProjectId } from './tasks.reducer';
@@ -35,7 +35,7 @@ export const initialState = {
 
 const byId = (state: ById = initialState.byId, action: Action) => {
   switch (action.type) {
-    case REFRESH_PROJECTS: {
+    case REFRESH_PROJECTS_FINISH: {
       return action.projects;
     }
 
@@ -79,7 +79,7 @@ const selectedId = (
       return action.project.guppy.id;
     }
 
-    case REFRESH_PROJECTS: {
+    case REFRESH_PROJECTS_FINISH: {
       // It's possible that the selected project no longer exists (say if the
       // user deletes that folder and then refreshes Guppy).
       // In that case, un-select it.

--- a/src/reducers/projects.reducer.test.js
+++ b/src/reducers/projects.reducer.test.js
@@ -1,10 +1,10 @@
 import {
   IMPORT_EXISTING_PROJECT_FINISH,
   ADD_DEPENDENCY_FINISH,
-  REFRESH_PROJECTS,
+  REFRESH_PROJECTS_FINISH,
   SELECT_PROJECT,
   ADD_PROJECT,
-} from '../../actions';
+} from '../actions';
 
 import reducer, {
   initialState as projectsInitialState,
@@ -12,7 +12,7 @@ import reducer, {
   getSelectedProjectId,
   getInternalProjectById,
   getProjectsArray,
-} from '../projects.reducer';
+} from './projects.reducer';
 
 describe('Projects Reducer', () => {
   describe(ADD_PROJECT, () => {
@@ -121,7 +121,7 @@ describe('Projects Reducer', () => {
     });
   });
 
-  describe(REFRESH_PROJECTS, () => {
+  describe(REFRESH_PROJECTS_FINISH, () => {
     it('returns a null selectedId if selected project does not exist in the list of projects', () => {
       const initialState = {
         ...projectsInitialState,
@@ -129,7 +129,7 @@ describe('Projects Reducer', () => {
       };
 
       const action = {
-        type: REFRESH_PROJECTS,
+        type: REFRESH_PROJECTS_FINISH,
         projects: {},
       };
 
@@ -148,7 +148,7 @@ describe('Projects Reducer', () => {
       };
 
       const action = {
-        type: REFRESH_PROJECTS,
+        type: REFRESH_PROJECTS_FINISH,
         projects: {},
       };
 
@@ -175,7 +175,7 @@ describe('Projects Reducer', () => {
       };
 
       const action = {
-        type: REFRESH_PROJECTS,
+        type: REFRESH_PROJECTS_FINISH,
         projects: initialState.byId,
       };
 

--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -18,7 +18,7 @@
 
 import produce from 'immer';
 import {
-  REFRESH_PROJECTS,
+  REFRESH_PROJECTS_FINISH,
   ADD_PROJECT,
   LAUNCH_DEV_SERVER,
   RUN_TASK,
@@ -40,7 +40,7 @@ const initialState = {};
 
 export default (state: State = initialState, action: Action) => {
   switch (action.type) {
-    case REFRESH_PROJECTS: {
+    case REFRESH_PROJECTS_FINISH: {
       return produce(state, draftState => {
         Object.keys(action.projects).forEach(projectId => {
           const project = action.projects[projectId];
@@ -125,8 +125,8 @@ export default (state: State = initialState, action: Action) => {
 
       return produce(state, draftState => {
         // For the eject task, we simply want to delete this task altogether.
-        // TODO: We should probably do this in `REFRESH_PROJECTS`, which is
-        // called right after the eject task succeeds!
+        // TODO: We should probably do this in `REFRESH_PROJECTS_FINISH`, which
+        // is called right after the eject task succeeds!
         if (task.name === 'eject') {
           delete draftState[task.id];
           return;

--- a/src/reducers/tasks.reducer.test.js
+++ b/src/reducers/tasks.reducer.test.js
@@ -1,5 +1,5 @@
 import {
-  REFRESH_PROJECTS,
+  REFRESH_PROJECTS_FINISH,
   ADD_PROJECT,
   RUN_TASK,
   ABORT_TASK,
@@ -11,12 +11,12 @@ import reducer, { getTaskDescription } from './tasks.reducer';
 jest.mock('electron');
 
 describe('Tasks reducer', () => {
-  describe(REFRESH_PROJECTS, () => {
+  describe(REFRESH_PROJECTS_FINISH, () => {
     test('captures task data from new projects', () => {
       const initialState = reducer(undefined, {});
 
       const action = {
-        type: REFRESH_PROJECTS,
+        type: REFRESH_PROJECTS_FINISH,
         projects: {
           foo: {
             name: 'foo',
@@ -114,7 +114,7 @@ describe('Tasks reducer', () => {
       };
 
       const action = {
-        type: REFRESH_PROJECTS,
+        type: REFRESH_PROJECTS_FINISH,
         projects: {
           foo: {
             name: 'foo',

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,0 +1,7 @@
+import { all } from 'redux-saga/effects';
+
+import refreshProjectsSaga from './refresh-projects.saga';
+
+export default function*() {
+  yield all([refreshProjectsSaga()]);
+}

--- a/src/sagas/refresh-projects.saga.js
+++ b/src/sagas/refresh-projects.saga.js
@@ -1,0 +1,29 @@
+// @flow
+import { call, put, select, takeEvery } from 'redux-saga/effects';
+
+import {
+  refreshProjectsFinish,
+  refreshProjectsError,
+  REFRESH_PROJECTS_START,
+} from '../actions';
+import { loadGuppyProjects } from '../services/read-from-disk.service';
+
+import { getPathsArray } from '../reducers/paths.reducer';
+
+import type { Saga } from 'redux-saga';
+
+export function* refreshProjects(): Saga<void> {
+  const pathsArray = yield select(getPathsArray);
+
+  try {
+    const projectsFromDisk = yield call(loadGuppyProjects, pathsArray);
+
+    yield put(refreshProjectsFinish(projectsFromDisk));
+  } catch (err) {
+    yield put(refreshProjectsError(err));
+  }
+}
+
+export default function* rootSaga(): Saga<void> {
+  yield takeEvery(REFRESH_PROJECTS_START, refreshProjects);
+}

--- a/src/sagas/refresh-projects.saga.js
+++ b/src/sagas/refresh-projects.saga.js
@@ -7,7 +7,6 @@ import {
   REFRESH_PROJECTS_START,
 } from '../actions';
 import { loadGuppyProjects } from '../services/read-from-disk.service';
-
 import { getPathsArray } from '../reducers/paths.reducer';
 
 import type { Saga } from 'redux-saga';

--- a/src/sagas/refresh-projects.saga.test.js
+++ b/src/sagas/refresh-projects.saga.test.js
@@ -1,0 +1,95 @@
+import { call, put, cancel, select, takeEvery } from 'redux-saga/effects';
+
+import rootSaga, { refreshProjects } from './refresh-projects.saga';
+
+import {
+  refreshProjectsError,
+  REFRESH_PROJECTS_START,
+  refreshProjectsFinish,
+} from '../actions';
+import { getPathsArray } from '../reducers/paths.reducer';
+import { loadGuppyProjects } from '../services/read-from-disk.service';
+
+// TODO: this?
+jest.mock('electron', () => ({
+  remote: {
+    app: { getAppPath: () => '' },
+    dialog: { showOpenDialog: jest.fn(), showErrorBox: jest.fn() },
+  },
+}));
+
+describe('refresh-projects saga', () => {
+  describe('root import-project saga', () => {
+    it('should watching for start actions', () => {
+      const saga = rootSaga();
+      expect(saga.next().value).toEqual(
+        takeEvery(REFRESH_PROJECTS_START, refreshProjects)
+      );
+    });
+  });
+
+  describe('refreshProjects', () => {
+    it('fetches and dispatches project info', () => {
+      const saga = refreshProjects();
+
+      // select the paths from Redux state
+      expect(saga.next().value).toEqual(select(getPathsArray));
+
+      // load the guppy projects from the paths specified.
+      const pathsArray = ['/path/to/project', 'another/path/to/project'];
+      expect(saga.next(pathsArray).value).toEqual(
+        call(loadGuppyProjects, pathsArray)
+      );
+
+      const guppyProjects = {
+        project: {
+          id: 'a',
+          name: 'a',
+          type: 'create-react-app',
+          icon: '',
+          color: '',
+          createdAt: Date.now(),
+          dependencies: [],
+          tasks: [],
+          path: pathsArray[0],
+        },
+        anotherProject: {
+          id: 'b',
+          name: 'b',
+          type: 'gatsby',
+          icon: '',
+          color: '',
+          createdAt: Date.now(),
+          dependencies: [],
+          tasks: [],
+          path: pathsArray[1],
+        },
+      };
+
+      // dispatch the 'finish' call with this data
+      expect(saga.next(guppyProjects).value).toEqual(
+        put(refreshProjectsFinish(guppyProjects))
+      );
+    });
+
+    it('dispatches an error when it cannot fetch the projects', () => {
+      const saga = refreshProjects();
+
+      // select the paths from Redux state
+      expect(saga.next().value).toEqual(select(getPathsArray));
+
+      // load the guppy projects from the paths specified.
+      const pathsArray = ['/path/to/project', 'another/path/to/project'];
+      expect(saga.next(pathsArray).value).toEqual(
+        call(loadGuppyProjects, pathsArray)
+      );
+
+      // dispatch the 'finish' call with this data
+      const error = 'invalid path';
+
+      expect(saga.throw(error).value).toEqual(
+        put(refreshProjectsError('invalid path'))
+      );
+    });
+  });
+});

--- a/src/sagas/refresh-projects.saga.test.js
+++ b/src/sagas/refresh-projects.saga.test.js
@@ -10,14 +10,6 @@ import {
 import { getPathsArray } from '../reducers/paths.reducer';
 import { loadGuppyProjects } from '../services/read-from-disk.service';
 
-// TODO: this?
-jest.mock('electron', () => ({
-  remote: {
-    app: { getAppPath: () => '' },
-    dialog: { showOpenDialog: jest.fn(), showErrorBox: jest.fn() },
-  },
-}));
-
 describe('refresh-projects saga', () => {
   describe('root import-project saga', () => {
     it('should watching for start actions', () => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -34,7 +34,7 @@ export default function configureStore() {
 
   // We don't want to store task info.
   // Tasks
-  engine = filter(engine, null, [['tasks']]);
+  engine = filter(engine, null, [['appLoaded', 'tasks']]);
   const storageMiddleware = storage.createMiddleware(engine);
 
   const wrappedReducer = storage.reducer(rootReducer);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,20 +1,24 @@
 // @flow
 import { createStore, compose, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+import createSagaMiddleware from 'redux-saga';
 import * as storage from 'redux-storage';
 import debounce from 'redux-storage-decorator-debounce';
 import filter from 'redux-storage-decorator-filter';
 
-import { refreshProjects } from '../actions';
+import { refreshProjectsStart } from '../actions';
 import rootReducer from '../reducers';
 import taskMiddleware from '../middlewares/task.middleware';
 import dependencyMiddleware from '../middlewares/dependency.middleware';
 import importProjectMiddleware from '../middlewares/import-project.middleware';
 import deleteProjectMiddleware from '../middlewares/delete-project.middleware';
+import rootSaga from '../sagas';
 import createEngine from './storage-engine';
 import handleMigrations from './migrations';
 
 import DevTools from '../components/DevTools';
+
+const sagaMiddleware = createSagaMiddleware();
 
 export default function configureStore() {
   // Store all Redux changes in an electron-store, handled by redux-storage.
@@ -44,11 +48,14 @@ export default function configureStore() {
         dependencyMiddleware,
         importProjectMiddleware,
         deleteProjectMiddleware,
-        storageMiddleware
+        storageMiddleware,
+        sagaMiddleware
       ),
       DevTools.instrument()
     )
   );
+
+  sagaMiddleware.run(rootSaga);
 
   // Allow direct access to the store, for debugging/testing
   window.store = store;
@@ -59,7 +66,7 @@ export default function configureStore() {
       // Once our state has been hydrated, we want to refresh the existing
       // projects, so that we can tell if the user has made any changes to
       // the projects (eg. installed dependencies) outside of Guppy.
-      store.dispatch(refreshProjects());
+      store.dispatch(refreshProjectsStart());
     })
     .catch(err => console.error('Failed to load previous state', err));
 

--- a/src/types.js
+++ b/src/types.js
@@ -102,3 +102,5 @@ export type Project = {
   // `path` is the project's on-disk location.
   path: string,
 };
+
+export type ProjectsMap = { [id: string]: Project };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9529,6 +9529,10 @@ redux-devtools@3.4.1:
     prop-types "^15.5.7"
     redux-devtools-instrument "^1.0.1"
 
+redux-saga@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
+
 redux-storage-decorator-debounce@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/redux-storage-decorator-debounce/-/redux-storage-decorator-debounce-1.1.3.tgz#34475e5368a8a0ae094cd68633bc1b9a5ca0b842"


### PR DESCRIPTION
**Related Issue:** #160 

**Summary:**
Some changes to redux persistence meant that the "Development Server" and "Tasks" panes aren't immediately available. This was causing content to jump around as the app loaded:

![fade-in-before](https://user-images.githubusercontent.com/6692932/44628191-355eb880-a909-11e8-90f0-50ac6eb5050b.gif)

This change adds a new `app-loaded` reducer to track this, and to only fade the app in once the redux state has been rehydrated from electron-store, and the projects have been parsed on disk to find the tasks.

This fix actually worsened another pre-existing bug. Here's what it looks like now:

![fade-in-now](https://user-images.githubusercontent.com/6692932/44628296-d1d58a80-a90a-11e8-8c1d-3d016cebe04d.gif)

This grey-box is a weird AF browser-rendering issue. Because it's pre-existing/separate, it will be dealt with in a subsequent PR.