### PR TITLE
Unify pattern for queue starter actions

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -224,13 +224,6 @@ export const installDependenciesStart = (
   dependencies,
 });
 
-export const installDependencyStart = (
-  projectId: string,
-  name: string,
-  version: string,
-  updating?: boolean
-) => installDependenciesStart(projectId, [{ name, version, updating }]);
-
 export const installDependenciesError = (
   projectId: string,
   dependencies: Array<QueuedDependency>
@@ -257,9 +250,6 @@ export const uninstallDependenciesStart = (
   projectId,
   dependencies,
 });
-
-export const uninstallDependencyStart = (projectId: string, name: string) =>
-  uninstallDependenciesStart(projectId, [{ name }]);
 
 export const uninstallDependenciesError = (
   projectId: string,

--- a/src/sagas/dependency.saga.js
+++ b/src/sagas/dependency.saga.js
@@ -20,11 +20,9 @@ import {
   START_NEXT_ACTION_IN_QUEUE,
   queueDependencyInstall,
   queueDependencyUninstall,
-  installDependencyStart,
   installDependenciesStart,
   installDependenciesError,
   installDependenciesFinish,
-  uninstallDependencyStart,
   uninstallDependenciesStart,
   uninstallDependenciesError,
   uninstallDependenciesFinish,
@@ -45,7 +43,7 @@ export function* handleAddDependency({
 
   // if there are no other ongoing operations, begin install
   if (!queuedAction) {
-    yield put(installDependencyStart(projectId, dependencyName, version));
+    yield put(startNextActionInQueue(projectId));
   }
 }
 
@@ -61,9 +59,7 @@ export function* handleUpdateDependency({
   );
 
   if (!queuedAction) {
-    yield put(
-      installDependencyStart(projectId, dependencyName, latestVersion, true)
-    );
+    yield put(startNextActionInQueue(projectId));
   }
 }
 
@@ -76,7 +72,7 @@ export function* handleDeleteDependency({
   yield put(queueDependencyUninstall(projectId, dependencyName));
 
   if (!queuedAction) {
-    yield put(uninstallDependencyStart(projectId, dependencyName));
+    yield put(startNextActionInQueue(projectId));
   }
 }
 

--- a/src/sagas/dependency.saga.test.js
+++ b/src/sagas/dependency.saga.test.js
@@ -28,11 +28,9 @@ import {
   START_NEXT_ACTION_IN_QUEUE,
   queueDependencyInstall,
   queueDependencyUninstall,
-  installDependencyStart,
   installDependenciesStart,
   installDependenciesError,
   installDependenciesFinish,
-  uninstallDependencyStart,
   uninstallDependenciesStart,
   uninstallDependenciesError,
   uninstallDependenciesFinish,
@@ -70,11 +68,7 @@ describe('Dependency sagas', () => {
           queueDependencyInstall(projectId, dependency.name, dependency.version)
         )
       );
-      expect(saga.next().value).toEqual(
-        put(
-          installDependencyStart(projectId, dependency.name, dependency.version)
-        )
-      );
+      expect(saga.next().value).toEqual(put(startNextActionInQueue(projectId)));
       expect(saga.next().done).toBe(true);
     });
 
@@ -130,16 +124,7 @@ describe('Dependency sagas', () => {
           )
         )
       );
-      expect(saga.next().value).toEqual(
-        put(
-          installDependencyStart(
-            projectId,
-            dependency.name,
-            dependency.version,
-            dependency.updating
-          )
-        )
-      );
+      expect(saga.next().value).toEqual(put(startNextActionInQueue(projectId)));
       expect(saga.next().done).toBe(true);
     });
 
@@ -191,9 +176,7 @@ describe('Dependency sagas', () => {
       expect(saga.next(queuedAction).value).toEqual(
         put(queueDependencyUninstall(projectId, dependency.name))
       );
-      expect(saga.next().value).toEqual(
-        put(uninstallDependencyStart(projectId, dependency.name))
-      );
+      expect(saga.next().value).toEqual(put(startNextActionInQueue(projectId)));
       expect(saga.next().done).toBe(true);
     });
 


### PR DESCRIPTION
Just a quick PR to unify the design pattern used for saga actions that start running a queue. I originally had separate action creators for each possible way to start a queue (`installDependencyStart`, `uninstallDependencyStart`), but I realized that it was functionally identical to just calling `startNextActionInQueue` and was less clear. This pattern is more maintainable, precise, and easy to adapt for future uses of the queue (e.g. - #120).