### PR TITLE
Fix bugs

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -62,9 +62,10 @@ export const RESET_ALL_STATE = 'RESET_ALL_STATE';
 //
 // Action Creators
 //
-export const addProject = (project: Project) => ({
+export const addProject = (project: Project, onboardingCompleted: boolean) => ({
   type: ADD_PROJECT,
   project,
+  onboardingCompleted,
 });
 
 export const refreshProjectsStart = () => ({
@@ -314,11 +315,13 @@ export const importExistingProjectError = () => ({
 
 export const importExistingProjectFinish = (
   projectPath: string,
-  project: Project
+  project: Project,
+  onboardingCompleted: boolean
 ) => ({
   type: IMPORT_EXISTING_PROJECT_FINISH,
   projectPath,
   project,
+  onboardingCompleted,
 });
 
 export const showDeleteProjectPrompt = (project: Project) => ({

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -62,10 +62,13 @@ export const RESET_ALL_STATE = 'RESET_ALL_STATE';
 //
 // Action Creators
 //
-export const addProject = (project: Project, onboardingCompleted: boolean) => ({
+export const addProject = (
+  project: Project,
+  isOnboardingCompleted: boolean
+) => ({
   type: ADD_PROJECT,
   project,
-  onboardingCompleted,
+  isOnboardingCompleted,
 });
 
 export const refreshProjectsStart = () => ({
@@ -316,12 +319,12 @@ export const importExistingProjectError = () => ({
 export const importExistingProjectFinish = (
   projectPath: string,
   project: Project,
-  onboardingCompleted: boolean
+  isOnboardingCompleted: boolean
 ) => ({
   type: IMPORT_EXISTING_PROJECT_FINISH,
   projectPath,
   project,
-  onboardingCompleted,
+  isOnboardingCompleted,
 });
 
 export const showDeleteProjectPrompt = (project: Project) => ({

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -40,13 +40,9 @@ class ApplicationMenu extends Component<Props> {
     this.buildMenu(this.props);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    if (
-      this.props.selectedProject &&
-      nextProps.selectedProject &&
-      this.props.selectedProject.id !== nextProps.selectedProject.id
-    ) {
-      this.buildMenu(nextProps);
+  componentDidUpdate(prevProps) {
+    if (this.props.selectedProject !== prevProps.selectedProject) {
+      this.buildMenu(this.props);
     }
   }
 

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -6,6 +6,7 @@ import slug from 'slug';
 
 import * as actions from '../../actions';
 import { getById } from '../../reducers/projects.reducer';
+import { getOnboardingStatus } from '../../reducers/onboarding-status.reducer';
 
 import TwoPaneModal from '../TwoPaneModal';
 
@@ -23,7 +24,8 @@ const FORM_STEPS: Array<Field> = ['projectName', 'projectType', 'projectIcon'];
 type Props = {
   projects: { [projectId: string]: ProjectInternal },
   isVisible: boolean,
-  addProject: (project: Project) => void,
+  onboardingStatus: string,
+  addProject: (project: Project, onboardingCompleted: boolean) => void,
   createNewProjectCancel: () => void,
   createNewProjectFinish: () => void,
 };
@@ -103,10 +105,15 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
   };
 
   finishBuilding = (project: Project) => {
+    const { onboardingStatus } = this.props;
+
+    // Get onboardingStatus to check if sidebar instructions should display
+    const onboardingCompleted = onboardingStatus === 'done';
+
     this.props.createNewProjectFinish();
 
     this.timeoutId = window.setTimeout(() => {
-      this.props.addProject(project);
+      this.props.addProject(project, onboardingCompleted);
 
       this.timeoutId = window.setTimeout(this.reinitialize, 500);
     }, 500);
@@ -184,6 +191,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
 const mapStateToProps = state => ({
   projects: getById(state),
   isVisible: state.modal === 'new-project-wizard',
+  onboardingStatus: getOnboardingStatus(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -6,7 +6,7 @@ import slug from 'slug';
 
 import * as actions from '../../actions';
 import { getById } from '../../reducers/projects.reducer';
-import { getOnboardingStatus } from '../../reducers/onboarding-status.reducer';
+import { getOnboardingCompleted } from '../../reducers/onboarding-status.reducer';
 
 import TwoPaneModal from '../TwoPaneModal';
 
@@ -24,8 +24,8 @@ const FORM_STEPS: Array<Field> = ['projectName', 'projectType', 'projectIcon'];
 type Props = {
   projects: { [projectId: string]: ProjectInternal },
   isVisible: boolean,
-  onboardingStatus: string,
-  addProject: (project: Project, onboardingCompleted: boolean) => void,
+  isOnboardingCompleted: boolean,
+  addProject: (project: Project, isOnboardingCompleted: boolean) => void,
   createNewProjectCancel: () => void,
   createNewProjectFinish: () => void,
 };
@@ -105,15 +105,12 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
   };
 
   finishBuilding = (project: Project) => {
-    const { onboardingStatus } = this.props;
-
-    // Get onboardingStatus to check if sidebar instructions should display
-    const onboardingCompleted = onboardingStatus === 'done';
+    const { isOnboardingCompleted } = this.props;
 
     this.props.createNewProjectFinish();
 
     this.timeoutId = window.setTimeout(() => {
-      this.props.addProject(project, onboardingCompleted);
+      this.props.addProject(project, isOnboardingCompleted);
 
       this.timeoutId = window.setTimeout(this.reinitialize, 500);
     }, 500);
@@ -191,7 +188,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
 const mapStateToProps = state => ({
   projects: getById(state),
   isVisible: state.modal === 'new-project-wizard',
-  onboardingStatus: getOnboardingStatus(state),
+  isOnboardingCompleted: getOnboardingCompleted(state),
 });
 
 const mapDispatchToProps = {

--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -73,6 +73,9 @@ export default (state: State = initialState, action: Action) => {
 
 type GlobalState = { onboardingStatus: State };
 
+export const getOnboardingCompleted = (state: GlobalState) =>
+  getOnboardingStatus(state) === 'done';
+
 export const getOnboardingStatus = (state: GlobalState) =>
   state.onboardingStatus;
 

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -90,7 +90,7 @@ const selectedIdReducer = (
       // _always_ be selected. This is a fundamental truth about how Guppy
       // works. In the future, though, we may want to have non-project screens,
       // and so this will have to be rethought.
-      return state ? action.project.guppy.id : null;
+      return action.onboardingCompleted ? action.project.guppy.id : null;
     }
 
     case REFRESH_PROJECTS_FINISH: {

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -90,7 +90,7 @@ const selectedIdReducer = (
       // _always_ be selected. This is a fundamental truth about how Guppy
       // works. In the future, though, we may want to have non-project screens,
       // and so this will have to be rethought.
-      return action.onboardingCompleted ? action.project.guppy.id : null;
+      return action.isOnboardingCompleted ? action.project.guppy.id : null;
     }
 
     case REFRESH_PROJECTS_FINISH: {

--- a/src/reducers/projects.reducer.test.js
+++ b/src/reducers/projects.reducer.test.js
@@ -17,17 +17,19 @@ import reducer, {
 describe('Projects Reducer', () => {
   [ADD_PROJECT, IMPORT_EXISTING_PROJECT_FINISH].forEach(ACTION => {
     describe(ACTION, () => {
-      it('adds the project to the state', () => {
+      const testProject = {
+        name: 'testing',
+        guppy: { id: 'best-id' },
+        scripts: {
+          start: 'react-scripts start',
+        },
+      };
+
+      it("adds the project to the state when still onboarding and doesn't select it", () => {
         const action = {
           type: ACTION, // ADD_PROJECT or IMPORT_EXISTING_PROJECT_FINISH
-          project: {
-            name: 'testing',
-            guppy: { id: 'best-id' },
-            scripts: {
-              start: 'react-scripts start',
-            },
-          },
-          isOnboardingCompleted: true,
+          project: testProject,
+          isOnboardingCompleted: false,
         };
         const actualState = reducer(initialState, action);
 
@@ -42,6 +44,28 @@ describe('Projects Reducer', () => {
             },
           },
           selectedId: null,
+        });
+      });
+
+      it('adds the project to the state when onboarding is finished and selects it', () => {
+        const action = {
+          type: ACTION, // ADD_PROJECT or IMPORT_EXISTING_PROJECT_FINISH
+          project: testProject,
+          isOnboardingCompleted: true,
+        };
+        const actualState = reducer(initialState, action);
+
+        const { name, guppy, scripts } = action.project;
+
+        expect(actualState).toEqual({
+          byId: {
+            [guppy.id]: {
+              name,
+              guppy,
+              scripts,
+            },
+          },
+          selectedId: guppy.id,
         });
       });
 
@@ -68,6 +92,7 @@ describe('Projects Reducer', () => {
               start: 'react-scripts start',
             },
           },
+          isOnboardingCompleted: true,
         };
         const actualState = reducer(prevState, action);
 

--- a/src/reducers/projects.reducer.test.js
+++ b/src/reducers/projects.reducer.test.js
@@ -27,7 +27,7 @@ describe('Projects Reducer', () => {
               start: 'react-scripts start',
             },
           },
-          onboardingCompleted: true,
+          isOnboardingCompleted: true,
         };
         const actualState = reducer(initialState, action);
 

--- a/src/reducers/projects.reducer.test.js
+++ b/src/reducers/projects.reducer.test.js
@@ -27,6 +27,7 @@ describe('Projects Reducer', () => {
               start: 'react-scripts start',
             },
           },
+          onboardingCompleted: true,
         };
         const actualState = reducer(initialState, action);
 

--- a/src/sagas/import-project.saga.js
+++ b/src/sagas/import-project.saga.js
@@ -1,6 +1,7 @@
 // @flow
 import electron from 'electron';
 import { call, put, cancel, select, takeEvery } from 'redux-saga/effects';
+
 import {
   importExistingProjectStart,
   importExistingProjectFinish,
@@ -71,6 +72,11 @@ export function* handleImportError(err: Error): Saga<void> {
 }
 
 export function* importProject({ path }: Action): Saga<void> {
+  const store = window.store.getState();
+
+  // Get onboardingStatus to check if sidebar instructions should display
+  const onboardingCompleted = store.onboardingStatus === 'done';
+
   try {
     // Let's load the basic project info for the path specified, if possible.
     const json = yield call(loadPackageJson, path);
@@ -124,7 +130,9 @@ export function* importProject({ path }: Action): Saga<void> {
       packageJsonWithGuppy
     );
 
-    yield put(importExistingProjectFinish(path, writedPackageJson));
+    yield put(
+      importExistingProjectFinish(path, writedPackageJson, onboardingCompleted)
+    );
   } catch (err) {
     yield call(handleImportError, err);
     yield put(importExistingProjectError());

--- a/src/sagas/import-project.saga.js
+++ b/src/sagas/import-project.saga.js
@@ -15,6 +15,7 @@ import {
 } from '../services/read-from-disk.service';
 import { getColorForProject } from '../services/create-project.service';
 import { getInternalProjectById } from '../reducers/projects.reducer';
+import { getOnboardingCompleted } from '../reducers/onboarding-status.reducer';
 
 import type { Action } from 'redux';
 import type { Saga } from 'redux-saga';
@@ -72,11 +73,6 @@ export function* handleImportError(err: Error): Saga<void> {
 }
 
 export function* importProject({ path }: Action): Saga<void> {
-  const store = window.store.getState();
-
-  // Get onboardingStatus to check if sidebar instructions should display
-  const onboardingCompleted = store.onboardingStatus === 'done';
-
   try {
     // Let's load the basic project info for the path specified, if possible.
     const json = yield call(loadPackageJson, path);
@@ -130,8 +126,14 @@ export function* importProject({ path }: Action): Saga<void> {
       packageJsonWithGuppy
     );
 
+    const isOnboardingCompleted = yield select(getOnboardingCompleted);
+
     yield put(
-      importExistingProjectFinish(path, writedPackageJson, onboardingCompleted)
+      importExistingProjectFinish(
+        path,
+        writedPackageJson,
+        isOnboardingCompleted
+      )
     );
   } catch (err) {
     yield call(handleImportError, err);

--- a/src/sagas/import-project.saga.test.js
+++ b/src/sagas/import-project.saga.test.js
@@ -21,6 +21,12 @@ import {
 import { getInternalProjectById } from '../reducers/projects.reducer';
 import { getColorForProject } from '../services/create-project.service';
 
+// Mock window.store.getState()
+const store = {
+  getState: jest.fn(() => ('onboardingStatus': 'done')),
+};
+window.store = store;
+
 describe('import-project saga', () => {
   const { showOpenDialog, showErrorBox } = electron.remote.dialog;
 
@@ -169,6 +175,10 @@ describe('import-project saga', () => {
           createdAt: 1532809641976,
         },
       };
+
+      const getState = window.store.getState();
+      const onboardingCompleted = getState.onboardingStatus === 'done';
+
       const spyOnDate = jest.spyOn(Date, 'now');
       spyOnDate.mockReturnValue(1532809641976);
 
@@ -186,7 +196,13 @@ describe('import-project saga', () => {
         call(writePackageJson, 'path/to/project', jsonWithGuppy)
       );
       expect(saga.next(jsonWithGuppy).value).toEqual(
-        put(importExistingProjectFinish('path/to/project', jsonWithGuppy))
+        put(
+          importExistingProjectFinish(
+            'path/to/project',
+            jsonWithGuppy,
+            onboardingCompleted
+          )
+        )
       );
       expect(saga.next().done).toBe(true);
       spyOnDate.mockRestore();

--- a/src/sagas/import-project.saga.test.js
+++ b/src/sagas/import-project.saga.test.js
@@ -18,14 +18,9 @@ import {
   loadPackageJson,
   writePackageJson,
 } from '../services/read-from-disk.service';
+import { getOnboardingCompleted } from '../reducers/onboarding-status.reducer';
 import { getInternalProjectById } from '../reducers/projects.reducer';
 import { getColorForProject } from '../services/create-project.service';
-
-// Mock window.store.getState()
-const store = {
-  getState: jest.fn(() => ('onboardingStatus': 'done')),
-};
-window.store = store;
 
 describe('import-project saga', () => {
   const { showOpenDialog, showErrorBox } = electron.remote.dialog;
@@ -176,9 +171,6 @@ describe('import-project saga', () => {
         },
       };
 
-      const getState = window.store.getState();
-      const onboardingCompleted = getState.onboardingStatus === 'done';
-
       const spyOnDate = jest.spyOn(Date, 'now');
       spyOnDate.mockReturnValue(1532809641976);
 
@@ -196,13 +188,10 @@ describe('import-project saga', () => {
         call(writePackageJson, 'path/to/project', jsonWithGuppy)
       );
       expect(saga.next(jsonWithGuppy).value).toEqual(
-        put(
-          importExistingProjectFinish(
-            'path/to/project',
-            jsonWithGuppy,
-            onboardingCompleted
-          )
-        )
+        select(getOnboardingCompleted)
+      );
+      expect(saga.next(true).value).toEqual(
+        put(importExistingProjectFinish('path/to/project', jsonWithGuppy, true))
       );
       expect(saga.next().done).toBe(true);
       spyOnDate.mockRestore();


### PR DESCRIPTION
**Summary:**

The Application Menu was bugging out and 'Current Project' menu item was not showing upon selecting project, and only showed after refreshing the app. 

After some tinkering around I figured out that `componentWillReceiveProps()` was causing it to be null on first try, and refreshing was the only way to trigger it to show. So I solved it by switching to `componentDidUpdate()` instead, per [the docs](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops) (seems like they're recommending to not use it anymore) and it seems to be working much better. 

We might want to think about switching other instances of `componentWillReceiveProps()` as well?

Also implemented the onboarding status check per our Gitter discussion. So now the sidebar instructions only show if onboardingStatus is 'introducing-sidebar'. And if 'done' then we just select the project and don't show the instructions again.
