### PR TITLE
"Move to Applications folder" on Mac

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -176,7 +176,7 @@ const manageApplicationLocation = () => {
       {
         type: 'question',
         buttons: ['Yes, move', 'Cancel'],
-        message: 'Move to applications folder?',
+        message: 'Move to Applications folder?',
         detail:
           "I see that I'm not in the Applications folder. I can move myself there if you'd like!",
         icon: path.join(__dirname, 'assets/icons/png/256x256.png'),

--- a/src/main.js
+++ b/src/main.js
@@ -158,6 +158,10 @@ const canApplicationBeMoved = () => {
     process.platform === 'darwin' &&
     typeof app.isInApplicationsFolder === 'function';
 
+  // NOTE: Because this file isn't compiled by Webpack, `process.env.NODE_ENV`
+  // will be undefined in the bundled application. Rather than check to see if
+  // it's set to `production`, we just care that it ISN'T set to `development`
+  // (development is set in package.json when running the 'start' script).
   const isProduction = process.env.NODE_ENV !== 'development';
 
   if (

--- a/src/main.js
+++ b/src/main.js
@@ -144,6 +144,12 @@ const killAllRunningProcesses = () => {
 };
 
 const manageApplicationLocation = () => {
+  if (canApplicationBeMoved()) {
+    showMoveToApplicationsFolderDialog();
+  }
+};
+
+const canApplicationBeMoved = () => {
   // The dialog should only be showed if :
   //  - The platform is MacOS
   //  - The app is running in production
@@ -156,9 +162,13 @@ const manageApplicationLocation = () => {
   const isProduction = process.env.NODE_ENV === 'production';
 
   if (!hasApplicationsFolder || !isProduction || app.isInApplicationsFolder()) {
-    return;
+    return false;
   }
 
+  return true;
+};
+
+const showMoveToApplicationsFolderDialog = () => {
   dialog.showMessageBox(
     {
       type: 'question',

--- a/src/main.js
+++ b/src/main.js
@@ -150,7 +150,7 @@ const manageApplicationLocation = () => {
 };
 
 const canApplicationBeMoved = () => {
-  // The dialog should only be showed if :
+  // The application can be moved if :
   //  - The platform is MacOS
   //  - The app is running in production
   //  - The function 'isInApplicationsFolder' exists
@@ -177,10 +177,12 @@ const showMoveToApplicationsFolderDialog = () => {
       detail:
         "I see that I'm not in the Applications folder. I can move myself there if you'd like!",
       icon: path.join(__dirname, 'assets/icons/png/256x256.png'),
-      defaultId: 0,
       cancelId: 1,
+      defaultId: 0,
+      checkboxLabel: 'Do not show this message again',
     },
-    res => {
+    (res, checkboxChecked) => {
+      // User wants the application to be moved
       if (res === 0) {
         try {
           app.moveToApplicationsFolder();
@@ -191,6 +193,11 @@ const showMoveToApplicationsFolderDialog = () => {
           );
           console.error('Could not move Guppy to the Applications folder', err);
         }
+      }
+
+      // User doesn't want to see the message again
+      if (checkboxChecked === true) {
+        // TODO: Store choice in electron-store
       }
     }
   );

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
  * This is our main Electron process.
  * It handles opening our app window, and quitting the application.
  */
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
 const url = require('url');
 const fixPath = require('fix-path');
@@ -30,6 +30,11 @@ let mainWindow;
 let processIds = [];
 
 function createWindow() {
+  // Verify on opening if guppy is in the Applications Folder
+  if (!app.isInApplicationsFolder()) {
+    showMoveToApplicationsFolderDialog();
+  }
+
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1120,
@@ -137,4 +142,31 @@ const killAllRunningProcesses = () => {
   } catch (err) {
     console.error('Got error when trying to kill children', err);
   }
+};
+
+const showMoveToApplicationsFolderDialog = () => {
+  dialog.showMessageBox(
+    {
+      type: 'question',
+      buttons: ['Yes, move', 'Cancel'],
+      message: 'Move to applications folder?',
+      detail:
+        "I see that I'm not in the Applications folder. I can move myself there if you'd like!",
+      icon: path.join(__dirname, 'assets/icons/png/256x256.png'),
+      defaultId: 0,
+      setAlwaysOnTop: true,
+    },
+    res => {
+      if (res === 0) {
+        try {
+          app.moveToApplicationsFolder();
+        } catch (err) {
+          console.error(
+            'Got error when trying to move guppy to the Applications Folder',
+            err
+          );
+        }
+      }
+    }
+  );
 };

--- a/src/main.js
+++ b/src/main.js
@@ -148,9 +148,10 @@ const killAllRunningProcesses = () => {
 const canApplicationBeMoved = () => {
   // The application can be moved if :
   //  - The platform is MacOS
-  //  - The app is running in production
   //  - The function 'isInApplicationsFolder' exists
+  //  - The app is running in production
   //  - Guppy is not already in the Applications folder
+  //  - The user hasn't chosen to not see the dialog prompt again
   const hasApplicationsFolder =
     process.platform === 'darwin' &&
     typeof app.isInApplicationsFolder === 'function';

--- a/src/main.js
+++ b/src/main.js
@@ -154,7 +154,6 @@ const showMoveToApplicationsFolderDialog = () => {
         "I see that I'm not in the Applications folder. I can move myself there if you'd like!",
       icon: path.join(__dirname, 'assets/icons/png/256x256.png'),
       defaultId: 0,
-      setAlwaysOnTop: true,
     },
     res => {
       if (res === 0) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -35,13 +35,17 @@ export default function configureStore() {
 
   const wrappedReducer = storage.reducer(rootReducer);
 
-  const store = createStore(
-    wrappedReducer,
-    compose(
-      applyMiddleware(thunk, storageMiddleware, sagaMiddleware),
-      DevTools.instrument()
-    )
-  );
+  const middlewares = [thunk, storageMiddleware, sagaMiddleware];
+
+  const enhancers =
+    process.env.NODE_ENV === 'production'
+      ? applyMiddleware(...middlewares)
+      : compose(
+          applyMiddleware(...middlewares),
+          DevTools.instrument()
+        );
+
+  const store = createStore(wrappedReducer, enhancers);
 
   sagaMiddleware.run(rootSaga);
 


### PR DESCRIPTION
**Related Issue:**
https://github.com/joshwcomeau/guppy/issues/185

**Summary:**
On the app ready hook, before the browser window creation, checks if guppy is already in the Applications folder and if not, shows a Message Box that allows the application to be moved. If canceled it will just resume its normal startup process. If accepted, the application will be closed, moved and then restarted without the message.

**Screenshots/GIFs:**

<img width="429" alt="screen shot 2018-09-01 at 11 37 04" src="https://user-images.githubusercontent.com/3718438/44944681-79efc580-addb-11e8-85aa-a0a0635e5a2a.png">

![sep-01-2018 11-48-34](https://user-images.githubusercontent.com/3718438/44944769-06e74e80-addd-11e8-8bec-93cc42b2fbfd.gif)
