### PR TITLE
Smooth out app open (Part 2)

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -28,10 +28,11 @@ class App extends Component<Props> {
     return (
       <Fragment>
         <Titlebar />
-        <ApplicationMenu />
 
         {isAppLoaded && (
           <Wrapper>
+            <ApplicationMenu />
+
             <Sidebar />
 
             <MainContent>

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -35,24 +35,16 @@ class ApplicationMenu extends Component<Props> {
   menu: any;
 
   componentDidMount() {
-    setTimeout(() => {
-      this.buildMenu();
-    }, 1000);
+    this.buildMenu(this.props);
   }
 
-  shouldComponentUpdate(nextProps) {
-    // We currently only need to rebuild the menu whenever the selected project
-    // changes (so that we can clear the right project's console)
-    return this.props.selectedProjectId !== nextProps.selectedProjectId;
+  componentWillReceiveProps(nextProps) {
+    if (this.props.selectedProjectId !== nextProps.selectedProjectId) {
+      this.buildMenu(nextProps);
+    }
   }
 
-  componentDidUpdate() {
-    setTimeout(() => {
-      this.buildMenu();
-    }, 1000);
-  }
-
-  buildMenu = () => {
+  buildMenu = props => {
     const {
       selectedProject,
       selectedProjectId,
@@ -61,7 +53,7 @@ class ApplicationMenu extends Component<Props> {
       showImportExistingProjectPrompt,
       clearConsole,
       showDeleteProjectPrompt,
-    } = this.props;
+    } = props;
 
     const template = [
       {

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -38,13 +38,13 @@ class ApplicationMenu extends Component<Props> {
     this.buildMenu(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     if (this.props.selectedProjectId !== nextProps.selectedProjectId) {
       this.buildMenu(nextProps);
     }
   }
 
-  buildMenu = props => {
+  buildMenu = (props: Props) => {
     const {
       selectedProject,
       selectedProjectId,

--- a/src/components/DependencyManagementPane/DependencyManagementPane.js
+++ b/src/components/DependencyManagementPane/DependencyManagementPane.js
@@ -18,6 +18,7 @@ import Card from '../Card';
 import Spacer from '../Spacer';
 import Spinner from '../Spinner';
 import OnlyOn from '../OnlyOn';
+import MountAfter from '../MountAfter';
 
 import type { Project } from '../../types';
 
@@ -140,14 +141,33 @@ class DependencyManagementPane extends PureComponent<Props, State> {
                 </DependencyButton>
               ))}
             </Dependencies>
-            <AddDependencyButton onClick={this.openAddNewDependencyModal}>
-              <IconBase icon={plus} size={20} />
-              <Spacer size={6} />
-              Add New
-              <OnlyOn size="mdMin" style={{ paddingLeft: 3 }}>
-                Dependency
-              </OnlyOn>
-            </AddDependencyButton>
+            <MountAfter
+              delay={1000}
+              reason={`
+                A _really weird_ Chrome bug means that for a brief moment
+                during initial mount, a large grey rectangle shows up on the
+                screen.
+
+                I traced it back to AddDependencyButton, and the fact that it
+                has a "dashed" border. If I change that border to "solid", it
+                fixes the bug o_O
+
+                For reasons unknown, if I delay the rendering of this component,
+                the bug is fixed. And because this component isn't needed
+                immediately, that's ok!
+
+                See the bug in action: https://imgur.com/a/SanrY61
+              `}
+            >
+              <AddDependencyButton onClick={this.openAddNewDependencyModal}>
+                <IconBase icon={plus} size={20} />
+                <Spacer size={6} />
+                Add New
+                <OnlyOn size="mdMin" style={{ paddingLeft: 3 }}>
+                  Dependency
+                </OnlyOn>
+              </AddDependencyButton>
+            </MountAfter>
           </DependencyList>
           <MainContent>
             {selectedDependency.status === 'installing' ? (

--- a/src/components/MountAfter/MountAfter.js
+++ b/src/components/MountAfter/MountAfter.js
@@ -1,0 +1,44 @@
+// @flow
+/**
+ * This is a hacky little component that helps us avoid rendering bugs and
+ * other issues by offsetting the mount of a component by a certain amount of
+ * time.
+ */
+import React, { Component } from 'react';
+
+type Props = {
+  delay: number,
+  reason: string,
+  children: React$Node,
+};
+
+type State = {
+  hasTimeElapsed: boolean,
+};
+
+class MountAfter extends Component<Props, State> {
+  state = {
+    hasTimeElapsed: false,
+  };
+
+  timeoutId: number;
+
+  componentDidMount() {
+    this.timeoutId = window.setTimeout(() => {
+      this.setState({ hasTimeElapsed: true });
+    }, this.props.delay);
+  }
+
+  componentWillUnmount() {
+    window.clearTimeout(this.timeoutId);
+  }
+
+  render() {
+    const { children } = this.props;
+    const { hasTimeElapsed } = this.state;
+
+    return hasTimeElapsed ? children : null;
+  }
+}
+
+export default MountAfter;

--- a/src/components/MountAfter/MountAfter.js
+++ b/src/components/MountAfter/MountAfter.js
@@ -4,7 +4,7 @@
  * other issues by offsetting the mount of a component by a certain amount of
  * time.
  */
-import React, { Component } from 'react';
+import { Component } from 'react';
 
 type Props = {
   delay: number,

--- a/src/components/MountAfter/MountAfter.stories.js
+++ b/src/components/MountAfter/MountAfter.stories.js
@@ -1,0 +1,44 @@
+// @flow
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Showcase from '../../../.storybook/components/Showcase';
+import MountAfter from './MountAfter';
+
+storiesOf('MountAfter', module).add(
+  'default',
+  withInfo()(() => (
+    <Fragment>
+      <Showcase label="Mount after 0ms">
+        <MountAfter reason="" delay={0}>
+          Hello World
+        </MountAfter>
+      </Showcase>
+
+      <Showcase label="Mount after 500ms">
+        <MountAfter reason="" delay={500}>
+          Hello World
+        </MountAfter>
+      </Showcase>
+
+      <Showcase label="Mount after 1000ms">
+        <MountAfter reason="" delay={1000}>
+          Hello World
+        </MountAfter>
+      </Showcase>
+
+      <Showcase label="Mount after 1500ms">
+        <MountAfter reason="" delay={1500}>
+          Hello World
+        </MountAfter>
+      </Showcase>
+
+      <Showcase label="Mount after 2000ms">
+        <MountAfter reason="" delay={2000}>
+          Hello World
+        </MountAfter>
+      </Showcase>
+    </Fragment>
+  ))
+);

--- a/src/components/MountAfter/index.js
+++ b/src/components/MountAfter/index.js
@@ -1,0 +1,1 @@
+export { default } from './MountAfter';


### PR DESCRIPTION
**Related Issue:** closes #160

**Summary:**
As discussed in #160, there is some wackyness happening when the component initially mounts.

In #163, I solved the major part of the problem, which was the fact that boxes loaded at different times. That made an existing issue much more apparent, though; that of the annoying grey rectangle:

![fade-in-now](https://user-images.githubusercontent.com/6692932/44628790-30a00180-a915-11e8-8019-f3b7f174c1ee.gif)

This turned out to be a super puzzling issue: when rendering a small button with a 2px dashed border, we get this huge grey box @_@.

This really seems like a Chrome rendering bug.

In fact, even when I float another div _on top_ of the app, the rendering bug breaks out of its z-index to show itself:

![wow](https://user-images.githubusercontent.com/6692932/44628807-807ec880-a915-11e8-86e9-8d842a1b639f.gif)

I have no idea what the cause of this issue is, but a somewhat-hacky solution is clear: just delay rendering the problematic component. For some reason, when it's not rendering at the same time, there's no problem.

**Screenshots/GIFs:**
![fade-final](https://user-images.githubusercontent.com/6692932/44628815-93919880-a915-11e8-9bbd-f07e4c2072c9.gif)
![stories](https://user-images.githubusercontent.com/6692932/44628842-e408f600-a915-11e8-82c1-7c36afc16d94.gif)
