### PR TITLE
Refactor Button -> FillButton & StrokeButton

### DIFF
--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -20,7 +20,7 @@ import Spinner from '../Spinner';
 import ExternalLink from '../ExternalLink';
 import License from '../License';
 import Middot from '../Middot';
-import Button from '../Button';
+import { StrokeButton } from '../Button';
 import CustomHighlight from '../CustomHighlight';
 
 import type { DependencyStatus } from '../../types';
@@ -113,7 +113,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
     }
 
     return (
-      <Button
+      <StrokeButton
         size="small"
         color1={COLORS.green[700]}
         color2={COLORS.lightGreen[500]}
@@ -121,7 +121,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
         onClick={() => addDependency(projectId, hit.name, hit.version)}
       >
         Add To Project
-      </Button>
+      </StrokeButton>
     );
   }
 

--- a/src/components/Button/ButtonBase.js
+++ b/src/components/Button/ButtonBase.js
@@ -4,36 +4,24 @@ import styled from 'styled-components';
 
 import { COLORS } from '../../constants';
 
-import CircularOutline from '../CircularOutline';
-
 type Size = 'xsmall' | 'small' | 'medium' | 'large';
-type Type = 'fill' | 'stroke';
 
 type Props = {
-  type: Type,
   size: Size,
-  color1: string,
-  color2: string,
+  background?: string,
+  hoverBackground?: string,
   textColor?: string,
-  showOutline: boolean,
   noPadding?: boolean,
-  style: { [key: string]: any },
+  activeSplat?: boolean,
   disabled?: boolean,
   children: React$Node,
 };
 
