### PR TITLE
Whimsy install - Add to build pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "redux-storage-decorator-migrate": "1.1.0",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
+    "resize-observer-polyfill": "1.5.0",
     "resolve": "1.6.0",
     "sass-loader": "7.0.0",
     "slug": "0.9.1",

--- a/src/components/AvailableWidth/AvailableWidth.js
+++ b/src/components/AvailableWidth/AvailableWidth.js
@@ -1,0 +1,81 @@
+/**
+ * Utility component that reports on the available width of the parent
+ * container. Helpful when you absolutely need to provide a pixel value for
+ * something that lives within a container without one.
+ */
+// @flow
+
+import React, { Component } from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+
+type Props = {
+  children: (width: number) => React$Node,
+};
+
+type State = {
+  width?: number,
+};
+
+class AvailableWidth extends Component<Props, State> {
+  state = {};
+
+  containerElem: ?HTMLElement;
+  observer: ResizeObserver;
+
+  componentDidMount() {
+    const { containerElem } = this;
+
+    // We ought to always have the element, but Flow doesn't believe me.
+    if (!containerElem) {
+      return;
+    }
+
+    // Set the width based on the DOM size on-mount.
+    // This is necessary because the 'autofiring' behaviour of ResizeObserver
+    // appears to be inconsistent on mobile.
+    const { width } = containerElem.getBoundingClientRect();
+    this.setState({ width });
+
+    // We want to be notified of any changes to the size of this element.
+    // Enter 'ResizeObserver'!
+    // Using a polyfill atm since it's only in Chrome 65+. Polyfill's only
+    // 2.4kb though, so I don't feel the need to import() it.
+    // Also, this will also report on mount, which'll set the initial value.
+    this.observer = new ResizeObserver(([entry]) => {
+      const observedWidth = entry.contentRect.width;
+
+      // This observer fires on mount, even though the size hasn't changed.
+      // Ignore this case.
+      if (observedWidth === this.state.width) {
+        return;
+      }
+
+      this.setState({ width: observedWidth });
+    });
+
+    this.observer.observe(containerElem);
+  }
+
+  componentWillUnmount() {
+    this.observer.disconnect();
+  }
+
+  render() {
+    const { width } = this.state;
+    const { children } = this.props;
+
+    return (
+      <div ref={elem => (this.containerElem = elem)}>
+        {/*
+          For the very first render, `width` will be undefined; this data is
+          only collected _after_ mount. So, a frame needs to pass with the
+          container being empty. Immediately after we collect the width and
+          re-render, invoking the children function.
+        */}
+        {width !== undefined && children(width)}
+      </div>
+    );
+  }
+}
+
+export default AvailableWidth;

--- a/src/components/AvailableWidth/index.js
+++ b/src/components/AvailableWidth/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvailableWidth';

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -165,13 +165,15 @@ class BuildPane extends PureComponent<Props, State> {
           WhimsicalInstaller and the height of Spacer can be determined
           dynamically.
         */}
-        {showWhimsyInstaller ? (
-          <FadeIn duration={850}>
-            <WhimsicalInstaller width={416} />
-          </FadeIn>
-        ) : (
-          <Spacer size={208} />
-        )}
+        <WhimsicalWrapper>
+          {showWhimsyInstaller ? (
+            <FadeIn duration={850}>
+              <WhimsicalInstaller width={416} />
+            </FadeIn>
+          ) : (
+            <Spacer size={208} />
+          )}
+        </WhimsicalWrapper>
 
         <Title>Building Project...</Title>
 
