### PR TITLE
Whimsy install - finishing touches

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "fix-path": "2.1.0",
     "gatsby-cli": "1.1.58",
     "ps-tree": "1.1.0",
+    "resize-observer-polyfill": "^1.5.0",
     "yarn": "1.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "fix-path": "2.1.0",
     "gatsby-cli": "1.1.58",
     "ps-tree": "1.1.0",
-    "resize-observer-polyfill": "^1.5.0",
     "yarn": "1.9.2"
   },
   "devDependencies": {
@@ -124,6 +123,7 @@
     "redux-storage-decorator-migrate": "1.1.0",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
+    "resize-observer-polyfill": "1.5.0",
     "resolve": "1.6.0",
     "sass-loader": "7.0.0",
     "slug": "0.9.1",

--- a/src/components/AvailableWidth/AvailableWidth.js
+++ b/src/components/AvailableWidth/AvailableWidth.js
@@ -42,7 +42,6 @@ class AvailableWidth extends Component<Props, State> {
     // 2.4kb though, so I don't feel the need to import() it.
     // Also, this will also report on mount, which'll set the initial value.
     this.observer = new ResizeObserver(([entry]) => {
-      console.log('REsize!');
       const observedWidth = entry.contentRect.width;
 
       // This observer fires on mount, even though the size hasn't changed.
@@ -64,8 +63,6 @@ class AvailableWidth extends Component<Props, State> {
   render() {
     const { width } = this.state;
     const { children } = this.props;
-
-    console.log({ width });
 
     return (
       <div ref={elem => (this.containerElem = elem)}>

--- a/src/components/AvailableWidth/AvailableWidth.js
+++ b/src/components/AvailableWidth/AvailableWidth.js
@@ -1,0 +1,84 @@
+/**
+ * Utility component that reports on the available width of the parent
+ * container. Helpful when you absolutely need to provide a pixel value for
+ * something that lives within a container without one.
+ */
+// @flow
+
+import React, { Component } from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+
+type Props = {
+  children: (width: number) => React$Node,
+};
+
+type State = {
+  width?: number,
+};
+
+class AvailableWidth extends Component<Props, State> {
+  state = {};
+
+  containerElem: ?HTMLElement;
+  observer: ResizeObserver;
+
+  componentDidMount() {
+    const { containerElem } = this;
+
+    // We ought to always have the element, but Flow doesn't believe me.
+    if (!containerElem) {
+      return;
+    }
+
+    // Set the width based on the DOM size on-mount.
+    // This is necessary because the 'autofiring' behaviour of ResizeObserver
+    // appears to be inconsistent on mobile.
+    const { width } = containerElem.getBoundingClientRect();
+    this.setState({ width });
+
+    // We want to be notified of any changes to the size of this element.
+    // Enter 'ResizeObserver'!
+    // Using a polyfill atm since it's only in Chrome 65+. Polyfill's only
+    // 2.4kb though, so I don't feel the need to import() it.
+    // Also, this will also report on mount, which'll set the initial value.
+    this.observer = new ResizeObserver(([entry]) => {
+      console.log('REsize!');
+      const observedWidth = entry.contentRect.width;
+
+      // This observer fires on mount, even though the size hasn't changed.
+      // Ignore this case.
+      if (observedWidth === this.state.width) {
+        return;
+      }
+
+      this.setState({ width: observedWidth });
+    });
+
+    this.observer.observe(containerElem);
+  }
+
+  componentWillUnmount() {
+    this.observer.disconnect();
+  }
+
+  render() {
+    const { width } = this.state;
+    const { children } = this.props;
+
+    console.log({ width });
+
+    return (
+      <div ref={elem => (this.containerElem = elem)}>
+        {/*
+          For the very first render, `width` will be undefined; this data is
+          only collected _after_ mount. So, a frame needs to pass with the
+          container being empty. Immediately after we collect the width and
+          re-render, invoking the children function.
+        */}
+        {width !== undefined && children(width)}
+      </div>
+    );
+  }
+}
+
+export default AvailableWidth;

--- a/src/components/AvailableWidth/index.js
+++ b/src/components/AvailableWidth/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvailableWidth';

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -63,6 +63,14 @@ class BuildPane extends PureComponent<Props, State> {
     ) {
       this.buildProject();
 
+      // We want to wait a bit before starting the whimsy animation, because
+      // at this very moment, the pane is just beginning to unfold. We don't
+      // want to re-render mid-animation!
+      //
+      // Also, WhimsicalInstaller takes its bounding-box measurements when
+      // `runInstaller` becomes true, so we want it to be in its final position
+      // when this happens. Otherwise, clicking files in the air instantly
+      // "teleports" them a couple inches from the mouse :/
       this.timeoutId = window.setTimeout(() => {
         this.setState({ runInstaller: true });
       }, 1000);

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -167,16 +167,11 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
               />
             }
             backface={
-              readyToBeBuilt && (
-                <BuildPane
-                  // Ugh. For some reason, even when I conditionally render
-                  // this <BuildPane> when `project` is complete, Flow doesn't
-                  // like it.
-                  // $FlowFixMe
-                  project={project}
-                  handleCompleteBuild={this.finishBuilding}
-                />
-              )
+              <BuildPane
+                {...project}
+                status={status}
+                handleCompleteBuild={this.finishBuilding}
+              />
             }
           />
         )}

--- a/src/components/WhimsicalInstaller/File.js
+++ b/src/components/WhimsicalInstaller/File.js
@@ -106,7 +106,7 @@ class File extends PureComponent<Props> {
 }
 
 const isGrabbable = (status: FileStatus) =>
-  status !== 'being-inhaled' && status !== 'swallowed';
+  status !== 'being-captured' && status !== 'captured';
 
 const WIDTH_RATIO = 20 / 28;
 

--- a/src/components/WhimsicalInstaller/File.js
+++ b/src/components/WhimsicalInstaller/File.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { COLORS } from '../../constants';
 
-import type { FileStatus } from './WhimsicalInstaller.helpers';
+import type { FileStatus } from './WhimsicalInstaller.types';
 
 type Props = {
   x: number,

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.js
@@ -1,33 +1,7 @@
 // @flow
 import { random } from '../../utils';
 
-export type Point = { x: number, y: number };
-
-type BezierPath = {
-  startPoint: Point,
-  endPoint: Point,
-  controlPoint: Point,
-};
-
-export type FileStatus =
-  | 'autonomous' // Flying autonomously towards the file
-  | 'being-inhaled' // Very close to the folder, being sucked in
-  | 'swallowed' // At the very center of the folder, no longer active
-  | 'caught' // The user is grabbing the file
-  | 'released'; // The user has released a previously-grabbed file
-
-export type FileData = {
-  id: string,
-  x: number,
-  y: number,
-  size: number,
-  status: FileStatus,
-  flightPath: BezierPath,
-  speed?: {
-    horizontalSpeed: number,
-    verticalSpeed: number,
-  },
-};
+import type { Point, BezierPath } from './WhimsicalInstaller.types';
 
 export const generateFlightPath = (
   width: number,

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.test.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.helpers.test.js
@@ -26,8 +26,8 @@ describe('WhimsicalInstaller helpers', () => {
       expect(actualOutput.startPoint).toEqual({ x: 100, y: 100 });
       expect(actualOutput.endPoint).toEqual({ x: 500, y: 100 });
       expect(actualOutput.controlPoint.x).toEqual(300);
-      expect(actualOutput.controlPoint.y).toBeGreaterThanOrEqual(-60);
-      expect(actualOutput.controlPoint.y).toBeLessThanOrEqual(40);
+      expect(actualOutput.controlPoint.y).toBeGreaterThanOrEqual(height * -0.2);
+      expect(actualOutput.controlPoint.y).toBeLessThanOrEqual(height * 0.35);
     });
   });
 

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.js
@@ -3,8 +3,6 @@ import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import uuid from 'uuid/v1';
 
-import { random } from '../../utils';
-
 import {
   generateFlightPath,
   getPositionOnQuadraticBezierPath,
@@ -101,7 +99,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     // stick out of the top, and not out of the bottom.
     y: this.getHeight() * 0.5 - 4,
   });
-  getPixelsPerTick = () => this.props.width * 0.01;
+  getPixelsPerTick = () => this.props.width * 0.0075;
 
   createFile = () => {
     /**
@@ -115,13 +113,6 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     const startPoint = this.getPlanetPoint();
     const endPoint = this.getFolderPoint();
 
-    // The speed of a file depends on the size of the container.
-    // In general, we want to move approximately 1% of its width every tick.
-    // Each file has its own speed, to keep things dynamic.
-    const minSpeed = width * 0.005;
-    const maxSpeed = width * 0.015;
-    const speed = random(minSpeed, maxSpeed);
-
     this.setState(state => {
       return {
         files: {
@@ -132,7 +123,6 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
             y: startPoint.y,
             status: 'autonomous',
             size: height * 0.2,
-            speed,
             flightPath: generateFlightPath(width, height, startPoint, endPoint),
           },
         },
@@ -167,7 +157,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
 
   fileGenerationLoop = () => {
     /**
-     * Every few seconds, a new file is generated, and long-swallowed files
+     * Every few seconds, a new file is generated, and long-captured files
      * are quietly cleaned.
      */
     const { files } = this.state;
@@ -176,9 +166,9 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
 
     this.createFile();
 
-    // Keep only the 2 most recent swallowed files
+    // Keep only the 2 most recent captured files
     const filesToDelete = fileIds
-      .filter(id => files[id].status === 'swallowed')
+      .filter(id => files[id].status === 'captured')
       .slice(0, -2);
 
     if (filesToDelete.length > 0) {
@@ -212,7 +202,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
      */
     const { status } = this.state.files[id];
 
-    if (status === 'being-inhaled') {
+    if (status === 'being-captured') {
       return;
     }
 
@@ -294,11 +284,11 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     const { files, isFolderOpen } = this.state;
 
     const freeFlyingFileIds = activeFileIds.filter(
-      id => files[id].status !== 'being-inhaled'
+      id => files[id].status !== 'being-captured'
     );
 
     const fileIdsBeingInhaled = activeFileIds.filter(
-      id => files[id].status === 'being-inhaled'
+      id => files[id].status === 'being-captured'
     );
 
     // When files get near the folder, the folder "mouth" opens up.
@@ -421,7 +411,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     const nonEatenFileIdsWithinPerimeter = fileIds.filter(id => {
       const file = files[id];
 
-      if (file.status === 'being-inhaled' || file.status === 'swallowed') {
+      if (file.status === 'being-captured' || file.status === 'captured') {
         return false;
       }
 
@@ -434,13 +424,13 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     });
 
     nonEatenFileIdsWithinPerimeter.forEach(fileId => {
-      this.updateFile(fileId, { status: 'being-inhaled' });
+      this.updateFile(fileId, { status: 'being-captured' });
     });
   };
 
   moveFilesCloserToTheirDoom = (activeFileIds: Array<string>) => {
     /**
-     * Inch all files in the process of being inhaled closer to the center.
+     * Inch all files in the process of being captured closer to the center.
      */
     const { files } = this.state;
 
@@ -448,7 +438,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     const pixelsPerTick = this.getPixelsPerTick();
 
     const fileIdsBeingInhaled = activeFileIds.filter(
-      id => files[id].status === 'being-inhaled'
+      id => files[id].status === 'being-captured'
     );
 
     fileIdsBeingInhaled.forEach(id => {
@@ -502,7 +492,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
   swallowFilesAtCenter = (activeFileIds: Array<string>) => {
     /**
      * Update the status for files that have made it to the center of the
-     * folder, after being inhaled.
+     * folder; they have officially been captured.
      */
     const { files } = this.state;
 
@@ -525,7 +515,7 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
     if (swallowedFileIds.length) {
       swallowedFileIds.forEach(id =>
         this.updateFile(id, {
-          status: 'swallowed',
+          status: 'captured',
         })
       );
     }
@@ -552,9 +542,9 @@ class WhimsicalInstaller extends PureComponent<Props, State> {
       this.autonomouslyIncrementFile(autonomousFile);
     }
 
-    // Several methods below need a list of not-swallowed files.
+    // Several methods below need a list of not-captured files.
     const activeFileIds = Object.keys(files).filter(
-      id => files[id].status !== 'swallowed'
+      id => files[id].status !== 'captured'
     );
 
     this.handleFolderOpeningAndClosing(activeFileIds);

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -10,17 +10,22 @@ import WhimsicalInstaller from './WhimsicalInstaller';
 storiesOf('WhimsicalInstaller', module)
   .add('default (400px)', () => (
     <Wrapper width={400} height={200}>
-      <WhimsicalInstaller width={400} />
+      <WhimsicalInstaller isRunning width={400} />
     </Wrapper>
   ))
   .add('Tiny (200px)', () => (
     <Wrapper width={200} height={100}>
-      <WhimsicalInstaller width={200} />
+      <WhimsicalInstaller isRunning width={200} />
     </Wrapper>
   ))
   .add('Large (600px)', () => (
     <Wrapper width={600} height={300}>
-      <WhimsicalInstaller width={600} />
+      <WhimsicalInstaller isRunning width={600} />
+    </Wrapper>
+  ))
+  .add('Not running', () => (
+    <Wrapper width={400} height={200}>
+      <WhimsicalInstaller width={400} />
     </Wrapper>
   ));
 

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.types.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.types.js
@@ -8,8 +8,8 @@ export type BezierPath = {
 
 export type FileStatus =
   | 'autonomous' // Flying autonomously towards the file
-  | 'being-inhaled' // Very close to the folder, being sucked in
-  | 'swallowed' // At the very center of the folder, no longer active
+  | 'being-captured' // Very close to the folder, being sucked in
+  | 'captured' // At the very center of the folder, no longer active
   | 'caught' // The user is grabbing the file
   | 'released'; // The user has released a previously-grabbed file
 

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.types.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.types.js
@@ -1,0 +1,27 @@
+export type Point = { x: number, y: number };
+
+export type BezierPath = {
+  startPoint: Point,
+  endPoint: Point,
+  controlPoint: Point,
+};
+
+export type FileStatus =
+  | 'autonomous' // Flying autonomously towards the file
+  | 'being-inhaled' // Very close to the folder, being sucked in
+  | 'swallowed' // At the very center of the folder, no longer active
+  | 'caught' // The user is grabbing the file
+  | 'released'; // The user has released a previously-grabbed file
+
+export type FileData = {
+  id: string,
+  x: number,
+  y: number,
+  status: FileStatus,
+  size: number,
+  flightPath: BezierPath,
+  speed?: {
+    horizontalSpeed: number,
+    verticalSpeed: number,
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,19 +2678,19 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@2.11.3, browserslist@^2.11.1, browserslist@^2.11.3:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  dependencies:
+    caniuse-lite "^1.0.30000792"
+    electron-to-chromium "^1.3.30"
+
 browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
   dependencies:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
-
-browserslist@^2.11.1, browserslist@^2.11.3:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
-  dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
 
 browserslist@^3.0.0, browserslist@^3.2.6:
   version "3.2.8"
@@ -3899,6 +3899,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -4757,7 +4764,7 @@ extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.4:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
@@ -4974,9 +4981,21 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-file-up@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/find-file-up/-/find-file-up-1.0.2.tgz#4d53664bc128cf793901497f4b13558d979755ca"
+  dependencies:
+    resolve-dir "^1.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
+find-pkg@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-pkg/-/find-pkg-1.0.0.tgz#96db242e001c7c55025d32213302ea3aba677177"
+  dependencies:
+    find-file-up "^1.0.2"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -5407,6 +5426,17 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
+globby@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -5471,6 +5501,13 @@ gzip-size@3.0.0:
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
   dependencies:
     duplexer "^0.1.1"
+
+gzip-size@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
 
 h2x-core@^0.1.9:
   version "0.1.9"
@@ -5875,6 +5912,10 @@ ignore@^3.3.3:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
+ignore@^3.3.5:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
 immer@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.3.1.tgz#3a8c18d9d618c8b7169760a79beec24a1da6a43e"
@@ -5983,6 +6024,24 @@ inquirer@3.3.0, inquirer@^3.0.1, inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.0.0.tgz#261b77cdb535495509f1b90197108ffb96c02db5"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -8292,6 +8351,12 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -8350,7 +8415,7 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-up@^2.0.0:
+pkg-up@2.0.0, pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
@@ -9010,27 +9075,31 @@ react-base16-styling@^0.5.1:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-dev-utils@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.2.tgz#7bb68d2c4f6ffe7ed1184c5b0124fcad692774d2"
+react-dev-utils@6.0.0-next.66cc7a90:
+  version "6.0.0-next.66cc7a90"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-6.0.0-next.66cc7a90.tgz#9d5fb27615454a94b448c679e4a79ea1fe716fba"
   dependencies:
+    "@babel/code-frame" "7.0.0-beta.44"
     address "1.0.3"
-    babel-code-frame "6.26.0"
-    chalk "1.1.3"
+    browserslist "2.11.3"
+    chalk "2.3.0"
     cross-spawn "5.1.0"
     detect-port-alt "1.1.6"
     escape-string-regexp "1.0.5"
     filesize "3.5.11"
+    find-pkg "1.0.0"
     global-modules "1.0.0"
-    gzip-size "3.0.0"
-    inquirer "3.3.0"
+    globby "7.1.1"
+    gzip-size "4.1.0"
+    inquirer "5.0.0"
     is-root "1.0.0"
     opn "5.2.0"
-    react-error-overlay "^4.0.1"
+    pkg-up "2.0.0"
+    react-error-overlay "5.0.0-next.66cc7a90"
     recursive-readdir "2.2.1"
     shell-quote "1.6.1"
-    sockjs-client "1.1.5"
-    strip-ansi "3.0.1"
+    sockjs-client "1.1.4"
+    strip-ansi "4.0.0"
     text-table "0.2.0"
 
 react-dev-utils@^5.0.0:
@@ -9096,13 +9165,13 @@ react-dom@16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-error-overlay@5.0.0-next.66cc7a90:
+  version "5.0.0-next.66cc7a90"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.0-next.66cc7a90.tgz#68379b131ebe74112a12197504bfe7fa53119b3b"
+
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
-
-react-error-overlay@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
 
 react-fuzzy@^0.5.2:
   version "0.5.2"
@@ -9738,6 +9807,10 @@ reselect@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
+resize-observer-polyfill@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -9841,6 +9914,12 @@ rx-lite-aggregates@^4.0.8:
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+rxjs@^5.5.2:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  dependencies:
+    symbol-observable "1.0.1"
 
 rxjs@^6.1.0:
   version "6.2.1"
@@ -10199,17 +10278,6 @@ sockjs-client@1.1.4:
     json3 "^3.3.2"
     url-parse "^1.1.8"
 
-sockjs-client@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.5.tgz#1bb7c0f7222c40f42adf14f4442cbd1269771a83"
-  dependencies:
-    debug "^2.6.6"
-    eventsource "0.1.6"
-    faye-websocket "~0.11.0"
-    inherits "^2.0.1"
-    json3 "^3.3.2"
-    url-parse "^1.1.8"
-
 sockjs@0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d"
@@ -10498,7 +10566,7 @@ strip-ansi@3.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@^4.0.0:
+strip-ansi@4.0.0, strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
@@ -10690,6 +10758,10 @@ sw-toolbox@^3.4.0:
   dependencies:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9807,7 +9807,7 @@ reselect@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
-resize-observer-polyfill@^1.5.0:
+resize-observer-polyfill@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
 


### PR DESCRIPTION
This diff addresses feedback from previous diffs:

- Changes `swallowed` and `being-inhaled` to `captured` and `being-captured`
- Changes `fileSpeed` to be based on the width of the installer
- Adds a new AvailableWidth helper to figure out how large the WhimsicalInstaller should be
- Removes the "fade in" on the installer, since it's distracting and unnecessary
- Creates a new `types` file, instead of bundling them in `helpers`.
- Adds some helpful comments

This is the last PR in a sequence:

1 - Creating the original components - https://github.com/joshwcomeau/guppy/pull/215
2 - Allowing them to be "thrown" - https://github.com/joshwcomeau/guppy/pull/218
3 - Implementing it in BuildPane - https://github.com/joshwcomeau/guppy/pull/224
4 - This PR, finishing touches

Let me know what y'all think! 