### PR TITLE
Fix blacklist

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,7 +30,7 @@ export default function configureStore() {
 
   // We don't want to store task info.
   // Tasks
-  engine = filter(engine, null, [['appLoaded', 'tasks']]);
+  engine = filter(engine, null, ['appLoaded', 'tasks']);
   const storageMiddleware = storage.createMiddleware(engine);
 
   const wrappedReducer = storage.reducer(rootReducer);


### PR DESCRIPTION
Argh this is embarrassing, I used the wrong syntax for the blacklist (nested arrays are for nested data structures).

This fix makes it so that `task` and `appLoaded` data isn't persisted from session to session.