@@ -242,6 +244,12 @@ const Title = styled.h1`
   margin-top: -30px;
   font-size: 36px;
   text-align: center;
+`;
+
+const WhimsicalWrapper = styled.div`
+  position: relative;
+  /* Make sure it sits below the "Finished" overlay, when completed */
+  z-index: 1;
 `;
 
 const Finished = styled.div`

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -9,6 +9,7 @@ import createProject from '../../services/create-project.service';
 
 import ProgressBar from '../ProgressBar';
 import Spacer from '../Spacer';
+import FadeIn from '../FadeIn';
 import WhimsicalInstaller from '../WhimsicalInstaller/WhimsicalInstaller';
 import BuildStepProgress from './BuildStepProgress';
 
@@ -41,13 +42,15 @@ type Props = {
 type State = {
   currentBuildStep: BuildStep,
   progress: number,
+  showWhimsyInstaller: boolean,
 };
 
 class BuildPane extends PureComponent<Props, State> {
+  timeoutId: ?number;
   state = {
     currentBuildStep: BUILD_STEPS[0],
-    completed: false,
     progress: 0,
+    showWhimsyInstaller: false,
   };
 
   componentDidMount() {
@@ -57,7 +60,17 @@ class BuildPane extends PureComponent<Props, State> {
       this.handleError,
       this.handleComplete
     );
+
+    this.timeoutId = window.setTimeout(this.toggleWhimsyInstaller, 1000);
   }
+
+  componentWillUnmount() {
+    window.clearTimeout(this.timeoutId);
+  }
+
+  toggleWhimsyInstaller = () => {
+    this.setState({ showWhimsyInstaller: !this.state.showWhimsyInstaller });
+  };
 
   handleStatusUpdate = (output: any) => {
     // HACK: So, I need some way of translating the raw output from CRA
@@ -119,7 +132,6 @@ class BuildPane extends PureComponent<Props, State> {
   };
 
   handleComplete = (project: Project) => {
-    return;
     this.setState({ progress: 1 });
 
     window.setTimeout(() => {
@@ -128,7 +140,7 @@ class BuildPane extends PureComponent<Props, State> {
   };
 
   render() {
-    const { currentBuildStep, progress } = this.state;
+    const { currentBuildStep, progress, showWhimsyInstaller } = this.state;
 
     return (
       <Wrapper>
@@ -148,9 +160,20 @@ class BuildPane extends PureComponent<Props, State> {
           />
         </ProgressBarWrapper>
 
-        <Title>Building Project...</Title>
+        {/*
+          TODO: Add an AvailableSpace helper so that the width of
+          WhimsicalInstaller and the height of Spacer can be determined
+          dynamically.
+        */}
+        {showWhimsyInstaller ? (
+          <FadeIn duration={850}>
+            <WhimsicalInstaller width={416} />
+          </FadeIn>
+        ) : (
+          <Spacer size={208} />
+        )}
 
-        <WhimsicalInstaller width={420} />
+        <Title>Building Project...</Title>
 
         <BuildSteps>
           {BUILD_STEP_KEYS.map(stepKey => {
@@ -215,8 +238,8 @@ const BuildSteps = styled.div`
 `;
 
 const Title = styled.h1`
-  padding: 40px;
-  padding-bottom: 0;
+  padding: 0 40px;
+  margin-top: -30px;
   font-size: 36px;
   text-align: center;
 `;

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -9,15 +9,13 @@ import createProject from '../../services/create-project.service';
 
 import ProgressBar from '../ProgressBar';
 import Spacer from '../Spacer';
+import WhimsicalInstaller from '../WhimsicalInstaller/WhimsicalInstaller';
 import BuildStepProgress from './BuildStepProgress';
 
 import type { BuildStep } from './types';
 import type { SubmittedProject, Project } from '../../types';
 
 const BUILD_STEPS = {
-  creatingParentDirectory: {
-    copy: 'Creating parent directory',
-  },
   installingCliTool: {
     copy: 'Installing build tool',
   },
@@ -68,14 +66,9 @@ class BuildPane extends PureComponent<Props, State> {
     // but I don't have any better ideas.
     const message = output.toString();
 
-    if (message.match(/Created parent directory/i)) {
+    if (message.match(/Installing packages/i)) {
       this.setState({
-        currentBuildStep: BUILD_STEP_KEYS[1],
-        progress: 0.1,
-      });
-    } else if (message.match(/Installing packages/i)) {
-      this.setState({
-        currentBuildStep: BUILD_STEP_KEYS[3],
+        currentBuildStep: BUILD_STEP_KEYS[2],
         progress: 0.4,
       });
       // eslint-disable-next-line no-control-regex
@@ -105,7 +98,7 @@ class BuildPane extends PureComponent<Props, State> {
       }));
     } else if (message.match(/Dependencies installed/i)) {
       this.setState({
-        currentBuildStep: BUILD_STEP_KEYS[4],
+        currentBuildStep: BUILD_STEP_KEYS[3],
         progress: 0.9,
       });
     }
@@ -119,13 +112,14 @@ class BuildPane extends PureComponent<Props, State> {
       // Everything appears to work though, so I'm just going to treat this
       // as a success.
       this.setState({
-        currentBuildStep: BUILD_STEP_KEYS[2],
+        currentBuildStep: BUILD_STEP_KEYS[1],
         progress: 0.2,
       });
     }
   };
 
   handleComplete = (project: Project) => {
+    return;
     this.setState({ progress: 1 });
 
     window.setTimeout(() => {
@@ -153,7 +147,10 @@ class BuildPane extends PureComponent<Props, State> {
             damping={progress === 1 ? 22 : 32}
           />
         </ProgressBarWrapper>
+
         <Title>Building Project...</Title>
+
+        <WhimsicalInstaller width={420} />
 
         <BuildSteps>
           {BUILD_STEP_KEYS.map(stepKey => {
@@ -194,7 +191,6 @@ const Wrapper = styled.div`
   justify-content: space-around;
   align-items: center;
   height: 100%;
