### PR TITLE
Added project selection & Show project settings to Application menu

### DIFF
--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -191,7 +191,7 @@ class ApplicationMenu extends Component<Props> {
         {
           label: isMac ? 'Open Settings' : 'Open settings',
           click: () => showProjectSettings(),
-          accelerator: 'CmdOrCtrl+,',
+          accelerator: 'CmdOrCtrl+shift+,',
         },
         { type: 'separator' },
       ];

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -191,7 +191,7 @@ class ApplicationMenu extends Component<Props> {
         {
           label: isMac ? 'Open Settings' : 'Open settings',
           click: () => showProjectSettings(),
-          accelerator: 'CmdOrCtrl+shift+S',
+          accelerator: 'CmdOrCtrl+,',
         },
         { type: 'separator' },
       ];
@@ -248,6 +248,22 @@ class ApplicationMenu extends Component<Props> {
   }
 }
 
+// helpers
+export const createProjectSelectionSubmenu = (
+  projects: Array<Project>,
+  selectedProjectId: string,
+  selectProject: (id: string) => any
+): any => {
+  const isSelected = testId => testId === selectedProjectId;
+
+  return projects.map(({ name, id }) => ({
+    label: name,
+    type: isSelected(id) ? 'checkbox' : 'normal',
+    checked: isSelected(id),
+    click: () => selectProject(id),
+  }));
+};
+
 const mapStateToProps = state => {
   const selectedProject = getSelectedProject(state);
 
@@ -277,19 +293,3 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(ApplicationMenu);
-
-// helpers
-export const createProjectSelectionSubmenu = (
-  projects: Array<Project>,
-  selectedProjectId: string,
-  selectProject: (id: string) => any
-): any => {
-  const isSelected = testId => testId === selectedProjectId;
-
-  return projects.map(({ name, id }) => ({
-    label: name,
-    type: isSelected(id) ? 'checkbox' : 'normal',
-    checked: isSelected(id),
-    click: () => selectProject(id),
-  }));
-};

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -16,7 +16,10 @@ import {
   openProjectInFolder,
   openProjectInEditor,
 } from '../../services/shell.service';
-import { getSelectedProject } from '../../reducers/projects.reducer';
+import {
+  getSelectedProject,
+  getProjectsArray,
+} from '../../reducers/projects.reducer';
 import { getDevServerTaskForProjectId } from '../../reducers/tasks.reducer';
 
 import type { Project, Task } from '../../types';
@@ -24,6 +27,7 @@ import type { Project, Task } from '../../types';
 const { app, process, Menu } = remote;
 
 type Props = {
+  projects: Array<Project>,
   selectedProject: ?Project,
   devServerTask: ?Task,
   createNewProjectStart: () => any,
@@ -31,6 +35,8 @@ type Props = {
   clearConsole: (task: Task) => any,
   showDeleteProjectPrompt: (project: any) => any,
   showResetStatePrompt: () => any,
+  showProjectSettings: () => any,
+  selectProject: (projectId: string) => any,
 };
 
 class ApplicationMenu extends Component<Props> {
@@ -55,6 +61,9 @@ class ApplicationMenu extends Component<Props> {
       clearConsole,
       showDeleteProjectPrompt,
       showResetStatePrompt,
+      showProjectSettings,
+      selectProject,
+      projects,
     } = props;
 
     const template = [
@@ -179,6 +188,11 @@ class ApplicationMenu extends Component<Props> {
           click: () => openProjectInEditor(selectedProject),
           accelerator: 'CmdOrCtrl+shift+E',
         },
+        {
+          label: isMac ? 'Open Settings' : 'Open settings',
+          click: () => showProjectSettings(),
+          accelerator: 'CmdOrCtrl+shift+S',
+        },
         { type: 'separator' },
       ];
 
@@ -194,6 +208,19 @@ class ApplicationMenu extends Component<Props> {
       submenu.push({
         label: isMac ? 'Delete Project' : 'Delete project',
         click: () => showDeleteProjectPrompt(selectedProject),
+      });
+
+      submenu.push({ type: 'separator' });
+
+      // Checking projects length not needed as we're having more than one project if the Current Project menu is available
+      submenu.push({
+        label: isMac ? 'Select Project' : 'Select project',
+        id: 'select-project',
+        submenu: createProjectSelectionSubmenu(
+          projects,
+          selectedProject.id,
+          selectProject
+        ),
       });
 
       template.splice(editMenuIndex, 0, {
@@ -232,7 +259,8 @@ const mapStateToProps = state => {
       )
     : null;
 
-  return { selectedProject, devServerTask };
+  const projects = getProjectsArray(state);
+  return { selectedProject, devServerTask, projects };
 };
 
 const mapDispatchToProps = {
@@ -241,9 +269,27 @@ const mapDispatchToProps = {
   clearConsole: actions.clearConsole,
   showDeleteProjectPrompt: actions.showDeleteProjectPrompt,
   showResetStatePrompt: actions.showResetStatePrompt,
+  showProjectSettings: actions.showProjectSettings,
+  selectProject: actions.selectProject,
 };
 
 export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(ApplicationMenu);
+
+// helpers
+export const createProjectSelectionSubmenu = (
+  projects: Array<Project>,
+  selectedProjectId: string,
+  selectProject: (id: string) => any
+): any => {
+  const isSelected = testId => testId === selectedProjectId;
+
+  return projects.map(({ name, id }) => ({
+    label: name,
+    type: isSelected(id) ? 'checkbox' : 'normal',
+    checked: isSelected(id),
+    click: () => selectProject(id),
+  }));
+};


### PR DESCRIPTION
**Related Issue:**
#140
**Summary:**
Addressing the two open todos of the issue:
- Open settings
- Select Project submenu

I've added the open project settings button to the other opening commands. It opens the project settings modal. Accelerator Ctrl+, to match the other accelerators. I think there should be no collision with other keyboard shortcuts. 

Select project is using the native checkbox option from electron. So this could look different on other OS. The screenshot below is on Windows.

**Screenshots/GIFs:**
![grafik](https://user-images.githubusercontent.com/3046542/45320446-f18fc400-b542-11e8-9764-72994af5c192.png)
