### PR TITLE
Quick fix for ProjectType onboarding buttons

### DIFF
--- a/src/components/Button/StrokeButton.stories.js
+++ b/src/components/Button/StrokeButton.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { decorateAction } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
@@ -10,6 +10,22 @@ import StrokeButton from './StrokeButton';
 const targetAction = decorateAction([args => [args[0].target]]);
 
 const SIZES = ['xsmall', 'small', 'medium', 'large'];
+
+class ToggleableButton extends Component<any, any> {
+  state = {
+    isToggled: true,
+  };
+
+  render() {
+    return (
+      <StrokeButton
+        {...this.props}
+        showStroke={this.state.isToggled}
+        onClick={() => this.setState({ isToggled: !this.state.isToggled })}
+      />
+    );
+  }
+}
 
 storiesOf('Button / Stroke', module)
   .add(
@@ -39,4 +55,8 @@ storiesOf('Button / Stroke', module)
         StrokeButton
       </StrokeButton>
     ))
+  )
+  .add(
+    'toggleable',
+    withInfo()(() => <ToggleableButton>I can be toggled!</ToggleableButton>)
   );

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -88,7 +88,7 @@ class MainPane extends PureComponent<Props> {
                   >
                     <ProjectTypeTogglesWrapper>
                       <ButtonWithIcon
-                        showOutline={projectType === 'create-react-app'}
+                        showStroke={projectType === 'create-react-app'}
                         icon={<ReactIcon src={reactIconSrc} />}
                         onClick={() =>
                           this.updateProjectType('create-react-app')
@@ -98,7 +98,7 @@ class MainPane extends PureComponent<Props> {
                       </ButtonWithIcon>
                       <Spacer inline size={10} />
                       <ButtonWithIcon
-                        showOutline={projectType === 'gatsby'}
+                        showStroke={projectType === 'gatsby'}
                         icon={<GatsbyIcon src={gatsbyIconSrc} />}
                         onClick={() => this.updateProjectType('gatsby')}
                       >


### PR DESCRIPTION
I realized that my recent refactor in #209 broke the ProjectType outlines in the create-new-project wizard (they were always outlined, even when not selected).

Quick fix, just a matter of renaming the prop. Also added a story for strokeButton outlines.