### PR TITLE
Added buttons for opening in editor & Finder to project page

### DIFF
--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -11,9 +11,15 @@ import MainContentWrapper from '../MainContentWrapper';
 import Heading from '../Heading';
 import PixelShifter from '../PixelShifter';
 import Spacer from '../Spacer';
+import Button from '../Button';
 import DevelopmentServerPane from '../DevelopmentServerPane';
 import TaskRunnerPane from '../TaskRunnerPane';
 import DependencyManagementPane from '../DependencyManagementPane';
+import {
+  openProjectInEditor,
+  openProjectInFolder,
+} from '../../services/shell.service';
+import { getCopyForOpeningFolder } from '../../services/platform.service';
 
 import type { Project } from '../../types';
 
@@ -23,6 +29,17 @@ type Props = {
 };
 
 class ProjectPage extends Component<Props> {
+  openIDE = () => {
+    const { project } = this.props;
+    openProjectInEditor(project);
+  };
+
+  openFolder = () => {
+    const { project } = this.props;
+    // Show a folder in the file manager
+    openProjectInFolder(project);
+  };
+
   componentDidMount() {
     const { project, loadDependencyInfoFromDisk } = this.props;
 
@@ -58,7 +75,15 @@ class ProjectPage extends Component<Props> {
               {project.name}
             </Heading>
           </PixelShifter>
-
+          <Spacer size={15} />
+          <ProjectActionBar>
+            <ActionButton size="small" onClick={this.openFolder}>
+              {getCopyForOpeningFolder()}
+            </ActionButton>
+            <ActionButton size="small" onClick={this.openIDE}>
+              Open editor
+            </ActionButton>
+          </ProjectActionBar>
           <Spacer size={30} />
           <DevelopmentServerPane leftSideWidth={300} />
 
@@ -78,6 +103,22 @@ class ProjectPage extends Component<Props> {
     );
   }
 }
+
+const FlexRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const ProjectActionBar = styled.div``;
+
+const ActionButton = styled(Button)`
+  margin-right: 0.3em;
+  background-color: ${COLORS.gray[200]};
+  &:hover {
+    background-color: ${COLORS.gray[300]};
+  }
+`;
 
 const fadeIn = keyframes`
   from { opacity: 0.5 }

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -104,12 +104,6 @@ class ProjectPage extends Component<Props> {
   }
 }
 
-const FlexRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
 const ProjectActionBar = styled.div``;
 
 const ActionButton = styled(Button)`

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -75,15 +75,31 @@ class ProjectPage extends Component<Props> {
               {project.name}
             </Heading>
           </PixelShifter>
-          <Spacer size={15} />
+
           <ProjectActionBar>
-            <ActionButton size="small" onClick={this.openFolder}>
+            <Button
+              type="fill"
+              color1={COLORS.gray[200]}
+              color2={COLORS.gray[200]}
+              textColor={COLORS.gray[900]}
+              size="small"
+              onClick={this.openFolder}
+            >
               {getCopyForOpeningFolder()}
-            </ActionButton>
-            <ActionButton size="small" onClick={this.openIDE}>
-              Open editor
-            </ActionButton>
+            </Button>
+            <Spacer size={15} />
+            <Button
+              type="fill"
+              color1={COLORS.gray[200]}
+              color2={COLORS.gray[200]}
+              textColor={COLORS.gray[900]}
+              size="small"
+              onClick={this.openIDE}
+            >
+              Open in Editor
+            </Button>
           </ProjectActionBar>
+
           <Spacer size={30} />
           <DevelopmentServerPane leftSideWidth={300} />
 
@@ -104,14 +120,8 @@ class ProjectPage extends Component<Props> {
   }
 }
 
-const ProjectActionBar = styled.div``;
-
-const ActionButton = styled(Button)`
-  margin-right: 0.3em;
-  background-color: ${COLORS.gray[200]};
-  &:hover {
-    background-color: ${COLORS.gray[300]};
-  }
+const ProjectActionBar = styled.div`
+  display: flex;
 `;
 
 const fadeIn = keyframes`


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
#46
<!--
Please provide the related issue #. Note that in most cases, you should only be opening a pull request that implements a solution discussed in an issue. See our contribution guidelines for more info
-->

**Summary:**
Added two buttons to `ProjectPage` Component.

It uses `platform.service` for `getCopyForOpenInFolder` caption.
Also `shell.service` is used for executing the commands.

Styling needs to be discussed. I think the size and location is OK but I'm not sure with the color.
A hover effect is changing the background color to a slightly darker gray.

<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->

**Screenshots/GIFs:**
<!--
For changes that affect the UI, please include a screenshot of the change. If the change is related to part of a flow, please include a GIF screen recording.

Free software to create screen-recording GIFs:
- Giphy Capture (MacOS only): https://giphy.com/apps/giphycapture
- Licecap (MacOS / Win): https://www.cockos.com/licecap/
- Peek (Linux): https://github.com/phw/peek
-->
![grafik](https://user-images.githubusercontent.com/3046542/44961657-24b7cf00-af15-11e8-99bc-416f340b4312.png)
