### PR TITLE
Check for guppy key in package.json

### DIFF
--- a/src/sagas/import-project.saga.js
+++ b/src/sagas/import-project.saga.js
@@ -97,11 +97,16 @@ export function* importProject({ path }: Action): Saga<void> {
     // icon.
     // TODO: Try importing the existing project's favicon as icon instead?
     const color = yield call(getColorForProject, json.name);
+
+    // If guppy key already exists in package.json (if importing a project that was
+    // on Guppy previously), then we don't want to overwrite guppy.name because
+    // it's the proper spaced version of the project name (json.name is dashed)
+    const hasGuppyKey = json.hasOwnProperty('guppy');
     const packageJsonWithGuppy = {
       ...json,
       guppy: {
         id: json.name,
-        name: json.name,
+        name: hasGuppyKey ? json.guppy.name : json.name,
         type,
         color,
         icon: null,

--- a/src/sagas/import-project.saga.js
+++ b/src/sagas/import-project.saga.js
@@ -98,20 +98,24 @@ export function* importProject({ path }: Action): Saga<void> {
     // TODO: Try importing the existing project's favicon as icon instead?
     const color = yield call(getColorForProject, json.name);
 
-    // If guppy key already exists in package.json (if importing a project that was
-    // on Guppy previously), then we don't want to overwrite guppy.name because
-    // it's the proper spaced version of the project name (json.name is dashed)
+    // If guppy key already exists in package.json, then we don't want
+    // to overwrite it
     const hasGuppyKey = json.hasOwnProperty('guppy');
+
+    const guppyFields = hasGuppyKey
+      ? json.guppy
+      : {
+          id: json.name,
+          name: json.name,
+          type,
+          color,
+          icon: null,
+          createdAt: Date.now(),
+        };
+
     const packageJsonWithGuppy = {
       ...json,
-      guppy: {
-        id: json.name,
-        name: hasGuppyKey ? json.guppy.name : json.name,
-        type,
-        color,
-        icon: hasGuppyKey ? json.guppy.icon : null,
-        createdAt: Date.now(),
-      },
+      guppy: guppyFields,
     };
 
     const writedPackageJson = yield call(

--- a/src/sagas/import-project.saga.js
+++ b/src/sagas/import-project.saga.js
@@ -109,7 +109,7 @@ export function* importProject({ path }: Action): Saga<void> {
         name: hasGuppyKey ? json.guppy.name : json.name,
         type,
         color,
-        icon: null,
+        icon: hasGuppyKey ? json.guppy.icon : null,
         createdAt: Date.now(),
       },
     };


### PR DESCRIPTION
**Summary:**

More bug fixin'. If a project was previously removed from Guppy and re-imported, it already has a `guppy` key in package.json. We want to check for this because currently importing projects assumes it's never been in Guppy before, and sets guppy.name to json.name... which doesn't have spaces.