### PR TITLE
Tweak visuals of project-path field

### DIFF
--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -2,19 +2,19 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Transition from 'react-transition-group/Transition';
-import slug from 'slug';
 
 import * as actions from '../../actions';
 import { getById } from '../../reducers/projects.reducer';
 import { getProjectHomePath } from '../../reducers/paths.reducer';
 import { getOnboardingCompleted } from '../../reducers/onboarding-status.reducer';
+import { getProjectId } from '../../services/create-project.service';
 
 import TwoPaneModal from '../TwoPaneModal';
+import Debounced from '../Debounced';
 
 import MainPane from './MainPane';
 import SummaryPane from './SummaryPane';
 import BuildPane from './BuildPane';
-import Debounced from '../Debounced';
 
 import type { Field, Status, Step } from './types';
 
@@ -74,7 +74,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
 
   verifyProjectNameUniqueness = (name: string) => {
     // Check to see if this name is already taken
-    const id = slug(name).toLowerCase();
+    const id = getProjectId(name);
     const isAlreadyTaken = !!this.props.projects[id];
 
     if (isAlreadyTaken) {

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -78,7 +78,7 @@ class MainPane extends PureComponent<Props> {
                 handleSubmit={handleSubmit}
                 isProjectNameTaken={isProjectNameTaken}
               />
-              <ProjectPath />
+              <ProjectPath projectName={projectName} />
 
               {currentStepIndex > 0 && (
                 <FadeIn>

--- a/src/components/CreateNewProjectWizard/ProjectPath.js
+++ b/src/components/CreateNewProjectWizard/ProjectPath.js
@@ -59,8 +59,6 @@ class ProjectPath extends PureComponent<Props> {
       displayedProjectPath = `${displayedProjectPath.slice(0, CLAMP_AT - 1)}…`;
     }
 
-    console.log({ displayedProjectPath });
-
     return (
       <MainText>
         Project will be created in{' '}

--- a/src/components/CreateNewProjectWizard/ProjectPath.js
+++ b/src/components/CreateNewProjectWizard/ProjectPath.js
@@ -1,22 +1,27 @@
 // @flow
+import path from 'path';
+import { remote } from 'electron';
 import React, { PureComponent } from 'react';
-import styled from 'styled-components';
 import { connect } from 'react-redux';
+import { Tooltip } from 'react-tippy';
+import styled from 'styled-components';
+
 import { changeProjectHomePath } from '../../actions';
 import { getProjectHomePath } from '../../reducers/paths.reducer';
-import TextButton from '../TextButton';
-import { Tooltip } from 'react-tippy';
+import { getProjectId } from '../../services/create-project.service';
 import { COLORS } from '../../constants';
-const { dialog } = window.require('electron').remote;
+
+import TextButton from '../TextButton';
 
 type Props = {
-  defaultProjectHome: string,
+  projectHome: string,
+  projectName: string,
   changeProjectHomePath: (path: string) => void,
 };
 
 class ProjectPath extends PureComponent<Props> {
   updatePath = () => {
-    dialog.showOpenDialog(
+    remote.dialog.showOpenDialog(
       {
         message: 'Select the directory of Project',
         properties: ['openDirectory'],
@@ -29,23 +34,40 @@ class ProjectPath extends PureComponent<Props> {
         }
 
         // Only a single path should be selected
-        const [path] = paths;
-        this.props.changeProjectHomePath(path);
+        const [firstPath] = paths;
+        this.props.changeProjectHomePath(firstPath);
       }
     );
   };
 
   render() {
-    const { defaultProjectHome } = this.props;
+    const { projectHome, projectName } = this.props;
+
+    const projectId = getProjectId(projectName);
+
+    // Join the projectHome with the prospective project ID
+    // Hide the leading forward-slash, on Mac/Linux
+    const fullProjectPath = path
+      .join(projectHome, projectId)
+      .replace(/^\//, '');
+
+    // Using CSS text-overflow is proving challenging, so we'll just crop it
+    // with JS.
+    const CLAMP_AT = 29;
+    let displayedProjectPath = fullProjectPath;
+    if (displayedProjectPath.length > CLAMP_AT) {
+      displayedProjectPath = `${displayedProjectPath.slice(0, CLAMP_AT - 1)}…`;
+    }
+
+    console.log({ displayedProjectPath });
+
     return (
       <MainText>
-        created in
-        <Tooltip title={defaultProjectHome} position="bottom">
-          <TextButton onClick={() => this.updatePath()}>
-            {defaultProjectHome.length > 30
-              ? `${defaultProjectHome.slice(0, 30)}...`
-              : defaultProjectHome}
-          </TextButton>
+        Project will be created in{' '}
+        <Tooltip title={fullProjectPath} position="bottom">
+          <DirectoryButton onClick={() => this.updatePath()}>
+            {displayedProjectPath}
+          </DirectoryButton>
         </Tooltip>
       </MainText>
     );
@@ -54,14 +76,21 @@ class ProjectPath extends PureComponent<Props> {
 
 const MainText = styled.div`
   text-align: left;
-  margin: -25px 0 30px 5px;
-  font-size: 18px;
-  color: ${COLORS.gray['500']};
+  margin: -20px 0 30px 5px;
+  font-size: 15px;
+  color: ${COLORS.gray[400]};
+`;
+
+const DirectoryButton = styled(TextButton)`
+  font-family: 'Fira Mono';
+  font-size: 12px;
+  color: ${COLORS.gray[600]};
+  text-decoration: none;
 `;
 
 const mapStateToProps = state => {
   return {
-    defaultProjectHome: getProjectHomePath(state.paths),
+    projectHome: getProjectHomePath(state.paths),
   };
 };
 

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -60,7 +60,7 @@ export default (
 
   onStatusUpdate('Created parent directory');
 
-  const id = slug(projectName).toLowerCase();
+  const id = getProjectId(projectName);
 
   // For Windows Support
   // To support cross platform with slashes and escapes
@@ -123,6 +123,14 @@ export default (
     );
   });
 };
+
+//
+//
+// Helpers
+//
+
+export const getProjectId = (projectName: string) =>
+  slug(projectName).toLowerCase();
 
 // Exported so that getColorForProject can be tested
 export const possibleProjectColors = [

--- a/src/store/migrations.js
+++ b/src/store/migrations.js
@@ -61,15 +61,18 @@ export function migrateToSupportProjectHomePath(state: any) {
     return state;
   }
 
-  state.paths = {
-    homePath:
-      process.env.NODE_ENV === 'development'
-        ? path.join(homedir, 'guppy-projects-dev')
-        : path.join(homedir, 'guppy-projects'),
-    byId: state.paths || {},
+  const nextState = {
+    ...state,
+    paths: {
+      homePath:
+        process.env.NODE_ENV === 'development'
+          ? path.join(homedir, 'guppy-projects-dev')
+          : path.join(homedir, 'guppy-projects'),
+      byId: state.paths || {},
+    },
   };
 
-  return state;
+  return nextState;
 }
 
 export default function handleMigrations(engine: any) {

--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -17,8 +17,6 @@ jest.mock('path', () => ({
   join: () => 'test/guppy-projects',
 }));
 
-const ENGINE_KEY = 'test-key';
-
 describe('Redux migrations', () => {
   describe('Version 0 -> Version 1', () => {
     it('does nothing with no initial state to work with', () => {


### PR DESCRIPTION
In #70, @Kermit-Xuan  added a new "project path" field (and a bunch of associated work to tackle the redux side of things). The code looks great, but I wanted to make a couple visual tweaks.

Before: 
<img width="1077" alt="screen shot 2018-09-06 at 7 44 11 am" src="https://user-images.githubusercontent.com/6692932/45155345-affcc300-b1a8-11e8-986f-21ad74be2bfe.png">


After:
<img width="1076" alt="screen shot 2018-09-06 at 7 46 05 am" src="https://user-images.githubusercontent.com/6692932/45155425-f3efc800-b1a8-11e8-92eb-0a6b60528058.png">


A GIF of the new showing-ID behaviour:
![new](https://user-images.githubusercontent.com/6692932/45155348-b1c68680-b1a8-11e8-9c57-589c75eb8c8f.gif)
