### PR TITLE
Fix colors

### DIFF
--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -159,10 +159,7 @@ export function* taskRun({ task }: Action): Saga<void> {
     ['run', name, ...additionalArgs],
     {
       cwd: projectPath,
-      env: {
-        ...getBaseProjectEnvironment(projectPath),
-        FORCE_COLOR: true,
-      },
+      env: getBaseProjectEnvironment(projectPath),
     }
   );
 
@@ -328,15 +325,12 @@ export const getDevServerCommand = (
         args: ['run', task.name],
         env: {
           PORT: port,
-          FORCE_COLOR: true,
         },
       };
     case 'gatsby':
       return {
         args: ['run', task.name, '-p', port],
-        env: {
-          FORCE_COLOR: true,
-        },
+        env: {},
       };
     default:
       throw new Error('Unrecognized project type: ' + projectType);

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -64,19 +64,10 @@ export function* launchDevServer({ task }: Action): Saga<void> {
 
     const stdioChannel = createStdioChannel(child, {
       stdout: emitter => data => {
-        // Ok so, unfortunately, failure-to-compile is still pushed
-        // through stdout, not stderr. We want that message specifically
-        // to trigger an error state, and so we need to parse it.
-        const text = data.toString();
+        const text = stripUnusableControlCharacters(data.toString());
 
-        // Ok, so this workflow really needs to be rewritten.
-        // We can't safely assume that all `stderr` output indicates
-        // a breaking/blocking error, since Jest writes its standard
-        // output to `stderr` (presumably to keep it from displaying in
-        // CI logs). Currently the only thing we know for sure is a
-        // breaking error is when the dev server fails to compile, so we're
-        // specifically handling that case, but we need a better, more
-        // generalized solution.
+        // Re-route "Failed to compile" messages to stderr, since this should
+        // be treated as an error.
         // TODO: refactor error handling
         const isDevServerFail = text.includes('Failed to compile');
 
@@ -87,7 +78,9 @@ export function* launchDevServer({ task }: Action): Saga<void> {
         });
       },
       stderr: emitter => data => {
-        emitter({ channel: 'stderr', text: data.toString() });
+        const text = stripUnusableControlCharacters(data.toString());
+
+        emitter({ channel: 'stderr', text });
       },
       exit: emitter => code => {
         // For Windows Support
@@ -106,11 +99,11 @@ export function* launchDevServer({ task }: Action): Saga<void> {
     while (true) {
       const message = yield take(stdioChannel);
 
-      // eslint-disable-next-line default-case
       switch (message.channel) {
         case 'stdout':
           yield put(receiveDataFromTaskExecution(task, message.text));
           break;
+
         case 'stderr':
           yield put(
             receiveDataFromTaskExecution(
@@ -120,12 +113,16 @@ export function* launchDevServer({ task }: Action): Saga<void> {
             )
           );
           break;
+
         case 'exit':
           yield call(displayTaskComplete, task, message.wasSuccessful);
           yield put(
             completeTask(task, message.timestamp, message.wasSuccessful)
           );
           break;
+
+        default:
+          throw new Error('Unexpected channel for message: ' + message.channel);
       }
     }
   } catch (err) {
@@ -162,7 +159,10 @@ export function* taskRun({ task }: Action): Saga<void> {
     ['run', name, ...additionalArgs],
     {
       cwd: projectPath,
-      env: getBaseProjectEnvironment(projectPath),
+      env: {
+        ...getBaseProjectEnvironment(projectPath),
+        FORCE_COLOR: true,
+      },
     }
   );
 
@@ -176,6 +176,8 @@ export function* taskRun({ task }: Action): Saga<void> {
 
   const stdioChannel = createStdioChannel(child, {
     stdout: emitter => data => {
+      const text = stripUnusableControlCharacters(data.toString());
+
       // The 'eject' task prompts the user, to ask if they're sure.
       // We can bypass this prompt, as our UI already has an alert that
       // confirms this action.
@@ -191,10 +193,12 @@ export function* taskRun({ task }: Action): Saga<void> {
         sendCommandToProcess(child, 'y');
       }
 
-      emitter({ channel: 'stdout', text: data.toString() });
+      emitter({ channel: 'stdout', text });
     },
     stderr: emitter => data => {
-      emitter({ channel: 'stderr', text: data.toString() });
+      const text = stripUnusableControlCharacters(data.toString());
+
+      emitter({ channel: 'stderr', text });
     },
     exit: emitter => code => {
       const timestamp = new Date();
@@ -207,14 +211,15 @@ export function* taskRun({ task }: Action): Saga<void> {
   while (true) {
     const message = yield take(stdioChannel);
 
-    // eslint-disable-next-line default-case
     switch (message.channel) {
       case 'stdout':
         yield put(receiveDataFromTaskExecution(task, message.text));
         break;
+
       case 'stderr':
         yield put(receiveDataFromTaskExecution(task, message.text));
         break;
+
       case 'exit':
         yield call(displayTaskComplete, task, message.wasSuccessful);
         yield put(completeTask(task, message.timestamp, message.wasSuccessful));
@@ -222,6 +227,9 @@ export function* taskRun({ task }: Action): Saga<void> {
           yield put(loadDependencyInfoFromDisk(project.id, project.path));
         }
         break;
+
+      default:
+        throw new Error('Unexpected channel for message: ' + message.channel);
     }
   }
 }
@@ -300,12 +308,12 @@ const createStdioChannel = (
       // it will throw
     };
 
-    // TODO: if this channel is ever used with async handlers, make sure to
+    // NOTE: if this channel is ever used with async handlers, make sure to
     // use an expanding buffer in order to avoid losing any information
     // passed up by the child process. Initialize it at a length of 2 because
     // at bare minimum we expect to have 2 messages queued at some point (as
     // the exit channel completes, it should emit the return code of the process
-    // and then immediately END.
+    // and then immediately END.)
   });
 };
 
@@ -320,17 +328,26 @@ export const getDevServerCommand = (
         args: ['run', task.name],
         env: {
           PORT: port,
+          FORCE_COLOR: true,
         },
       };
     case 'gatsby':
       return {
         args: ['run', task.name, '-p', port],
-        env: {},
+        env: {
+          FORCE_COLOR: true,
+        },
       };
     default:
       throw new Error('Unrecognized project type: ' + projectType);
   }
 };
+
+export const stripUnusableControlCharacters = (text: string) =>
+  // The control character '[1G' is meant to "Clear vertical tab stop at
+  // current line". Unfortunately, it isn't correctly parsed, and shows
+  // up in the output as "G".
+  text.replace(/\[1G/g, '');
 
 export const sendCommandToProcess = (child: any, command: string) => {
   // Commands have to be suffixed with '\n' to signal that the command is

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -56,6 +56,10 @@ export const getBaseProjectEnvironment = (
   currentEnvironment: Object = window.process.env
 ) => ({
   ...currentEnvironment,
+  // NOTE: this option adds control characters to the output.
+  // If at some point we need "raw" output with no control characters, we
+  // should move this out into a "wrapping" function, and update current
+  // callsites to use it.
   FORCE_COLOR: true,
   PATH:
     currentEnvironment.PATH +

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -44,10 +44,21 @@ export const PACKAGE_MANAGER_CMD = path.join(
 // Forward the host env, and append the
 // project's .bin directory to PATH to allow
 // package scripts to function properly.
-export const getBaseProjectEnvironment = (projectPath: string) => ({
-  ...window.process.env,
+/**
+ * For running tasks in a cross-platform manner, this helper does a few things:
+ *  - Forward the host environment
+ *  - Append the project's .bin directory to PATH to allow package scripts to
+ *    function properly.
+ *  - Add `FORCE_COLOR: true`, so that terminal output includes color codes.
+ */
+export const getBaseProjectEnvironment = (
+  projectPath: string,
+  currentEnvironment: Object = window.process.env
+) => ({
+  ...currentEnvironment,
+  FORCE_COLOR: true,
   PATH:
-    window.process.env.PATH +
+    currentEnvironment.PATH +
     path.delimiter +
     path.join(projectPath, 'node_modules', '.bin'),
 });

--- a/src/services/platform.service.test.js
+++ b/src/services/platform.service.test.js
@@ -1,0 +1,23 @@
+// @flow
+import path from 'path';
+
+import { getBaseProjectEnvironment } from './platform.service';
+
+describe('Platform service', () => {
+  describe('getBaseProjectEnvironment', () => {
+    it('returns a valid PATH', () => {
+      const baseEnv = getBaseProjectEnvironment('hello-world', {});
+
+      expect(baseEnv.PATH).toBeTruthy();
+      expect(
+        baseEnv.PATH.indexOf(path.join('hello-world', 'node_modules', '.bin'))
+      ).toBeGreaterThan(0);
+    });
+
+    it('includes FORCE_COLOR: true', () => {
+      const baseEnv = getBaseProjectEnvironment('hello-world', {});
+
+      expect(baseEnv.FORCE_COLOR).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION

**Related Issue:** closes #30 

**Summary:**
Our terminal output hasn't been displaying the ANSI color codes that commands have been generating. This has led to very bland terminal output.

This change fixes that, by enabling an environment variable that includes those color codes, and then also fixes a display quirk by stripping out an unused control character.

**Screenshots/GIFs:**
<img width="712" alt="screen shot 2018-09-09 at 8 19 00 am" src="https://user-images.githubusercontent.com/6692932/45264340-08320000-b409-11e8-9c2c-e1c3983eed40.png">
<img width="976" alt="screen shot 2018-09-09 at 8 18 49 am" src="https://user-images.githubusercontent.com/6692932/45264341-08320000-b409-11e8-98e0-c810ff671a5b.png">
<img width="674" alt="screen shot 2018-09-09 at 8 14 51 am" src="https://user-images.githubusercontent.com/6692932/45264342-08320000-b409-11e8-8e7c-d1b6e232edaa.png">
