### PR TITLE
Kill all running processes on window reload

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import { ipcRenderer } from 'electron';
 import styled, { keyframes } from 'styled-components';
 
 import { COLORS } from '../../constants';
@@ -22,6 +23,18 @@ type Props = {
 };
 
 class App extends Component<Props> {
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.killAllRunningProcesses);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.killAllRunningProcesses);
+  }
+
+  killAllRunningProcesses = () => {
+    ipcRenderer.send('killAllRunningProcesses');
+  };
+
   render() {
     const { isAppLoaded, selectedProject } = this.props;
 

--- a/src/main.js
+++ b/src/main.js
@@ -118,6 +118,10 @@ ipcMain.on('removeProcessId', (event, processId) => {
   processIds = processIds.filter(id => id !== processId);
 });
 
+ipcMain.on('killAllRunningProcesses', event => {
+  killAllRunningProcesses();
+});
+
 const killAllRunningProcesses = () => {
   try {
     processIds.forEach(processId => {


### PR DESCRIPTION
**Related Issue:** #106

**Summary:**
Electron's ipcRenderer keeps track of all running tasks spawned by Guppy and ensures that they are killed before the app closes. However, reloading the app (using `View > Reload` or `View > Force Reload`) refreshes the window without killing any processes, orphaning all processes spawned up until that point.

This PR adds a listener to the `beforeunload` event that is fired just before the window is reloaded to kill all running processes.