### PR TITLE
Two small quality-of-life tweaks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: 'react-app',
   rules: {
-    'no-unused-vars': 2,
+    'no-unused-vars': 1,
     'no-shadow': 2,
   },
 };

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,10 @@
 [ignore]
+# `electron-packager` comes with intentionally-bad JSON, and Flow trips over it
 .*/node_modules/electron-packager/test/fixtures/infer-malformed-json/package.json
+
+# Release builds are git-ignored, and thus can cause problems when checking out
+# new branches, and have Flow run on old files without the same dependencies.
+.*/release-builds/*
 
 [include]
 


### PR DESCRIPTION
While working, I noticed two things were getting on my nerves:

- Our stricter ESLint rules meant that when refactoring a file, I had to resolve all unused variables before I could preview my changes; because `no-unused-vars` is an error now, instead of just a warning, it throws up an error screen. This is super annoying when re-organizing things, or even just commenting out a section of code temporarily.

I do think we want to avoid having unused variables make it into our code. I wish there was a way for CircleCI to reject any warnings, or to have create-react-app allow errors.

- Flow was checking code in release-builds. In addition to being unnecessary, it meant I would get Flow failures when checking out different branches (if, for example, I check out to an older branch from before redux-saga, it complains about the unresolvable dependency)