### PR TITLE
Fix migration test on Windows

### DIFF
--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -13,6 +13,10 @@ jest.mock('../services/platform.service', () => ({
   windowsHomeDir: 'test',
 }));
 
+jest.mock('path', () => ({
+  join: () => 'test/guppy-projects',
+}));
+
 const ENGINE_KEY = 'test-key';
 
 describe('Redux migrations', () => {


### PR DESCRIPTION
**Related Issue / PR**
#70 
<!--
Please provide the related issue #. Note that in most cases, you should only be opening a pull request that implements a solution discussed in an issue. See our contribution guidelines for more info
-->

**Summary:**
During my work on codecov CI I noticed that `migrations.test` failed if I run `yarn test` on Windows.
`Path.join` returns a backslash on Windows. That's why I added a mock to it so it's returning the expected path.