### PR TITLE
Stop scanning home directory for projects

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -62,11 +62,11 @@ function runElectronApp(port) {
   electronProcess.stdout.on('data', data => {
     // dont log blank output or empty newlines
     const output = data.toString().trim();
-    if (output.length) console.log(chalk.green('[ELECTRON]'), output);
+    if (output.length) console.info(chalk.green('[ELECTRON]'), output);
   });
   electronProcess.stderr.on('data', data => {
     const output = data.toString();
-    console.log(chalk.red(`[ELECTRON] ${output}`));
+    console.error(chalk.red(`[ELECTRON] ${output}`));
   });
 
   // close webpack server when electron quits

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -203,6 +203,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   createNewProjectStart: actions.createNewProjectStart,
+  selectProject: actions.selectProject,
 };
 
 export default connect(

--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ function createWindow() {
     try {
       installExtension(extension);
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }
 

--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -8,6 +8,7 @@ import {
   IMPORT_EXISTING_PROJECT_ERROR,
   IMPORT_EXISTING_PROJECT_FINISH,
   SELECT_PROJECT,
+  REFRESH_PROJECTS_FINISH,
 } from '../actions';
 
 import type { Action } from 'redux';
@@ -45,6 +46,24 @@ export default (state: State = initialState, action: Action) => {
     case DISMISS_SIDEBAR_INTRO:
     case SELECT_PROJECT: {
       return state === 'introducing-sidebar' ? 'done' : state;
+    }
+
+    case REFRESH_PROJECTS_FINISH: {
+      // In earlier versions of the app, we would automatically parse the
+      // Guppy project directory for projects.
+      //
+      // If the user clears their electron store, this could lead to a state
+      // where their onboarding status is reset, but projects exist. This ought
+      // to be an impossible state: if the user has projects, they're done with
+      // onboarding!
+      //
+      // Now that we've solved the state-persistence issue and are no longer
+      // scanning directories for projects, this shouldn't be an issue anymore.
+      // This change is for older clients, and can safely be removed in
+      // winter 2018.
+      const projectKeys = Object.keys(action.projects);
+
+      return projectKeys.length > 0 ? 'done' : state;
     }
 
     default:

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -76,7 +76,15 @@ const selectedIdReducer = (
   switch (action.type) {
     case ADD_PROJECT:
     case IMPORT_EXISTING_PROJECT_FINISH: {
-      return action.project.guppy.id;
+      // When a new project is created/imported, we generally want to select
+      // it! The only exception is during onboarding. We want the user to
+      // manually click the icon, to teach them what these icons are.
+      //
+      // NOTE: This is knowable because after onboarding, a project will
+      // _always_ be selected. This is a fundamental truth about how Guppy
+      // works. In the future, though, we may want to have non-project screens,
+      // and so this will have to be rethought.
+      return state ? action.project.guppy.id : null;
     }
 
     case REFRESH_PROJECTS_FINISH: {

--- a/src/reducers/projects.reducer.test.js
+++ b/src/reducers/projects.reducer.test.js
@@ -14,59 +14,80 @@ import reducer, {
 } from './projects.reducer';
 
 describe('Projects Reducer', () => {
-  describe(ADD_PROJECT, () => {
-    it('adds a project', () => {
-      const action = {
-        type: ADD_PROJECT,
-        project: {
-          name: 'testing',
-          guppy: { id: 'best-id' },
-          scripts: {
-            start: 'react-scripts start',
+  [ADD_PROJECT, IMPORT_EXISTING_PROJECT_FINISH].forEach(ACTION => {
+    describe(ACTION, () => {
+      it('adds the project to the state', () => {
+        const action = {
+          type: ACTION, // ADD_PROJECT or IMPORT_EXISTING_PROJECT_FINISH
+          project: {
+            name: 'testing',
+            guppy: { id: 'best-id' },
+            scripts: {
+              start: 'react-scripts start',
+            },
           },
-        },
-      };
-      const actualState = reducer(projectsInitialState, action);
+        };
+        const actualState = reducer(projectsInitialState, action);
 
-      const { name, guppy, scripts } = action.project;
+        const { name, guppy, scripts } = action.project;
 
-      expect(actualState).toEqual({
-        byId: {
-          [guppy.id]: {
-            name,
-            guppy,
-            scripts,
+        expect(actualState).toEqual({
+          byId: {
+            [guppy.id]: {
+              name,
+              guppy,
+              scripts,
+            },
           },
-        },
-        selectedId: guppy.id,
+          selectedId: null,
+        });
       });
-    });
-  });
 
-  describe(IMPORT_EXISTING_PROJECT_FINISH, () => {
-    it('imports existing project', () => {
-      const action = {
-        type: IMPORT_EXISTING_PROJECT_FINISH,
-        project: {
-          name: 'testing',
-          guppy: { id: 'best-id' },
-          scripts: {
-            start: 'react-scripts start',
+      it("selects it, when it isn't the first one", () => {
+        const initialState = {
+          byId: {
+            preexisting: {
+              name: 'I pre-exist!',
+              guppy: {},
+              scripts: {
+                start: 'react-scripts start',
+              },
+            },
           },
-        },
-      };
-      const actualState = reducer(projectsInitialState, action);
+          selectedId: 'preexisting',
+        };
 
-      const { name, guppy, scripts } = action.project;
-      expect(actualState).toEqual({
-        byId: {
-          [guppy.id]: {
-            name,
-            guppy,
-            scripts,
+        const action = {
+          type: ACTION, // ADD_PROJECT or IMPORT_EXISTING_PROJECT_FINISH
+          project: {
+            name: 'next project',
+            guppy: { id: 'next-project' },
+            scripts: {
+              start: 'react-scripts start',
+            },
           },
-        },
-        selectedId: guppy.id,
+        };
+        const actualState = reducer(initialState, action);
+
+        const { name, guppy, scripts } = action.project;
+
+        expect(actualState).toEqual({
+          byId: {
+            preexisting: {
+              name: 'I pre-exist!',
+              guppy: {},
+              scripts: {
+                start: 'react-scripts start',
+              },
+            },
+            [guppy.id]: {
+              name,
+              guppy,
+              scripts,
+            },
+          },
+          selectedId: guppy.id,
+        });
       });
     });
   });

--- a/src/services/read-from-disk.service.js
+++ b/src/services/read-from-disk.service.js
@@ -4,7 +4,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { pick } from '../utils';
-import { defaultParentPath } from '../reducers/paths.reducer';
 
 import type { DependencyLocation, ProjectInternal } from '../types';
 
@@ -52,33 +51,8 @@ export const writePackageJson = (projectPath: string, json: any) => {
  * Given an array of paths, load each one as a distinct Guppy project.
  * Parses the `package.json` to find Guppy's saved info.
  */
-export function loadGuppyProjects(projectPathsInput: Array<string>) {
-  const { readdirSync, statSync } = fs;
-
-  // Create a clone of paths so we aren't mutating the provided array.
-  const projectPaths = [...projectPathsInput];
-
-  // In addition to the paths recovered from localStorage, we also want to
-  // parse the default parent path, to collect any local projects that Guppy
-  // doesn't know about
-  // (this is mainly useful for dev, so that I can clear localStorage to
-  // emulate a clean slate, but might also be useful for users who want to
-  // create projects outside of Guppy but have them managed internally)
-  try {
-    readdirSync(defaultParentPath).forEach(f => {
-      const projectPath = path.join(defaultParentPath, f);
-      const isDirectory = statSync(projectPath).isDirectory();
-
-      if (isDirectory && !projectPaths.includes(projectPath)) {
-        projectPaths.push(projectPath);
-      }
-    });
-  } catch (e) {
-    // If the default parent path doesn't exist, it'll throw an error.
-    // This is fine, though; it just means that we have
-  }
-
-  return new Promise((resolve, reject) => {
+export const loadGuppyProjects = (projectPaths: Array<string>) =>
+  new Promise((resolve, reject) => {
     // Each project in a Guppy directory should have a package.json.
     // We'll read all the project info we need from this file.
     // TODO: Maybe use asyncReduce to handle the output format in 1 neat step?
@@ -126,7 +100,6 @@ export function loadGuppyProjects(projectPathsInput: Array<string>) {
       }
     );
   });
-}
 
 /**
  * Find a specific project's dependency information.

--- a/src/store/storage-engine.js
+++ b/src/store/storage-engine.js
@@ -18,6 +18,8 @@ function rejectWithMessage(error) {
 export default function createEngine(key: string) {
   const store = new ElectronStore();
 
+  window.electronStore = store;
+
   return {
     load: () =>
       new Promise(resolve => {


### PR DESCRIPTION
**Summary:**
Our philosophy around state persistence recently changed.

Before, we wanted to treat state as ephemeral; you could clear state whenever you wanted, and Guppy would try and rebuild itself magically.

Now, we realized a better state is just to make state-persistence more dependable, so that the user should never have to clear state. They still can if there's an issue, but it should be less common, and so it doesn't matter so much if it's slightly more inconvenient.

As a result, we no longer want to scan and automatically add projects found in the projects directory.

This change brings a few benefits:
- No more weirdness with onboarding when clearing state
- Deleting projects from guppy, but not from disk, will be possible now!
- No weirdness around changing home directory
- I believe this will fix #173, although I can't be sure.