### PR TITLE
[WIP] Delete project from disk

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -47,7 +47,6 @@ export const IMPORT_EXISTING_PROJECT_START = 'IMPORT_EXISTING_PROJECT_START';
 export const IMPORT_EXISTING_PROJECT_ERROR = 'IMPORT_EXISTING_PROJECT_ERROR';
 export const IMPORT_EXISTING_PROJECT_FINISH = 'IMPORT_EXISTING_PROJECT_FINISH';
 export const SHOW_DELETE_PROJECT_PROMPT = 'SHOW_DELETE_PROJECT_PROMPT';
-export const DELETE_PROJECT_FROM_DISK = 'DELETE_PROJECT_FROM_DISK';
 export const FINISH_DELETING_PROJECT_FROM_DISK =
   'FINISH_DELETING_PROJECT_FROM_DISK';
 
@@ -65,14 +64,9 @@ export const showDeleteProjectPrompt = (project: Project) => ({
   project,
 });
 
-export const deleteProjectFromDisk = (project: string) => ({
-  type: DELETE_PROJECT_FROM_DISK,
-  project,
-});
-
-export const deleteProjectFromDiskFinish = (deletedProject: string) => ({
+export const finishDeletingProjectFromDisk = (projectId: string) => ({
   type: FINISH_DELETING_PROJECT_FROM_DISK,
-  deletedProject,
+  projectId,
 });
 
 export const refreshProjects = () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -70,9 +70,9 @@ export const deleteProjectFromDisk = (project: string) => ({
   project,
 });
 
-export const deleteProjectFromDiskFinish = (deletedProjectId: string) => ({
+export const deleteProjectFromDiskFinish = (deletedProject: string) => ({
   type: FINISH_DELETING_PROJECT_FROM_DISK,
-  deletedProjectId,
+  deletedProject,
 });
 
 export const refreshProjects = () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -46,6 +46,10 @@ export const SHOW_IMPORT_EXISTING_PROJECT_PROMPT =
 export const IMPORT_EXISTING_PROJECT_START = 'IMPORT_EXISTING_PROJECT_START';
 export const IMPORT_EXISTING_PROJECT_ERROR = 'IMPORT_EXISTING_PROJECT_ERROR';
 export const IMPORT_EXISTING_PROJECT_FINISH = 'IMPORT_EXISTING_PROJECT_FINISH';
+export const SHOW_DELETE_PROJECT_PROMPT = 'SHOW_DELETE_PROJECT_PROMPT';
+export const DELETE_PROJECT_FROM_DISK = 'DELETE_PROJECT_FROM_DISK';
+export const FINISH_DELETING_PROJECT_FROM_DISK =
+  'FINISH_DELETING_PROJECT_FROM_DISK';
 
 //
 //
@@ -54,6 +58,21 @@ export const IMPORT_EXISTING_PROJECT_FINISH = 'IMPORT_EXISTING_PROJECT_FINISH';
 export const addProject = (project: Project) => ({
   type: ADD_PROJECT,
   project,
+});
+
+export const showDeleteProjectPrompt = (project: Project) => ({
+  type: SHOW_DELETE_PROJECT_PROMPT,
+  project,
+});
+
+export const deleteProjectFromDisk = (project: string) => ({
+  type: DELETE_PROJECT_FROM_DISK,
+  project,
+});
+
+export const deleteProjectFromDiskFinish = (deletedProjectId: string) => ({
+  type: FINISH_DELETING_PROJECT_FROM_DISK,
+  deletedProjectId,
 });
 
 export const refreshProjects = () => {

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -10,6 +10,7 @@ import {
   createNewProjectStart,
   showImportExistingProjectPrompt,
   clearConsole,
+  showDeleteProjectPrompt,
 } from '../../actions';
 import { GUPPY_REPO_URL } from '../../constants';
 import { isMac } from '../../services/platform.service';
@@ -21,11 +22,13 @@ import type { Task } from '../../types';
 const { app, process, Menu } = remote;
 
 type Props = {
+  selectedProject: ?string,
   selectedProjectId: ?string,
   devServerTask: ?Task,
   createNewProjectStart: () => any,
   showImportExistingProjectPrompt: () => any,
   clearConsole: (task: Task) => any,
+  showDeleteProjectPrompt: (project: any) => any,
 };
 
 class ApplicationMenu extends Component<Props> {
@@ -47,11 +50,13 @@ class ApplicationMenu extends Component<Props> {
 
   buildMenu = () => {
     const {
+      selectedProject,
       selectedProjectId,
       devServerTask,
       createNewProjectStart,
       showImportExistingProjectPrompt,
       clearConsole,
+      showDeleteProjectPrompt,
     } = this.props;
 
     const template = [
@@ -168,6 +173,10 @@ class ApplicationMenu extends Component<Props> {
             click: () => clearConsole(devServerTask),
             accelerator: 'CmdOrCtrl+K',
           },
+          {
+            label: isMac ? 'Delete Project' : 'Delete project',
+            click: () => showDeleteProjectPrompt(selectedProject),
+          },
         ],
       });
     }
@@ -202,13 +211,14 @@ const mapStateToProps = state => {
       )
     : null;
 
-  return { selectedProjectId, devServerTask };
+  return { selectedProject, selectedProjectId, devServerTask };
 };
 
 const mapDispatchToProps = {
   createNewProjectStart,
   showImportExistingProjectPrompt,
   clearConsole,
+  showDeleteProjectPrompt,
 };
 
 export default connect(

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -164,26 +164,26 @@ class ApplicationMenu extends Component<Props> {
       // have a different index depending on the platform.
       const editMenuIndex = template.findIndex(menu => menu.id === 'edit');
 
-      // If there's no devServerTask then hide that menu item
-      // this will happen if the project doesn't have any start tasks
-      const clearConsoleMenuItems = devServerTask
-        ? {
-            label: isMac ? 'Clear Server Logs' : 'Clear server logs',
-            click: () => clearConsole(devServerTask),
-            accelerator: 'CmdOrCtrl+K',
-          }
-        : { visible: false };
+      // Only include clear console menu item if devServerTask exists
+      let submenu = [];
+
+      if (devServerTask) {
+        submenu.push({
+          label: isMac ? 'Clear Server Logs' : 'Clear server logs',
+          click: () => clearConsole(devServerTask),
+          accelerator: 'CmdOrCtrl+K',
+        });
+      }
+
+      submenu.push({
+        label: isMac ? 'Delete Project' : 'Delete project',
+        click: () => showDeleteProjectPrompt(selectedProject),
+      });
 
       template.splice(editMenuIndex, 0, {
         id: 'project',
         label: isMac ? 'Project' : '&Project',
-        submenu: [
-          clearConsoleMenuItems,
-          {
-            label: isMac ? 'Delete Project' : 'Delete project',
-            click: () => showDeleteProjectPrompt(selectedProject),
-          },
-        ],
+        submenu,
       });
     }
 

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -159,20 +159,26 @@ class ApplicationMenu extends Component<Props> {
     // During onboarding, there is no selected project (because none exists
     // yet). Therefore, we only want to show the 'Project' menu when a project
     // is selected.
-    if (selectedProjectId && devServerTask) {
+    if (selectedProjectId) {
       // The `Project` menu should be inserted right after `Edit`, which will
       // have a different index depending on the platform.
       const editMenuIndex = template.findIndex(menu => menu.id === 'edit');
+
+      // If there's no devServerTask then hide that menu item
+      // this will happen if the project doesn't have any start tasks
+      const clearConsoleMenuItems = devServerTask
+        ? {
+            label: isMac ? 'Clear Server Logs' : 'Clear server logs',
+            click: () => clearConsole(devServerTask),
+            accelerator: 'CmdOrCtrl+K',
+          }
+        : { visible: false };
 
       template.splice(editMenuIndex, 0, {
         id: 'project',
         label: isMac ? 'Project' : '&Project',
         submenu: [
-          {
-            label: isMac ? 'Clear Server Logs' : 'Clear server logs',
-            click: () => clearConsole(devServerTask),
-            accelerator: 'CmdOrCtrl+K',
-          },
+          clearConsoleMenuItems,
           {
             label: isMac ? 'Delete Project' : 'Delete project',
             click: () => showDeleteProjectPrompt(selectedProject),

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -35,7 +35,9 @@ class ApplicationMenu extends Component<Props> {
   menu: any;
 
   componentDidMount() {
-    this.buildMenu();
+    setTimeout(() => {
+      this.buildMenu();
+    }, 1000);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -45,7 +47,9 @@ class ApplicationMenu extends Component<Props> {
   }
 
   componentDidUpdate() {
-    this.buildMenu();
+    setTimeout(() => {
+      this.buildMenu();
+    }, 1000);
   }
 
   buildMenu = () => {

--- a/src/middlewares/delete-project.middleware.js
+++ b/src/middlewares/delete-project.middleware.js
@@ -1,0 +1,87 @@
+// @flow
+import { remote } from 'electron';
+import {
+  SHOW_DELETE_PROJECT_PROMPT,
+  DELETE_PROJECT_FROM_DISK,
+  FINISH_DELETING_PROJECT_FROM_DISK,
+  deleteProjectFromDisk,
+  deleteProjectFromDiskFinish,
+  refreshProjects,
+  selectProject,
+  dismissSidebarIntro,
+} from '../actions';
+
+const { dialog, shell } = remote;
+
+export default (store: any) => (next: any) => (action: any) => {
+  // eslint-disable-next-line default-case
+  switch (action.type) {
+    case SHOW_DELETE_PROJECT_PROMPT: {
+      dialog.showMessageBox(
+        {
+          type: 'warning',
+          buttons: ['Delete from Disk', 'Cancel'],
+          defaultId: 0,
+          title: `Delete ${action.project.name}`,
+          message: `Are you sure you want to delete ${action.project.name}?`,
+          detail: 'WARNING! Deleting from disk will send the project to trash!',
+        },
+        (response: number) => {
+          // TODO: Eventually need to do shouldDeleteFromGuppy as well
+          const shouldDeleteFromDisk = response === 0;
+
+          if (shouldDeleteFromDisk) {
+            const { project } = action;
+            store.dispatch(deleteProjectFromDisk(project));
+          }
+        }
+      );
+      break;
+    }
+
+    case DELETE_PROJECT_FROM_DISK: {
+      const { path, id } = action.project;
+
+      // Returns true if successfully deleted
+      const successfullyDeleted = shell.moveItemToTrash(path);
+
+      if (successfullyDeleted) {
+        store.dispatch(deleteProjectFromDiskFinish(id));
+      }
+      break;
+    }
+
+    case FINISH_DELETING_PROJECT_FROM_DISK: {
+      // Make sure we get an updated project list
+      store.dispatch(refreshProjects());
+
+      // Get the deleted project id from the action
+      // so we know what is deleted
+      const { deletedProjectId } = action;
+
+      // Get the fresh projects list from state
+      const { projects } = store.getState();
+
+      // Calculate the remaining projects by filtering
+      // out the deletedProjectId
+      const remainingProjects = Object.keys(projects.byId).filter(
+        id => id !== deletedProjectId
+      );
+
+      if (remainingProjects.length >= 1) {
+        // If remainingProjects array has at least one project
+        // there's a project to select
+        const nextId = remainingProjects[0];
+        store.dispatch(selectProject(nextId));
+      } else {
+        // Otherwise there are no more projects
+        // so spit out to the new project screen
+        store.dispatch(dismissSidebarIntro());
+      }
+
+      break;
+    }
+  }
+
+  return next(action);
+};

--- a/src/middlewares/delete-project.middleware.js
+++ b/src/middlewares/delete-project.middleware.js
@@ -8,7 +8,7 @@ import {
   deleteProjectFromDiskFinish,
   refreshProjects,
   selectProject,
-  dismissSidebarIntro,
+  createNewProjectStart,
 } from '../actions';
 
 const { dialog, shell } = remote;
@@ -76,7 +76,7 @@ export default (store: any) => (next: any) => (action: any) => {
       } else {
         // Otherwise there are no more projects
         // so spit out to the new project screen
-        store.dispatch(dismissSidebarIntro());
+        store.dispatch(createNewProjectStart());
       }
 
       break;

--- a/src/middlewares/delete-project.middleware.js
+++ b/src/middlewares/delete-project.middleware.js
@@ -1,12 +1,9 @@
 // @flow
 import { remote } from 'electron';
+
 import {
   SHOW_DELETE_PROJECT_PROMPT,
-  DELETE_PROJECT_FROM_DISK,
-  FINISH_DELETING_PROJECT_FROM_DISK,
-  deleteProjectFromDisk,
-  deleteProjectFromDiskFinish,
-  refreshProjects,
+  finishDeletingProjectFromDisk,
   selectProject,
   createNewProjectStart,
 } from '../actions';
@@ -19,65 +16,65 @@ export default (store: any) => (next: any) => (action: any) => {
   // eslint-disable-next-line default-case
   switch (action.type) {
     case SHOW_DELETE_PROJECT_PROMPT: {
+      const { name, path, id: deletedId } = action.project;
+
       dialog.showMessageBox(
         {
           type: 'warning',
           buttons: ['Delete from Disk', 'Cancel'],
           defaultId: 0,
-          title: `Delete ${action.project.name}`,
-          message: `Are you sure you want to delete ${action.project.name}?`,
+          title: `Delete ${name}`,
+          message: `Are you sure you want to delete ${name}?`,
           detail: 'WARNING! Deleting from disk will send the project to trash!',
         },
         (response: number) => {
           // TODO: Eventually need to do shouldDeleteFromGuppy as well
           const shouldDeleteFromDisk = response === 0;
 
-          if (shouldDeleteFromDisk) {
-            const { project } = action;
-            store.dispatch(deleteProjectFromDisk(project));
+          if (!shouldDeleteFromDisk) {
+            return;
+          }
+
+          // Get a list of projects before deletion
+          const projects = getProjectsArray(store.getState());
+
+          // Get the position of the deleted project
+          const index = projects.map(project => project.id).indexOf(deletedId);
+
+          // Run the deletion
+          const successfullyDeleted = shell.moveItemToTrash(path);
+
+          if (successfullyDeleted) {
+            // Update state
+            store.dispatch(finishDeletingProjectFromDisk(deletedId));
+          }
+
+          // Calculate remaining projects by filtering out the deleted project
+          const remainingProjects = projects.filter(
+            project => project.id !== action.project.id
+          );
+
+          // Get the index for the next project
+          // It's either the next project after deleted project's position
+          // or if deleted project was last, then select the new last element
+          const nextIndex =
+            index < remainingProjects.length
+              ? index
+              : remainingProjects.length - 1;
+
+          // If remainingProjects array has at least one project
+          // then there's a project to select next
+          if (remainingProjects.length >= 1) {
+            // Select the next project
+            const nextProject = remainingProjects[nextIndex];
+            store.dispatch(selectProject(nextProject.id));
+          } else {
+            // Otherwise there are no more projects left
+            // so just render the create/import screen
+            store.dispatch(createNewProjectStart());
           }
         }
       );
-      break;
-    }
-
-    case DELETE_PROJECT_FROM_DISK: {
-      const { project } = action;
-      const { path } = project;
-
-      // Returns true if successfully deleted
-      const successfullyDeleted = shell.moveItemToTrash(path);
-
-      if (successfullyDeleted) {
-        store.dispatch(deleteProjectFromDiskFinish(project));
-        store.dispatch(refreshProjects());
-      }
-      break;
-    }
-
-    case FINISH_DELETING_PROJECT_FROM_DISK: {
-      // Get the deleted project from the action
-      // so we know what was deleted
-      const { deletedProject } = action;
-
-      // Get a fresh projects array from state
-      const projects = getProjectsArray(store.getState());
-
-      // Calculate remaining projects by filtering out deletedProject.id
-      const remainingProjects = projects.filter(
-        project => project.id !== deletedProject.id
-      );
-
-      // If remainingProjects array has at least one project
-      // then there's a project to select next
-      if (remainingProjects.length >= 1) {
-        const nextProject = remainingProjects[0];
-        store.dispatch(selectProject(nextProject.id));
-      } else {
-        // Otherwise there are no more projects left
-        // so just render the create/import screen
-        store.dispatch(createNewProjectStart());
-      }
       break;
     }
   }

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -5,6 +5,7 @@ import produce from 'immer';
 import {
   ADD_PROJECT,
   IMPORT_EXISTING_PROJECT_FINISH,
+  FINISH_DELETING_PROJECT_FROM_DISK,
   ADD_DEPENDENCY_FINISH,
   REFRESH_PROJECTS,
   SELECT_PROJECT,
@@ -52,6 +53,14 @@ const byId = (state: ById = initialState.byId, action: Action) => {
       return produce(state, draftState => {
         draftState[projectId].dependencies[dependency.name] =
           dependency.version;
+      });
+    }
+
+    case FINISH_DELETING_PROJECT_FROM_DISK: {
+      const { projectId } = action;
+
+      return produce(state, draftState => {
+        delete draftState[projectId];
       });
     }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,6 +10,7 @@ import rootReducer from '../reducers';
 import taskMiddleware from '../middlewares/task.middleware';
 import dependencyMiddleware from '../middlewares/dependency.middleware';
 import importProjectMiddleware from '../middlewares/import-project.middleware';
+import deleteProjectMiddleware from '../middlewares/delete-project.middleware';
 import createEngine from './storage-engine';
 import handleMigrations from './migrations';
 
@@ -42,6 +43,7 @@ export default function configureStore() {
         taskMiddleware,
         dependencyMiddleware,
         importProjectMiddleware,
+        deleteProjectMiddleware,
         storageMiddleware
       ),
       DevTools.instrument()


### PR DESCRIPTION
**Related Issue:**
#90 and #140

**Summary:**
This is the functionality for deleting project from disk. Right now it lives in the Project app menu but will eventually also live in the modal from #120. And eventually it will also have 'Delete from Guppy' option as well. It will also need to be converted to a saga once #154 lands.

Right now things seem to be 99% working, but there's an annoying bug I can't seem to figure out where the circular animations are not firing consistently. If you delete a project that's anything but the first in the list it will run, but not the first in the list 😕

In this PR I've also tweaked the Project menu conditional slightly. It was originally only showing up if `selectedProjectId && devServerTask` and this was fine when it just had the clear log task, but now it needs to always be there since user will always be able to delete a project. I noticed this issue because some of my projects don't have a start task (so, no `devServerTask` either) so there's no `Development Server` pane, and the Project menu wasn't showing up at all.

**Screenshots/GIFs:**

Normal view:

<img width="772" alt="screen shot 2018-08-26 at 9 01 28 am" src="https://user-images.githubusercontent.com/17421347/44630214-d7cd6a80-a90e-11e8-8d50-20cf3d39da9c.png">

No start task:

<img width="769" alt="screen shot 2018-08-26 at 9 01 59 am" src="https://user-images.githubusercontent.com/17421347/44630210-cc7a3f00-a90e-11e8-931f-5bf81470fe81.png">

Circular animation bug:

![kapture 2018-08-26 at 9 07 39](https://user-images.githubusercontent.com/17421347/44630294-d2245480-a90f-11e8-8c29-147f8d3a8977.gif)

