### PR TITLE
Fix for #187 (Dynamic button width breaks outline)

### DIFF
--- a/src/components/CircularOutline/CircleOutline.stories.js
+++ b/src/components/CircularOutline/CircleOutline.stories.js
@@ -1,0 +1,56 @@
+// @flow
+import React, { Fragment, Component } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Showcase from '../../../.storybook/components/Showcase';
+import Button from '../Button';
+
+type Props = { children: (data: any) => React$Node };
+type State = { copyIndex: number };
+
+const BUTTON_COPY = [
+  'hello',
+  'hello world',
+  '!',
+  'Wow this is so long why is it so long ahhhhhhhhhhhh',
+];
+class CopyManager extends Component<Props, State> {
+  state = {
+    copyIndex: 0,
+  };
+
+  cycleCopy = () => {
+    // This line means we always get a value between 0-3:
+    const nextCopyIndex = (this.state.copyIndex + 1) % BUTTON_COPY.length;
+
+    this.setState({ copyIndex: nextCopyIndex });
+  };
+
+  render() {
+    const { children } = this.props;
+    const { copyIndex } = this.state;
+
+    const copy = BUTTON_COPY[copyIndex];
+
+    return (
+      <Fragment>
+        <button onClick={this.cycleCopy}>Change Size</button>
+        <br />
+        <br />
+        {children(copy)}
+      </Fragment>
+    );
+  }
+}
+
+storiesOf('CircleOutline', module).add(
+  'dynamicSizing',
+  withInfo()(() => (
+    <Fragment>
+      <Showcase label="Dynamic Sizing">
+        <CopyManager>{copy => <Button type="fill">{copy}</Button>}</CopyManager>
+      </Showcase>
+    </Fragment>
+  ))
+);

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -59,7 +59,7 @@ class RoundedOutline extends Component<Props, State> {
   };
 
   wrapperNode: HTMLElement;