-  padding: 40px;
   background-image: linear-gradient(
     45deg,
     ${COLORS.blue[900]},
@@ -219,6 +215,8 @@ const BuildSteps = styled.div`
 `;
 
 const Title = styled.h1`
+  padding: 40px;
+  padding-bottom: 0;
   font-size: 36px;
   text-align: center;
 `;

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -9,12 +9,12 @@ import createProject from '../../services/create-project.service';
 
 import ProgressBar from '../ProgressBar';
 import Spacer from '../Spacer';
-import FadeIn from '../FadeIn';
-import WhimsicalInstaller from '../WhimsicalInstaller/WhimsicalInstaller';
+import WhimsicalInstaller from '../WhimsicalInstaller';
+import AvailableWidth from '../AvailableWidth';
 import BuildStepProgress from './BuildStepProgress';
 
-import type { BuildStep } from './types';
-import type { SubmittedProject, Project } from '../../types';
+import type { BuildStep, Status } from './types';
+import type { Project, ProjectType } from '../../types';
 
 const BUILD_STEPS = {
   installingCliTool: {
@@ -35,14 +35,17 @@ const BUILD_STEPS = {
 const BUILD_STEP_KEYS: Array<BuildStep> = Object.keys(BUILD_STEPS);
 
 type Props = {
-  project: SubmittedProject,
+  projectName: string,
+  projectType: ?ProjectType,
+  projectIcon: ?string,
+  status: Status,
   handleCompleteBuild: (project: Project) => void,
 };
 
 type State = {
   currentBuildStep: BuildStep,
   progress: number,
-  showWhimsyInstaller: boolean,
+  runInstaller: boolean,
 };
 
 class BuildPane extends PureComponent<Props, State> {
@@ -50,33 +53,50 @@ class BuildPane extends PureComponent<Props, State> {
   state = {
     currentBuildStep: BUILD_STEPS[0],
     progress: 0,
-    showWhimsyInstaller: false,
+    runInstaller: false,
   };
 
-  componentDidMount() {
+  componentDidUpdate(prevProps: Props) {
+    if (
+      prevProps.status === 'filling-in-form' &&
+      this.props.status === 'building-project'
+    ) {
+      this.buildProject();
+
+      // We want to wait a bit before starting the whimsy animation, because
+      // at this very moment, the pane is just beginning to unfold. We don't
+      // want to re-render mid-animation!
+      //
+      // Also, WhimsicalInstaller takes its bounding-box measurements when
+      // `runInstaller` becomes true, so we want it to be in its final position
+      // when this happens. Otherwise, clicking files in the air instantly
+      // "teleports" them a couple inches from the mouse :/
+      this.timeoutId = window.setTimeout(() => {
+        this.setState({ runInstaller: true });
+      }, 1000);
+    }
+  }
+
+  buildProject = () => {
+    const { projectName, projectType, projectIcon } = this.props;
+
+    if (!projectName || !projectType || !projectIcon) {
+      console.error('Missing one of:', {
+        projectName,
+        projectType,
+        projectIcon,
+      });
+      throw new Error(
+        'Tried to build project with insufficient data. See console for more info'
+      );
+    }
+
     createProject(
-      this.props.project,
+      { projectName, projectType, projectIcon },
       this.handleStatusUpdate,
       this.handleError,
       this.handleComplete
     );
-
-    // We show the whimsy installer after a second because we need to wait until
-    // the TwoPaneModal animation completes, so that the installer's
-    // BoundingBox is accurately captured.
-    //
-    // TODO: Use ResizeObserver within WhimsyInstaller to recalculate
-    // automatically? Not sure if that will negatively impact the performance
-    // of the animation.
-    this.timeoutId = window.setTimeout(this.toggleWhimsyInstaller, 1000);
-  }
-
-  componentWillUnmount() {
-    window.clearTimeout(this.timeoutId);
-  }
-
-  toggleWhimsyInstaller = () => {
-    this.setState({ showWhimsyInstaller: !this.state.showWhimsyInstaller });
   };
 
   handleStatusUpdate = (output: any) => {
@@ -147,7 +167,7 @@ class BuildPane extends PureComponent<Props, State> {
   };
 
   render() {
-    const { currentBuildStep, progress, showWhimsyInstaller } = this.state;
+    const { currentBuildStep, progress, runInstaller } = this.state;
 
     return (
       <Wrapper>
@@ -167,19 +187,12 @@ class BuildPane extends PureComponent<Props, State> {
           />
         </ProgressBarWrapper>
 
-        {/*
-          TODO: Add an AvailableSpace helper so that the width of
-          WhimsicalInstaller and the height of Spacer can be determined
-          dynamically.
-        */}
         <WhimsicalWrapper>
-          {showWhimsyInstaller ? (
-            <FadeIn duration={850}>
-              <WhimsicalInstaller width={416} />
-            </FadeIn>
-          ) : (
-            <Spacer size={208} />
-          )}
+          <AvailableWidth>
+            {width => (
+              <WhimsicalInstaller isRunning={runInstaller} width={width} />
+            )}
+          </AvailableWidth>
         </WhimsicalWrapper>
 
         <Title>Building Project...</Title>
@@ -255,6 +268,7 @@ const Title = styled.h1`
 
 const WhimsicalWrapper = styled.div`
   position: relative;
+  width: 100%;
   /* Make sure it sits below the "Finished" overlay, when completed */
   z-index: 1;
 `;

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -61,6 +61,13 @@ class BuildPane extends PureComponent<Props, State> {
       this.handleComplete
     );
 
+    // We show the whimsy installer after a second because we need to wait until
+    // the TwoPaneModal animation completes, so that the installer's
+    // BoundingBox is accurately captured.
+    //
+    // TODO: Use ResizeObserver within WhimsyInstaller to recalculate
+    // automatically? Not sure if that will negatively impact the performance
+    // of the animation.
     this.timeoutId = window.setTimeout(this.toggleWhimsyInstaller, 1000);
   }
 

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -167,16 +167,11 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
               />
             }
             backface={
-              readyToBeBuilt && (
-                <BuildPane
-                  // Ugh. For some reason, even when I conditionally render
-                  // this <BuildPane> when `project` is complete, Flow doesn't
-                  // like it.
-                  // $FlowFixMe
-                  project={project}
-                  handleCompleteBuild={this.finishBuilding}
-                />
-              )
+              <BuildPane
+                {...project}
+                status={status}
+                handleCompleteBuild={this.finishBuilding}
+              />
             }
           />
         )}

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -157,7 +157,7 @@ class MainPane extends PureComponent<Props> {
 }
 
 const Wrapper = styled.div`
-  height: 470px;
+  height: 500px;
   will-change: transform;
 `;
 

--- a/src/components/CreateNewProjectWizard/SummaryPane.js
+++ b/src/components/CreateNewProjectWizard/SummaryPane.js
@@ -38,7 +38,7 @@ class SummaryPane extends PureComponent<Props> {
               Let's start by giving your new project a name.
             </Paragraph>
 
-            <Spacer size={100} />
+            <Spacer size={130} />
             <ImportExisting />
           </FadeIn>
         </IntroWrapper>

--- a/src/components/CreateNewProjectWizard/types.js
+++ b/src/components/CreateNewProjectWizard/types.js
@@ -2,7 +2,6 @@
 
 export type Field = 'projectName' | 'projectType' | 'projectIcon';
 export type BuildStep =
-  | 'creatingParentDirectory'
   | 'installingCliTool'
   | 'creatingProjectDirectory'
   | 'installingDependencies'

--- a/src/components/Planet/Orbit.js
+++ b/src/components/Planet/Orbit.js
@@ -52,15 +52,6 @@ class PlanetCloud extends Component<Props> {
   }
 }
 
-const Wrapper = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  opacity: ${props => props.opacity};
-  transform: translateY(${props => props.offset}px)
-    rotate(${props => props.rotation}deg);
-`;
-
 const Orbiter = styled.div`
   display: inline-block;
 `;

--- a/src/components/Planet/PlanetCloud.js
+++ b/src/components/Planet/PlanetCloud.js
@@ -83,8 +83,4 @@ const Wrapper = styled.div`
     rotate(${props => props.rotation}deg);
 `;
 
-const Orbiter = styled.div`
-  display: inline-block;
-`;
-
 export default PlanetCloud;

--- a/src/components/WhimsicalInstaller/File.js
+++ b/src/components/WhimsicalInstaller/File.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { COLORS } from '../../constants';
 
-import type { FileStatus } from './WhimsicalInstaller.helpers';
+import type { FileStatus } from './WhimsicalInstaller.types';
 
 type Props = {
   x: number,
@@ -106,7 +106,7 @@ class File extends PureComponent<Props> {
 }
 
 const isGrabbable = (status: FileStatus) =>
-  status !== 'being-inhaled' && status !== 'swallowed';
+  status !== 'being-captured' && status !== 'captured';
 
 const WIDTH_RATIO = 20 / 28;
 

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.js
@@ -31,7 +31,9 @@ export type FileData = {
 
 export const generateFlightPath = (
   width: number,
-  height: number
+  height: number,
+  startPoint: Point,
+  endPoint: Point
 ): BezierPath => {
   // We can imagine this as an SVG created that spans the size of our area.
   //  ____________________________________
@@ -42,11 +44,8 @@ export const generateFlightPath = (
   //
   // We want to draw a quadratic bezier curve between the two, arcing up
   // slightly.
-  const startPoint = { x: width * (1 / 6), y: height * 0.5 };
-  const endPoint = { x: width * (5 / 6), y: height * 0.5 };
-
-  const minControlY = height * -0.3;
-  const maxControlY = height * 0.2;
+  const minControlY = height * -0.2;
+  const maxControlY = height * 0.35;
 
   const controlPoint = {
     x: width * 0.5,

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.js
@@ -1,33 +1,7 @@
 // @flow
 import { random } from '../../utils';
 
-export type Point = { x: number, y: number };
-
-type BezierPath = {
-  startPoint: Point,
-  endPoint: Point,
-  controlPoint: Point,
-};
-
-export type FileStatus =
-  | 'autonomous' // Flying autonomously towards the file
-  | 'being-inhaled' // Very close to the folder, being sucked in
-  | 'swallowed' // At the very center of the folder, no longer active
-  | 'caught' // The user is grabbing the file
-  | 'released'; // The user has released a previously-grabbed file
-
-export type FileData = {
-  id: string,
-  x: number,
-  y: number,
-  size: number,
-  status: FileStatus,
-  flightPath: BezierPath,
-  speed?: {
-    horizontalSpeed: number,
-    verticalSpeed: number,
-  },
-};
+import type { Point, BezierPath } from './WhimsicalInstaller.types';
 
 export const generateFlightPath = (
   width: number,

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.test.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.test.js
@@ -26,8 +26,8 @@ describe('WhimsicalInstaller helpers', () => {
       expect(actualOutput.startPoint).toEqual({ x: 100, y: 100 });
       expect(actualOutput.endPoint).toEqual({ x: 500, y: 100 });
       expect(actualOutput.controlPoint.x).toEqual(300);
-      expect(actualOutput.controlPoint.y).toBeGreaterThanOrEqual(-60);
-      expect(actualOutput.controlPoint.y).toBeLessThanOrEqual(40);
+      expect(actualOutput.controlPoint.y).toBeGreaterThanOrEqual(height * -0.2);
+      expect(actualOutput.controlPoint.y).toBeLessThanOrEqual(height * 0.35);
     });
   });
 

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.test.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.test.js
@@ -11,8 +11,15 @@ describe('WhimsicalInstaller helpers', () => {
     it('creates a valid path', () => {
       const width = 600;
       const height = 200;
+      const startPoint = { x: 100, y: 100 };
+      const endPoint = { x: 500, y: 100 };
 
-      const actualOutput = generateFlightPath(width, height);
+      const actualOutput = generateFlightPath(
+        width,
+        height,
+        startPoint,
+        endPoint
+      );
 
       // We expect a path to be created with predictable start/end points,
       // but the control point has an element of randomness on its `y` coord.

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.js
@@ -164,7 +164,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
 
     // After a 2-4 second delay, generate another file!
     const DELAY = Math.random() * 2000 + 2000;
-    window.setTimeout(this.fileGenerationLoop, DELAY);
+    this.generationLoopId = window.setTimeout(this.fileGenerationLoop, DELAY);
   };
 
   areFilesWithinRangeOfFolder = (fileIds: Array<string>, range: number) => {

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.js
@@ -382,10 +382,8 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
      * The file could be autonomous, or held by the user, or released in its
      * direction.
      */
-    const { width } = this.props;
     const { files } = this.state;
 
-    const height = this.getHeight();
     const fileIds = Object.keys(files);
 
     // Check if there are any files within range of our folder maw.

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.js
@@ -208,9 +208,6 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     const relativeX = clientX - this.wrapperBoundingBox.left;
     const relativeY = clientY - this.wrapperBoundingBox.top;
 
-    console.log(clientX, relativeX);
-    console.log(clientY, relativeY);
-
     const grabbedFileId = Object.keys(files).find(
       id => files[id].status === 'caught'
     );
@@ -345,13 +342,20 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
       const nextX = file.x + file.speed.horizontalSpeed;
       const nextY = file.y + file.speed.verticalSpeed;
 
+      // Our x/y coordinates are within the context of the containing element,
+      // not the window. We need to "undo" the fact that we made them relative
+      // coordinates
+      const absoluteX = nextX + this.wrapperBoundingBox.left;
+      const absoluteY = nextY + this.wrapperBoundingBox.top;
+
       // Once the file leaves the window, we want to dispose of it.
       const isFileOutsideWindow = isPointOutsideWindow(
-        { x: nextX, y: nextY },
+        { x: absoluteX, y: absoluteY },
         file.size
       );
 
       if (isFileOutsideWindow) {
+        console.log('Deleting', file.id);
         this.deleteFiles([file.id]);
         return;
       }

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.js
@@ -67,21 +67,21 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
   }
 
   getHeight = () =>
-    // Our height will be 1/3rd of our width.
-    // This is so we end up with 3 squares:
-    //  _____________________
-    // |      |      |      |
-    // |      |      |      |
-    // |______|______|______|
+    // Our height will be 1/2 of our width.
+    // This is so we end up with 2 squares:
+    //  ______________
+    // |      |      |
+    // |      |      |
+    // |______|______|
     //
-    this.props.width * (1 / 3);
+    this.props.width * (1 / 2);
 
   getPlanetPoint = () => ({
-    x: this.props.width * (1 / 6),
+    x: this.props.width * (1 / 4),
     y: this.getHeight() * 0.5,
   });
   getFolderPoint = () => ({
-    x: this.props.width * (5 / 6),
+    x: this.props.width * (3 / 4),
     // The folderPoint is used purely for where files should wind up.
     // We want them to be slightly above the actual center, so that they
     // stick out of the top, and not out of the bottom.
@@ -97,7 +97,8 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
 
     const fileId = uuid();
 
-    const startingPoint = this.getPlanetPoint();
+    const startPoint = this.getPlanetPoint();
+    const endPoint = this.getFolderPoint();
 
     this.setState(state => {
       return {
@@ -105,11 +106,11 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
           ...state.files,
           [fileId]: {
             id: fileId,
-            x: startingPoint.x,
-            y: startingPoint.y,
+            x: startPoint.x,
+            y: startPoint.y,
             status: 'autonomous',
-            size: height / 4,
-            flightPath: generateFlightPath(width, height),
+            size: height * 0.2,
+            flightPath: generateFlightPath(width, height, startPoint, endPoint),
           },
         },
       };
@@ -207,6 +208,9 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     const relativeX = clientX - this.wrapperBoundingBox.left;
     const relativeY = clientY - this.wrapperBoundingBox.top;
 
+    console.log(clientX, relativeX);
+    console.log(clientY, relativeY);
+
     const grabbedFileId = Object.keys(files).find(
       id => files[id].status === 'caught'
     );
@@ -284,7 +288,9 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
       this.areFilesWithinRangeOfFolder(freeFlyingFileIds, FOLDER_OPEN_RADIUS)
     ) {
       this.setState({ isFolderOpen: true });
-    } else if (
+    }
+
+    if (
       isFolderOpen &&
       this.areFilesWithinRangeOfFolder(fileIdsBeingInhaled, FOLDER_CLOSE_RADIUS)
     ) {
@@ -375,7 +381,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     // Folders have a 50px radius around them that sucks files in.
     // NOTE: This isn't dependent on `width` to make the calculations easier.
     // Might change later.
-    const folderPoint = { x: width * (5 / 6), y: height * 0.5 };
+    const folderPoint = this.getFolderPoint();
 
     const nonEatenFileIdsWithinPerimeter = fileIds.filter(id => {
       const file = files[id];
@@ -521,7 +527,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     return (
       <Wrapper width={width} innerRef={node => (this.wrapperNode = node)}>
         <PlanetContainer size={height}>
-          <Earth size={height / 2} />
+          <Earth size={height * 0.4} />
         </PlanetContainer>
 
         {filesArray.map(file => (
@@ -537,7 +543,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
         ))}
 
         <FolderContainer size={height}>
-          <Folder isOpen={isFolderOpen} size={height * 0.365} />
+          <Folder isOpen={isFolderOpen} size={height * 0.32} />
         </FolderContainer>
       </Wrapper>
     );
@@ -559,6 +565,7 @@ const PlanetContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  pointer-events: none;
 `;
 
 const FolderContainer = styled.div`

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -12,17 +12,17 @@ import WhimsicalInstaller from './WhimsicalInstaller';
 
 storiesOf('WhimsicalInstaller', module)
   .add('default (600px)', () => (
-    <Wrapper width={600} height={200}>
+    <Wrapper width={600} height={300}>
       <WhimsicalInstaller width={600} />
     </Wrapper>
   ))
   .add('Tiny (200px)', () => (
-    <Wrapper width={200} height={66.6}>
+    <Wrapper width={200} height={100}>
       <WhimsicalInstaller width={200} />
     </Wrapper>
   ))
   .add('Large (1000px)', () => (
-    <Wrapper width={1000} height={333.3}>
+    <Wrapper width={1000} height={500}>
       <WhimsicalInstaller width={1000} />
     </Wrapper>
   ));

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -10,17 +10,22 @@ import WhimsicalInstaller from './WhimsicalInstaller';
 storiesOf('WhimsicalInstaller', module)
   .add('default (400px)', () => (
     <Wrapper width={400} height={200}>
-      <WhimsicalInstaller width={400} />
+      <WhimsicalInstaller isRunning width={400} />
     </Wrapper>
   ))
   .add('Tiny (200px)', () => (
     <Wrapper width={200} height={100}>
-      <WhimsicalInstaller width={200} />
+      <WhimsicalInstaller isRunning width={200} />
     </Wrapper>
   ))
   .add('Large (600px)', () => (
     <Wrapper width={600} height={300}>
-      <WhimsicalInstaller width={600} />
+      <WhimsicalInstaller isRunning width={600} />
+    </Wrapper>
+  ))
+  .add('Not running', () => (
+    <Wrapper width={400} height={200}>
+      <WhimsicalInstaller width={400} />
     </Wrapper>
   ));
 

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -11,9 +11,9 @@ import Folder from './Folder';
 import WhimsicalInstaller from './WhimsicalInstaller';
 
 storiesOf('WhimsicalInstaller', module)
-  .add('default (600px)', () => (
-    <Wrapper width={600} height={300}>
-      <WhimsicalInstaller width={600} />
+  .add('default (400px)', () => (
+    <Wrapper width={400} height={200}>
+      <WhimsicalInstaller width={400} />
     </Wrapper>
   ))
   .add('Tiny (200px)', () => (
@@ -21,14 +21,16 @@ storiesOf('WhimsicalInstaller', module)
       <WhimsicalInstaller width={200} />
     </Wrapper>
   ))
-  .add('Large (1000px)', () => (
-    <Wrapper width={1000} height={500}>
-      <WhimsicalInstaller width={1000} />
+  .add('Large (600px)', () => (
+    <Wrapper width={600} height={300}>
+      <WhimsicalInstaller width={600} />
     </Wrapper>
   ));
 
 const Wrapper = styled.div`
   position: relative;
+  top: 100px;
+  left: 100px;
   width: ${props => props.width}px;
   height: ${props => props.height}px;
   background: ${COLORS.blue[700]};

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -28,9 +28,6 @@ storiesOf('WhimsicalInstaller', module)
   ));
 
 const Wrapper = styled.div`
-  position: relative;
-  top: 100px;
-  left: 100px;
   width: ${props => props.width}px;
   height: ${props => props.height}px;
   background: ${COLORS.blue[700]};

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -1,13 +1,10 @@
 // @flow
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
 
 import { COLORS } from '../../constants';
 
-import Showcase from '../../../.storybook/components/Showcase';
-import File from './File';
-import Folder from './Folder';
 import WhimsicalInstaller from './WhimsicalInstaller';
 
 storiesOf('WhimsicalInstaller', module)

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.types.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.types.js
@@ -1,0 +1,27 @@
+export type Point = { x: number, y: number };
+
+export type BezierPath = {
+  startPoint: Point,
+  endPoint: Point,
+  controlPoint: Point,
+};
+
+export type FileStatus =
+  | 'autonomous' // Flying autonomously towards the file
+  | 'being-captured' // Very close to the folder, being sucked in
+  | 'captured' // At the very center of the folder, no longer active
+  | 'caught' // The user is grabbing the file
+  | 'released'; // The user has released a previously-grabbed file
+
+export type FileData = {
+  id: string,
+  x: number,
+  y: number,
+  status: FileStatus,
+  size: number,
+  flightPath: BezierPath,
+  speed?: {
+    horizontalSpeed: number,
+    verticalSpeed: number,
+  },
+};

--- a/src/reducers/dependencies.reducer.test.js
+++ b/src/reducers/dependencies.reducer.test.js
@@ -568,7 +568,7 @@ Object {
     };
     const action = { type: RESET_ALL_STATE };
 
-    expect(reducer(prevState, action)).toMatchInlineSnapshot(`Object {}`);
+    expect(reducer(prevState, action)).toEqual(initialState);
   });
 });
 

--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -1,8 +1,6 @@
 // @flow
 import { migrateToReduxStorage } from './migrations';
 
-const ENGINE_KEY = 'test-key';
-
 describe('Redux migrations', () => {
   describe('Version 0 -> Version 1', () => {
     it('does nothing with no initial state to work with', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,19 +2678,19 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@2.11.3, browserslist@^2.11.1, browserslist@^2.11.3:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  dependencies:
+    caniuse-lite "^1.0.30000792"
+    electron-to-chromium "^1.3.30"
+
 browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
   dependencies:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
-
-browserslist@^2.11.1, browserslist@^2.11.3:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
-  dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
 
 browserslist@^3.0.0, browserslist@^3.2.6:
   version "3.2.8"
@@ -3899,6 +3899,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -4757,7 +4764,7 @@ extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.4:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
@@ -4974,9 +4981,21 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-file-up@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/find-file-up/-/find-file-up-1.0.2.tgz#4d53664bc128cf793901497f4b13558d979755ca"
+  dependencies:
+    resolve-dir "^1.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
+find-pkg@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-pkg/-/find-pkg-1.0.0.tgz#96db242e001c7c55025d32213302ea3aba677177"
+  dependencies:
+    find-file-up "^1.0.2"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -5407,6 +5426,17 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
+globby@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -5471,6 +5501,13 @@ gzip-size@3.0.0:
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
   dependencies:
     duplexer "^0.1.1"
+
+gzip-size@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
 
 h2x-core@^0.1.9:
   version "0.1.9"
@@ -5875,6 +5912,10 @@ ignore@^3.3.3:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
+ignore@^3.3.5:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
 immer@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.3.1.tgz#3a8c18d9d618c8b7169760a79beec24a1da6a43e"
@@ -5983,6 +6024,24 @@ inquirer@3.3.0, inquirer@^3.0.1, inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.0.0.tgz#261b77cdb535495509f1b90197108ffb96c02db5"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -8292,6 +8351,12 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -8350,7 +8415,7 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-up@^2.0.0:
+pkg-up@2.0.0, pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
@@ -9010,27 +9075,31 @@ react-base16-styling@^0.5.1:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-dev-utils@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.2.tgz#7bb68d2c4f6ffe7ed1184c5b0124fcad692774d2"
+react-dev-utils@6.0.0-next.66cc7a90:
+  version "6.0.0-next.66cc7a90"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-6.0.0-next.66cc7a90.tgz#9d5fb27615454a94b448c679e4a79ea1fe716fba"
   dependencies:
+    "@babel/code-frame" "7.0.0-beta.44"
     address "1.0.3"
-    babel-code-frame "6.26.0"
-    chalk "1.1.3"
+    browserslist "2.11.3"
+    chalk "2.3.0"
     cross-spawn "5.1.0"
     detect-port-alt "1.1.6"
     escape-string-regexp "1.0.5"
     filesize "3.5.11"
+    find-pkg "1.0.0"
     global-modules "1.0.0"
-    gzip-size "3.0.0"
-    inquirer "3.3.0"
+    globby "7.1.1"
+    gzip-size "4.1.0"
+    inquirer "5.0.0"
     is-root "1.0.0"
     opn "5.2.0"
-    react-error-overlay "^4.0.1"
+    pkg-up "2.0.0"
+    react-error-overlay "5.0.0-next.66cc7a90"
     recursive-readdir "2.2.1"
     shell-quote "1.6.1"
-    sockjs-client "1.1.5"
-    strip-ansi "3.0.1"
+    sockjs-client "1.1.4"
+    strip-ansi "4.0.0"
     text-table "0.2.0"
 
 react-dev-utils@^5.0.0:
@@ -9096,13 +9165,13 @@ react-dom@16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-error-overlay@5.0.0-next.66cc7a90:
+  version "5.0.0-next.66cc7a90"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.0-next.66cc7a90.tgz#68379b131ebe74112a12197504bfe7fa53119b3b"
+
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
-
-react-error-overlay@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
 
 react-fuzzy@^0.5.2:
   version "0.5.2"
@@ -9738,6 +9807,10 @@ reselect@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
+resize-observer-polyfill@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -9841,6 +9914,12 @@ rx-lite-aggregates@^4.0.8:
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+rxjs@^5.5.2:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  dependencies:
+    symbol-observable "1.0.1"
 
 rxjs@^6.1.0:
   version "6.2.1"
@@ -10199,17 +10278,6 @@ sockjs-client@1.1.4:
     json3 "^3.3.2"
     url-parse "^1.1.8"
 
-sockjs-client@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.5.tgz#1bb7c0f7222c40f42adf14f4442cbd1269771a83"
-  dependencies:
-    debug "^2.6.6"
-    eventsource "0.1.6"
-    faye-websocket "~0.11.0"
-    inherits "^2.0.1"
-    json3 "^3.3.2"
-    url-parse "^1.1.8"
-
 sockjs@0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d"
@@ -10498,7 +10566,7 @@ strip-ansi@3.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@^4.0.0:
+strip-ansi@4.0.0, strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
@@ -10690,6 +10758,10 @@ sw-toolbox@^3.4.0:
   dependencies:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This is the almost-final PR for my whimsical installer!! :D

It implements it in the build pane:

 
![animation2](https://user-images.githubusercontent.com/6692932/45218776-c40ef600-b276-11e8-99e7-6a03b84fb5e6.gif)

I'll have 1 more PR after this, which tackles:

- Seeing about using ResizeObserver in WhimsicalInstaller to avoid needing the fade-in delay in BuildPane
- Adds an `AvailableSpace` helper component which figures out how much width/height is available in a container, and passes it down with a render prop. This way, BuildPane doesn't have to specify an arbitrary width for the WhimsicalInstaller element, it can just fill the available space.
- Renames `being-inhaled` to `being-captured`, and `swallowed` to `captured`, from @j-f1's feedback in #215 