-type State = {
-  isHovered: boolean,
-};
-
-class Button extends Component<Props, State> {
+class ButtonBase extends Component<Props> {
   static defaultProps = {
-    type: 'stroke',
     size: 'medium',
-    color1: COLORS.purple[500],
-    color2: COLORS.violet[500],
-    showOutline: true,
-    style: {},
+    background: COLORS.gray[200],
+    textColor: COLORS.gray[900],
   };
 
   getButtonElem = (size: Size) => {
@@ -52,104 +40,92 @@ class Button extends Component<Props, State> {
 
   render() {
     const {
-      type,
       size,
       children,
-      color1,
-      color2,
+      background,
+      hoverBackground,
       textColor,
-      showOutline,
-      style,
       disabled,
       ...delegated
     } = this.props;
 
     const Elem = this.getButtonElem(size);
 
-    let mutatedStyle = { ...style };
-    if (type === 'fill') {
-      mutatedStyle.color = '#FFF';
-      mutatedStyle.backgroundImage = `
-        linear-gradient(
-          45deg,
-          ${color1},
-          ${color2}
-        )
-      `;
-    }
-
-    if (textColor) {
-      mutatedStyle.color = textColor;
-    }
-
     return (
-      <Elem disabled={disabled} type={type} style={mutatedStyle} {...delegated}>
-        <CircularOutline
-          color1={disabled ? COLORS.gray[400] : color1}
-          color2={disabled ? COLORS.gray[300] : color2}
-          isShown={showOutline}
-          animateChanges={type === 'stroke'}
-        />
-
-        <span style={{ display: 'block' }}>{children}</span>
+      <Elem
+        background={background}
+        hoverBackground={hoverBackground}
+        textColor={textColor}
+        disabled={disabled}
+        {...delegated}
+      >
+        {children}
       </Elem>
     );
   }
 }
 
-const ButtonBase = styled.button`
+const ButtonBaseStyles = styled.button`
   position: relative;
   border: 0;
-  background: transparent;
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  background: ${props => props.background};
+  color: ${props => props.textColor};
   cursor: pointer;
   outline: none;
-  color: ${COLORS.gray[900]};
   white-space: nowrap;
 
+  &:hover {
+    background: ${props => props.hoverBackground};
+  }
+
+  &:disabled {
+    filter: grayscale(100%);
+    opacity: 0.75;
+  }
+
+  /*
+    HACK: We want to double the border-thickness of StrokeButton when active.
+    This feels hacky, but it would also be hacky to manage this state in React.
+  */
   &:not(:disabled):active rect {
     stroke-width: 4;
   }
 
-  &:disabled {
-    background-image: ${props =>
-      props.type === 'fill' &&
-      `linear-gradient(
-      45deg,
-      ${COLORS.gray[400]},
-      ${COLORS.gray[300]}
-    ) !important`};
+  &:not(:disabled):active {
+    transform-origin: center center;
+    transform: ${props => props.activeSplat && 'scale(1.1)'};
   }
 `;
 
-const XSmallButton = styled(ButtonBase)`
+const XSmallButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0px 12px')};
   height: ${props => (props.noPadding ? 'auto' : '22px')};
   border-radius: 15px;
   font-size: 12px;
 `;
 
-const SmallButton = styled(ButtonBase)`
+const SmallButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0px 14px')};
   height: ${props => (props.noPadding ? 'auto' : '30px')};
   border-radius: 17px;
   font-size: 14px;
 `;
 
-const MediumButton = styled(ButtonBase)`
+const MediumButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0px 20px')};
   height: ${props => (props.noPadding ? 'auto' : '38px')};
   border-radius: 19px;
   font-size: 16px;
 `;
 
-const LargeButton = styled(ButtonBase)`
+const LargeButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0 32px')};
   height: ${props => (props.noPadding ? 'auto' : '48px')};
   border-radius: 24px;
   font-size: 24px;
 `;
 
-export default Button;
+export default ButtonBase;

--- a/src/components/Button/ButtonBase.stories.js
+++ b/src/components/Button/ButtonBase.stories.js
@@ -1,0 +1,64 @@
+// @flow
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { decorateAction } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
+
+import Showcase from '../../../.storybook/components/Showcase';
+import { COLORS } from '../../constants';
+import ButtonBase from './ButtonBase';
+
+const targetAction = decorateAction([args => [args[0].target]]);
+
+const SIZES = ['xsmall', 'small', 'medium', 'large'];
+
+storiesOf('Button / Base', module)
+  .add(
+    'default',
+    withInfo()(() => (
+      <ButtonBase onClick={targetAction('clicked')}>Vanilla Button</ButtonBase>
+    ))
+  )
+  .add(
+    'sizes',
+    withInfo()(() =>
+      SIZES.map((size, i) => (
+        <Showcase label={size} key={i}>
+          <ButtonBase onClick={targetAction('button-clicked')} size={size}>
+            Button
+          </ButtonBase>
+        </Showcase>
+      ))
+    )
+  )
+  .add(
+    'Colors',
+    withInfo()(() => (
+      <Fragment>
+        <Showcase label="Solid Colours">
+          <ButtonBase
+            background={COLORS.blue[700]}
+            hoverBackground={COLORS.violet[700]}
+            textColor={COLORS.yellow[500]}
+            onClick={targetAction('button-clicked')}
+          >
+            Colourful!
+          </ButtonBase>
+        </Showcase>
+        <Showcase label="Gradients">
+          <ButtonBase
+            background={`linear-gradient(0deg, ${COLORS.blue[700]}, ${
+              COLORS.violet[500]
+            })`}
+            hoverBackground={`linear-gradient(0deg, ${COLORS.red[700]}, ${
+              COLORS.orange[500]
+            })`}
+            textColor={COLORS.yellow[500]}
+            onClick={targetAction('button-clicked')}
+          >
+            Colourful!
+          </ButtonBase>
+        </Showcase>
+      </Fragment>
+    ))
+  );

--- a/src/components/Button/FillButton.js
+++ b/src/components/Button/FillButton.js
@@ -1,0 +1,55 @@
+// @flow
+import React, { Component } from 'react';
+
+import { COLORS } from '../../constants';
+
+import ButtonBase from './ButtonBase';
+
+type Props = {
+  colors?: Array<string>,
+  hoverColors?: Array<string>,
+  textColor: string,
+  children: React$Node,
+};
+
+const wrapColorsInGradient = colors => {
+  if (!Array.isArray(colors)) {
+    return colors;
+  }
+
+  if (colors.length === 1) {
+    return colors[0];
+  }
+
+  return `linear-gradient(
+    45deg,
+    ${colors.join(',')}
+  )`;
+};
+
+class FillButton extends Component<Props> {
+  static defaultProps = {
+    colors: [COLORS.purple[500], COLORS.violet[500]],
+    textColor: COLORS.white,
+  };
+
+  render() {
+    const { colors, hoverColors, children, ...delegated } = this.props;
+
+    const background = wrapColorsInGradient(colors);
+    const hoverBackground = wrapColorsInGradient(hoverColors) || background;
+
+    return (
+      <ButtonBase
+        activeSplat
+        background={background}
+        hoverBackground={hoverBackground}
+        {...delegated}
+      >
+        {children}
+      </ButtonBase>
+    );
+  }
+}
+
+export default FillButton;

--- a/src/components/Button/FillButton.stories.js
+++ b/src/components/Button/FillButton.stories.js
@@ -5,17 +5,17 @@ import { decorateAction } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 
 import Showcase from '../../../.storybook/components/Showcase';
-import Button from './Button';
+import FillButton from './FillButton';
 
 const targetAction = decorateAction([args => [args[0].target]]);
 
 const SIZES = ['xsmall', 'small', 'medium', 'large'];
 
-storiesOf('Button', module)
+storiesOf('Button / Fill', module)
   .add(
     'default',
     withInfo()(() => (
-      <Button onClick={targetAction('clicked')}>Hello Button</Button>
+      <FillButton onClick={targetAction('clicked')}>FillButton</FillButton>
     ))
   )
   .add(
@@ -23,25 +23,18 @@ storiesOf('Button', module)
     withInfo()(() =>
       SIZES.map((size, i) => (
         <Showcase label={size} key={i}>
-          <Button onClick={targetAction('button-clicked')} size={size}>
-            Button
-          </Button>
+          <FillButton onClick={targetAction('button-clicked')} size={size}>
+            FillButton
+          </FillButton>
         </Showcase>
       ))
     )
   )
   .add(
-    'types (visual styles)',
+    'disabled',
     withInfo()(() => (
-      <React.Fragment>
-        <Showcase label="Default (stroke)">
-          <Button onClick={targetAction('button-clicked')}>Button</Button>
-        </Showcase>
-        <Showcase label="Fill">
-          <Button onClick={targetAction('button-clicked')} type="fill">
-            Button
-          </Button>
-        </Showcase>
-      </React.Fragment>
+      <FillButton disabled onClick={targetAction('clicked')}>
+        FillButton
+      </FillButton>
     ))
   );

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -1,0 +1,41 @@
+// @flow
+import React, { Component } from 'react';
+
+import { COLORS } from '../../constants';
+
+import CircularOutline from '../CircularOutline';
+import ButtonBase from './ButtonBase';
+
+type Props = {
+  color1: string,
+  color2: string,
+  showStroke: boolean,
+  children: React$Node,
+};
+
+class StrokeButton extends Component<Props> {
+  static defaultProps = {
+    color1: COLORS.purple[500],
+    color2: COLORS.violet[500],
+    showStroke: true,
+  };
+
+  render() {
+    const { color1, color2, showStroke, children, ...delegated } = this.props;
+
+    return (
+      <ButtonBase background="transparent" {...delegated}>
+        <CircularOutline
+          isShown={showStroke}
+          animateChanges
+          color1={color1}
+          color2={color2}
+        />
+
+        <span style={{ display: 'block' }}>{children}</span>
+      </ButtonBase>
+    );
+  }
+}
+
+export default StrokeButton;

--- a/src/components/Button/StrokeButton.stories.js
+++ b/src/components/Button/StrokeButton.stories.js
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { decorateAction } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
+
+import Showcase from '../../../.storybook/components/Showcase';
+import StrokeButton from './StrokeButton';
+
+const targetAction = decorateAction([args => [args[0].target]]);
+
+const SIZES = ['xsmall', 'small', 'medium', 'large'];
+
+storiesOf('Button / Stroke', module)
+  .add(
+    'default',
+    withInfo()(() => (
+      <StrokeButton onClick={targetAction('clicked')}>
+        StrokeButton
+      </StrokeButton>
+    ))
+  )
+  .add(
+    'sizes',
+    withInfo()(() =>
+      SIZES.map((size, i) => (
+        <Showcase label={size} key={i}>
+          <StrokeButton onClick={targetAction('button-clicked')} size={size}>
+            StrokeButton
+          </StrokeButton>
+        </Showcase>
+      ))
+    )
+  )
+  .add(
+    'disabled',
+    withInfo()(() => (
+      <StrokeButton disabled onClick={targetAction('clicked')}>
+        StrokeButton
+      </StrokeButton>
+    ))
+  );

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,1 +1,2 @@
-export { default } from './Button';
+export { default as StrokeButton } from './StrokeButton';
+export { default as FillButton } from './FillButton';

--- a/src/components/ButtonWithIcon/ButtonWithIcon.js
+++ b/src/components/ButtonWithIcon/ButtonWithIcon.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import Button from '../Button';
+import { StrokeButton } from '../Button';
 
 const ButtonWithIcon = ({ icon, children, ...delegated }) => (
   // TODO: Support other sizes
-  <Button noPadding {...delegated}>
+  <StrokeButton noPadding {...delegated}>
     <InnerWrapper>
       <IconWrapper>{icon}</IconWrapper>
       {children}
     </InnerWrapper>
-  </Button>
+  </StrokeButton>
 );
 
 const InnerWrapper = styled.div`

--- a/src/components/CreateNewProjectWizard/SubmitButton.js
+++ b/src/components/CreateNewProjectWizard/SubmitButton.js
@@ -7,7 +7,7 @@ import { chevronRight } from 'react-icons-kit/feather/chevronRight';
 
 import { COLORS } from '../../constants';
 
-import Button from '../Button';
+import { FillButton } from '../Button';
 import Spinner from '../Spinner';
 
 type Props = {
@@ -30,13 +30,14 @@ const SubmitButton = ({
       : 'Next';
 
   return (
-    <Button
+    <FillButton
       disabled={isDisabled || hasBeenSubmitted}
-      type="fill"
       size="large"
-      color1={readyToBeSubmitted ? COLORS.green[700] : COLORS.blue[700]}
-      color2={readyToBeSubmitted ? COLORS.lightGreen[500] : COLORS.blue[500]}
-      style={{ color: COLORS.pink[500], width: 200 }}
+      colors={[
+        readyToBeSubmitted ? COLORS.green[700] : COLORS.blue[700],
+        readyToBeSubmitted ? COLORS.lightGreen[500] : COLORS.blue[500],
+      ]}
+      style={{ width: 200 }}
       onClick={onSubmit}
     >
       <ChildWrapper>{buttonText}</ChildWrapper>
@@ -51,7 +52,7 @@ const SubmitButton = ({
           />
         )}
       </SubmitButtonIconWrapper>
-    </Button>
+    </FillButton>
   );
 };
 

--- a/src/components/DeleteDependencyButton/DeleteDependencyButton.js
+++ b/src/components/DeleteDependencyButton/DeleteDependencyButton.js
@@ -6,7 +6,7 @@ import { remote } from 'electron';
 import * as actions from '../../actions';
 import { COLORS } from '../../constants';
 
-import Button from '../Button';
+import { FillButton } from '../Button';
 import Spinner from '../Spinner';
 import PixelShifter from '../PixelShifter';
 
@@ -66,11 +66,9 @@ class DeleteDependencyButton extends PureComponent<Props> {
     const { dependencyStatus } = this.props;
 
     return (
-      <Button
+      <FillButton
         size="small"
-        type="fill"
-        color1={COLORS.pink[300]}
-        color2={COLORS.red[500]}
+        colors={[COLORS.pink[300], COLORS.red[500]]}
         onClick={this.handleClick}
       >
         {dependencyStatus === 'deleting' ? (
@@ -83,7 +81,7 @@ class DeleteDependencyButton extends PureComponent<Props> {
         ) : (
           DEPENDENCY_DELETE_COPY[dependencyStatus]
         )}
-      </Button>
+      </FillButton>
     );
   }
 }

--- a/src/components/DependencyUpdateRow/DependencyUpdateRow.js
+++ b/src/components/DependencyUpdateRow/DependencyUpdateRow.js
@@ -8,7 +8,7 @@ import { check } from 'react-icons-kit/feather/check';
 import * as actions from '../../actions';
 import { COLORS } from '../../constants';
 
-import Button from '../Button';
+import { FillButton } from '../Button';
 import Label from '../Label';
 import Spinner from '../Spinner';
 import Spacer from '../Spacer';
@@ -57,18 +57,16 @@ class DependencyUpdateRow extends Component<Props> {
         Up-to-date
       </UpToDate>
     ) : (
-      <Button
+      <FillButton
         size="small"
-        type="fill"
-        color1={COLORS.green[700]}
-        color2={COLORS.lightGreen[500]}
+        colors={[COLORS.green[700], COLORS.lightGreen[500]]}
         style={{ width: 80 }}
         onClick={() =>
           updateDependency(projectId, dependency.name, latestVersion)
         }
       >
         {isUpdating ? <Spinner size={16} color={COLORS.white} /> : 'Update'}
-      </Button>
+      </FillButton>
     );
   }
 

--- a/src/components/HoverableOutlineButton/HoverableOutlineButton.js
+++ b/src/components/HoverableOutlineButton/HoverableOutlineButton.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import Button from '../Button';
+import { StrokeButton } from '../Button';
 
 type Props = {
   color1: string,
@@ -33,16 +33,16 @@ class HoverableOutlineButton extends Component<Props, State> {
     const { isHovered } = this.state;
 
     return (
-      <Button
+      <StrokeButton
         color1={color1}
         color2={color2}
-        showOutline={isHovered}
+        showStroke={isHovered}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         {...delegated}
       >
         {children}
-      </Button>
+      </StrokeButton>
     );
   }
 }

--- a/src/components/IntroScreen/IntroScreen.js
+++ b/src/components/IntroScreen/IntroScreen.js
@@ -6,7 +6,7 @@ import * as actions from '../../actions';
 import { COLORS } from '../../constants';
 import { getOnboardingStatus } from '../../reducers/onboarding-status.reducer';
 
-import Button from '../Button';
+import { StrokeButton } from '../Button';
 import ImportProjectButton from '../ImportProjectButton';
 import Spacer from '../Spacer';
 import Logo from '../Logo';
@@ -30,9 +30,9 @@ class IntroScreen extends Component<Props> {
           </Header>
 
           <Actions>
-            <Button size="large" onClick={() => createNewProjectStart()}>
+            <StrokeButton size="large" onClick={() => createNewProjectStart()}>
               Create a new web application
-            </Button>
+            </StrokeButton>
             <Spacer size={40} />
             <div>
               Or,{' '}

--- a/src/components/ProgressBar/ProgressBar.stories.js
+++ b/src/components/ProgressBar/ProgressBar.stories.js
@@ -6,7 +6,7 @@ import { withInfo } from '@storybook/addon-info';
 import { COLORS } from '../../constants';
 
 import Showcase from '../../../.storybook/components/Showcase';
-import Button from '../Button';
+import { StrokeButton } from '../Button';
 import ProgressBar from './ProgressBar';
 
 type Props = { children: (data: any) => React$Node };
@@ -36,9 +36,9 @@ class ProgressManager extends Component<Props, State> {
           updateProgress: this.updateProgress,
         })}
         <br />
-        <Button size="small" onClick={this.updateProgress}>
+        <StrokeButton size="small" onClick={this.updateProgress}>
           Generate new value
-        </Button>
+        </StrokeButton>
       </Fragment>
     );
   }

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -11,7 +11,7 @@ import MainContentWrapper from '../MainContentWrapper';
 import Heading from '../Heading';
 import PixelShifter from '../PixelShifter';
 import Spacer from '../Spacer';
-import Button from '../Button';
+import { FillButton } from '../Button';
 import DevelopmentServerPane from '../DevelopmentServerPane';
 import TaskRunnerPane from '../TaskRunnerPane';
 import DependencyManagementPane from '../DependencyManagementPane';
@@ -77,27 +77,25 @@ class ProjectPage extends Component<Props> {
           </PixelShifter>
 
           <ProjectActionBar>
-            <Button
-              type="fill"
-              color1={COLORS.gray[200]}
-              color2={COLORS.gray[200]}
+            <FillButton
+              colors={COLORS.gray[200]}
+              hoverColors={COLORS.gray[300]}
               textColor={COLORS.gray[900]}
               size="small"
               onClick={this.openFolder}
             >
               {getCopyForOpeningFolder()}
-            </Button>
+            </FillButton>
             <Spacer size={15} />
-            <Button
-              type="fill"
-              color1={COLORS.gray[200]}
-              color2={COLORS.gray[200]}
+            <FillButton
+              colors={COLORS.gray[200]}
+              hoverColors={COLORS.gray[300]}
               textColor={COLORS.gray[900]}
               size="small"
               onClick={this.openIDE}
             >
               Open in Editor
-            </Button>
+            </FillButton>
           </ProjectActionBar>
 
           <Spacer size={30} />

--- a/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
+++ b/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
@@ -11,7 +11,7 @@ import { capitalize } from '../../utils';
 
 import Card from '../Card';
 import Spinner from '../Spinner';
-import Button from '../Button';
+import { StrokeButton } from '../Button';
 import EjectButton from '../EjectButton';
 import Toggle from '../Toggle';
 
@@ -52,9 +52,9 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
         </StatusColumn>
 
         <LinkColumn>
-          <Button size="small" onClick={() => onViewDetails(id)}>
+          <StrokeButton size="small" onClick={() => onViewDetails(id)}>
             View Details
-          </Button>
+          </StrokeButton>
         </LinkColumn>
 
         <ActionsColumn>

--- a/src/components/TerminalOutput/TerminalOutput.js
+++ b/src/components/TerminalOutput/TerminalOutput.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import * as actions from '../../actions';
 import { COLORS } from '../../constants';
 
-import Button from '../Button';
+import { FillButton } from '../Button';
 import Heading from '../Heading';
 import PixelShifter from '../PixelShifter';
 
@@ -77,16 +77,13 @@ class TerminalOutput extends PureComponent<Props> {
               offset.
             `}
           >
-            <Button
+            <FillButton
               size="xsmall"
-              type="fill"
-              color1={COLORS.red[700]}
-              color2={COLORS.red[500]}
-              textColor={COLORS.white}
+              colors={[COLORS.red[700], COLORS.red[500]]}
               onClick={this.handleClear}
             >
               Clear
-            </Button>
+            </FillButton>
           </PixelShifter>
         </Header>
         <Wrapper


### PR DESCRIPTION
**Summary:**
Our `Button` component was trying to do too many things.

We ran into this when adding "Open in X" buttons in #205 - we wanted a simple hover state, but there was no simple way to add it, because we'd have to figure out what that should mean for stroke buttons, even though we only needed it on a fill button.

This PR creates two new Button components, `StrokeButton` and `FillButton`. They both use the same low-level primitive `ButtonBase` component, but offer their own props and styles.

For the most part, styles are unchanged, with two exceptions:
- I added a "splat" effect to FillButton when it's active. Before we were simulating this with a border, but now it feels better.
- We were able to add the hover effect to "Open in X" buttons!


**Screenshots/GIFs:**
![button](https://user-images.githubusercontent.com/6692932/44996800-f1f2f280-af77-11e8-8a37-d191d8ff2836.gif)

![buttons2](https://user-images.githubusercontent.com/6692932/44996825-2070cd80-af78-11e8-9186-305a6210776a.gif)


