### PR TITLE
Fix name in package.json after new project creation

### DIFF
--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -105,7 +105,7 @@ export default (
         // Gatsby specific fix - the command 'npx gatsby new ...' always sets the
         // name key in package.json to `gatsby-starter-default`. Overwrite it so
         // project is named correctly.
-        if (args[0] === 'gatsby') {
+        if (projectType === 'gatsby') {
           packageJson.name = id;
         }
 

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -102,6 +102,13 @@ export default (
           createdAt: Date.now(),
         };
 
+        // Gatsby specific fix - the command 'npx gatsby new ...' always sets the
+        // name key in package.json to `gatsby-starter-default`. Overwrite it so
+        // project is named correctly.
+        if (args[0] === 'gatsby') {
+          packageJson.name = id;
+        }
+
         const prettyPrintedPackageJson = JSON.stringify(packageJson, null, 2);
 
         fs.writeFile(


### PR DESCRIPTION
**Related Issue:**
closes #190

**Summary:**
When creating a new project we run `npx gatsby new ...` and it sets the package.json name key to `gatsby-starter-default` (this is just how `gatsby new` behaves, nothing to do with Guppy). Small PR to fix it.