-  shapeNode: any;
+  shapeNode: any; // "SVGPathElement" (which cannot be resolved), we need "getTotalLength()"
 
   static defaultProps = {
     color1: COLORS.purple[500],
@@ -77,20 +77,18 @@ class RoundedOutline extends Component<Props, State> {
   }
 
   componentDidUpdate(_: Props, prevState: State) {
-    if (
-      prevState.width == null &&
-      prevState.height == null &&
-      this.state.width !== null &&
-      this.state.height !== null
-    ) {
-      // $FlowFixMe
-      const pathLength = this.shapeNode.getTotalLength();
+    if (this.state.width !== null && this.state.height !== null) {
+      if (prevState.width == null && prevState.height == null) {
+        const pathLength = this.shapeNode.getTotalLength();
 
-      this.setState({ pathLength });
-    }
+        this.setState({ pathLength });
+      } else {
+        const { width, height } = this.wrapperNode.getBoundingClientRect();
 
-    if (prevState.pathLength === 0 && this.state.pathLength !== 0) {
-      this.setState({ finishedAllMountingSteps: true });
+        if (this.state.width !== width || this.state.height !== height) {
+          this.setState({ width, height });
+        }
+      }
     }
 
     if (this.state.pathLength !== null) {
@@ -99,6 +97,10 @@ class RoundedOutline extends Component<Props, State> {
       if (this.state.pathLength !== newPathLength) {
         this.setState({ pathLength: newPathLength });
       }
+    }
+
+    if (prevState.pathLength === 0 && this.state.pathLength !== 0) {
+      this.setState({ finishedAllMountingSteps: true });
     }
   }
 
@@ -149,8 +151,8 @@ class RoundedOutline extends Component<Props, State> {
                   innerRef={node => (this.shapeNode = node)}
                   x={0}
                   y={0}
-                  width="100%"
-                  height="100%"
+                  width={width}
+                  height={height}
                   rx={height / 2}
                   ry={height / 2}
                   fill="none"

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -26,9 +26,6 @@
  *                      can be animated
  *
  * There's surely a lot of room for improvement with this flow.
- *
- * Also, this component is oblivious to any parent resize-changes, so don't use
- * it in a component that has the propensity to change sizes.
  */
 import React, { Component } from 'react';
 import styled from 'styled-components';
@@ -144,18 +141,14 @@ class RoundedOutline extends Component<Props, State> {
                   innerRef={node => (this.shapeNode = node)}
                   x={0}
                   y={0}
-                  width={width}
-                  height={height}
+                  width="100%"
+                  height="100%"
                   rx={height / 2}
-                  ry={width / 2}
+                  ry={height / 2}
                   fill="none"
                   stroke={`url(#${svgId})`}
                   strokeWidth={strokeWidth}
                   strokeLinecap="round"
-                  style={{
-                    strokeDasharray: `${pathLength}, ${pathLength + 1}`,
-                    strokeDashoffset: interpolatedDashOffset,
-                  }}
                 />
               )}
           </Svg>

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -59,7 +59,7 @@ class RoundedOutline extends Component<Props, State> {
   };
 
   wrapperNode: HTMLElement;
-  shapeNode: HTMLElement;
+  shapeNode: any;
 
   static defaultProps = {
     color1: COLORS.purple[500],
@@ -91,6 +91,14 @@ class RoundedOutline extends Component<Props, State> {
 
     if (prevState.pathLength === 0 && this.state.pathLength !== 0) {
       this.setState({ finishedAllMountingSteps: true });
+    }
+
+    if (this.state.pathLength !== null) {
+      const newPathLength = this.shapeNode.getTotalLength();
+
+      if (this.state.pathLength !== newPathLength) {
+        this.setState({ pathLength: newPathLength });
+      }
     }
   }
 
@@ -149,6 +157,10 @@ class RoundedOutline extends Component<Props, State> {
                   stroke={`url(#${svgId})`}
                   strokeWidth={strokeWidth}
                   strokeLinecap="round"
+                  style={{
+                    strokeDasharray: `${pathLength}, ${pathLength + 1}`,
+                    strokeDashoffset: interpolatedDashOffset,
+                  }}
                 />
               )}
           </Svg>

--- a/src/components/CircularOutline/CircularOutline.stories.js
+++ b/src/components/CircularOutline/CircularOutline.stories.js
@@ -4,7 +4,8 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import Showcase from '../../../.storybook/components/Showcase';
-import Button from '../Button';
+import CircularOutline from './CircularOutline';
+import styled from 'styled-components';
 
 type Props = { children: (data: any) => React$Node };
 type State = { copyIndex: number };
@@ -38,19 +39,59 @@ class CopyManager extends Component<Props, State> {
         <button onClick={this.cycleCopy}>Change Size</button>
         <br />
         <br />
-        {children(copy)}
+        <ButtonElem>
+          <OutlineWrapper>{children(copy)}</OutlineWrapper>
+          {copy}
+        </ButtonElem>
       </Fragment>
     );
   }
 }
 
-storiesOf('CircleOutline', module).add(
+storiesOf('CircularOutline', module).add(
   'dynamicSizing',
   withInfo()(() => (
     <Fragment>
       <Showcase label="Dynamic Sizing">
-        <CopyManager>{copy => <Button type="fill">{copy}</Button>}</CopyManager>
+        <CopyManager>
+          {copy => (
+            <CircularOutline
+              color1={'red'}
+              color2={'blue'}
+              strokeWidth={2}
+              isShown={true}
+              animateChanges={true}
+            >
+              {copy}
+            </CircularOutline>
+          )}
+        </CopyManager>
       </Showcase>
     </Fragment>
   ))
 );
+
+const ButtonElem = styled.button`
+  position: relative;
+  width: ${props => props.size}px;
+  height: ${props => props.size}px;
+  border: none;
+  background: none;
+  outline: none;
+  padding: 0;
+  cursor: pointer;
+
+  &:active rect {
+    stroke-width: 4;
+  }
+`;
+
+const OutlineWrapper = styled.div`
+  position: absolute;
+  z-index: 3;
+  top: -3px;
+  left: -3px;
+  right: -3px;
+  bottom: -3px;
+  pointer-events: none;
+`;


### PR DESCRIPTION
**Related Issue:** #187 

**Summary:**

OK So I've fixed the issue it by making the CircularOutline <Rect> 100% of the parent SVG (and that is 100% of the parent div size).

**Screenshots/GIFs:**

![44954751-1af38480-ae9f-11e8-813f-cca10b804b57](https://user-images.githubusercontent.com/9812458/44954778-d2889680-ae9f-11e8-81b9-e60a8475e40e.png)

I think we can remove all "width" props from this component now; does that seem right? I am still pretty new to this :)
We will have to keep the height because that determines the  values for `rx` and `ry`.