### PR TITLE
Add migration tests from initialState to current

### DIFF
--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -79,9 +79,6 @@ describe('Redux migrations', () => {
         type: 'AHH MADE UP ACTION',
       });
 
-      // Run it through all migrations
-      // NOTE: Please add any new migrations here, in addition to creating
-      // their own tests.
       expect(() => migrateToReduxStorage(state)).not.toThrow();
     });
   });
@@ -138,9 +135,6 @@ describe('Redux migrations', () => {
         type: 'AHH MADE UP ACTION',
       });
 
-      // Run it through all migrations
-      // NOTE: Please add any new migrations here, in addition to creating
-      // their own tests.
       expect(() => migrateToReduxStorage(state)).not.toThrow();
       state = migrateToReduxStorage(state);
 

--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -3,6 +3,7 @@ import {
   migrateToReduxStorage,
   migrateToSupportProjectHomePath,
 } from './migrations';
+import rootReducer from '../reducers';
 
 jest.mock('os', () => ({
   homedir: () => 'test',
@@ -72,6 +73,17 @@ describe('Redux migrations', () => {
 
       expect(actualOutput).toEqual(expectedOutput);
     });
+
+    it('builds without crashing', () => {
+      let state = rootReducer(undefined, {
+        type: 'AHH MADE UP ACTION',
+      });
+
+      // Run it through all migrations
+      // NOTE: Please add any new migrations here, in addition to creating
+      // their own tests.
+      expect(() => migrateToReduxStorage(state)).not.toThrow();
+    });
   });
 
   describe('Version 1 -> Version 2', () => {
@@ -119,6 +131,20 @@ describe('Redux migrations', () => {
       const expectedOutput = persistedState;
       const actualOutput = migrateToSupportProjectHomePath(persistedState);
       expect(actualOutput).toEqual(expectedOutput);
+    });
+
+    it('builds without crashing', () => {
+      let state = rootReducer(undefined, {
+        type: 'AHH MADE UP ACTION',
+      });
+
+      // Run it through all migrations
+      // NOTE: Please add any new migrations here, in addition to creating
+      // their own tests.
+      expect(() => migrateToReduxStorage(state)).not.toThrow();
+      state = migrateToReduxStorage(state);
+
+      expect(() => migrateToSupportProjectHomePath(state)).not.toThrow();
     });
   });
 });

--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -18,7 +18,12 @@ jest.mock('path', () => ({
   join: () => 'test/guppy-projects',
 }));
 
-const FAKE_ACTION = 'AHH THIS IS NOT A REAL ACTION';
+const getInitialState = () =>
+  // Get the initial Redux state by running the reducer with `undefined` state,
+  // and a bogus action.
+  // (this causes each reducer slice to use the default state value, and to
+  // return it since the action won't match.)
+  rootReducer(undefined, { type: 'Ahh, this is not a real action' });
 
 describe('Redux migrations', () => {
   describe('Version 0 -> Version 1', () => {
@@ -77,7 +82,7 @@ describe('Redux migrations', () => {
     });
 
     it('builds without crashing', () => {
-      let state = rootReducer(undefined, { type: FAKE_ACTION });
+      let state = getInitialState();
 
       expect(() => migrateToReduxStorage(state)).not.toThrow();
     });
@@ -131,7 +136,7 @@ describe('Redux migrations', () => {
     });
 
     it('builds without crashing', () => {
-      let state = rootReducer(undefined, { type: FAKE_ACTION });
+      let state = getInitialState();
 
       expect(() => migrateToReduxStorage(state)).not.toThrow();
       state = migrateToReduxStorage(state);

--- a/src/store/migrations.test.js
+++ b/src/store/migrations.test.js
@@ -18,6 +18,8 @@ jest.mock('path', () => ({
   join: () => 'test/guppy-projects',
 }));
 
+const FAKE_ACTION = 'AHH THIS IS NOT A REAL ACTION';
+
 describe('Redux migrations', () => {
   describe('Version 0 -> Version 1', () => {
     it('does nothing with no initial state to work with', () => {
@@ -75,9 +77,7 @@ describe('Redux migrations', () => {
     });
 
     it('builds without crashing', () => {
-      let state = rootReducer(undefined, {
-        type: 'AHH MADE UP ACTION',
-      });
+      let state = rootReducer(undefined, { type: FAKE_ACTION });
 
       expect(() => migrateToReduxStorage(state)).not.toThrow();
     });
@@ -131,9 +131,7 @@ describe('Redux migrations', () => {
     });
 
     it('builds without crashing', () => {
-      let state = rootReducer(undefined, {
-        type: 'AHH MADE UP ACTION',
-      });
+      let state = rootReducer(undefined, { type: FAKE_ACTION });
 
       expect(() => migrateToReduxStorage(state)).not.toThrow();
       state = migrateToReduxStorage(state);


### PR DESCRIPTION
Earlier, it was revealed that our migration tests weren't quite sufficient; they didn't accurately test how the migrations would work, when given state provided by the reducer, or by previous migrations!

This change adds a new pattern, which is that every `describe` block for a migration should include a test that:

- Starts with `initialState` created by running our root reducer
- Runs it through every previous migration function, in order.

For now, I think having the pattern in code is sufficient; we'll be monitoring changes to migrations closely, as they have the potential to break code for lots of people. If we find that migrations are slipping through review without solid tests, we can add some docs somewhere.