### PR TITLE
Quick fix to projectPath migration

### DIFF
--- a/src/store/migrations.js
+++ b/src/store/migrations.js
@@ -53,12 +53,15 @@ export function migrateToSupportProjectHomePath(state: any) {
   if (!state) {
     return state;
   }
-  const {
-    paths: { byId: pathsById, homePath },
-  } = state;
 
-  if (pathsById && homePath) {
-    return state;
+  if (state.paths) {
+    const {
+      paths: { byId: pathsById, homePath },
+    } = state;
+
+    if (pathsById && homePath) {
+      return state;
+    }
   }
 
   const nextState = {


### PR DESCRIPTION
**Related Issue:**
None, reported on Gitter by @shockry.

**Summary:**
The migration for `projectPath` throws an error on fresh clone. It can also be re-created by clearing state in console with `electronStore.clear()` and the re-freshing. (Not happening if done with the refresh menu item).
This is happening on master.

The error message is like following:
![grafik](https://user-images.githubusercontent.com/3046542/45244175-f06a5700-b2f6-11e8-8c64-3b3bdf79da7f.png)


**Screenshots/GIFs:**
<!--
For changes that affect the UI, please include a screenshot of the change. If the change is related to part of a flow, please include a GIF screen recording.

Free software to create screen-recording GIFs:
- Giphy Capture (MacOS only): https://giphy.com/apps/giphycapture
- Licecap (MacOS / Win): https://www.cockos.com/licecap/
- Peek (Linux): https://github.com/phw/peek
-->
