### PR TITLE
Fix delete

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -357,7 +357,7 @@ export const saveProjectSettingsStart = (
 });
 
 export const saveProjectSettingsFinish = (
-  project: Project,
+  project: ProjectInternal,
   projectPath: string
 ) => ({
   type: SAVE_PROJECT_SETTINGS_FINISH,

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -79,6 +79,7 @@ class ProjectPage extends PureComponent<Props> {
             </PixelShifter>
             <SettingsButton />
           </FlexRow>
+
           <ProjectActionBar>
             <FillButton
               colors={COLORS.gray[200]}

--- a/src/reducers/app-loaded.reducer.js
+++ b/src/reducers/app-loaded.reducer.js
@@ -22,7 +22,7 @@ type State = boolean;
 
 const initialState = false;
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case REFRESH_PROJECTS_FINISH:
       return true;

--- a/src/reducers/dependencies.reducer.js
+++ b/src/reducers/dependencies.reducer.js
@@ -25,7 +25,7 @@ type State = {
 
 export const initialState = {};
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case LOAD_DEPENDENCY_INFO_FROM_DISK: {
       const { projectId, dependencies } = action;

--- a/src/reducers/dependencies.reducer.test.js
+++ b/src/reducers/dependencies.reducer.test.js
@@ -15,7 +15,7 @@ import {
 
 describe('dependencies reducer', () => {
   it('should return initial state', () => {
-    expect(reducer(undefined, {})).toEqual({});
+    expect(reducer()).toEqual({});
   });
 
   it(`should handle ${LOAD_DEPENDENCY_INFO_FROM_DISK}`, () => {

--- a/src/reducers/dependencies.reducer.test.js
+++ b/src/reducers/dependencies.reducer.test.js
@@ -1,7 +1,4 @@
-import reducer, {
-  getDependenciesForProjectId,
-  initialState,
-} from './dependencies.reducer';
+import reducer, { getDependenciesForProjectId } from './dependencies.reducer';
 import {
   LOAD_DEPENDENCY_INFO_FROM_DISK,
   ADD_DEPENDENCY,

--- a/src/reducers/modal.reducer.js
+++ b/src/reducers/modal.reducer.js
@@ -21,7 +21,7 @@ type State = 'new-project-wizard' | 'project-settings' | null;
 
 const initialState = null;
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case CREATE_NEW_PROJECT_START:
       return 'new-project-wizard';

--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -23,7 +23,7 @@ export type State =
 // TODO: Pull this from localStorage
 const initialState = 'brand-new';
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case CREATE_NEW_PROJECT_START:
     case IMPORT_EXISTING_PROJECT_START: {

--- a/src/reducers/paths.reducer.js
+++ b/src/reducers/paths.reducer.js
@@ -37,7 +37,7 @@ const homedir = isWin ? windowsHomeDir : os.homedir();
 // Noticing some weird quirks when I try to use a dev project on the compiled
 // "production" app, so separating their home paths should help.
 
-const initialState = {
+export const initialState = {
   homePath:
     process.env.NODE_ENV === 'development'
       ? path.join(homedir, 'guppy-projects-dev')
@@ -45,7 +45,7 @@ const initialState = {
   byId: {},
 };
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case ADD_PROJECT: {
       const { project } = action;
@@ -61,7 +61,7 @@ export default (state: State = initialState, action: Action) => {
     }
 
     case IMPORT_EXISTING_PROJECT_FINISH: {
-      const { projectPath, project } = action;
+      const { project, projectPath } = action;
 
       return produce(state, draftState => {
         draftState.byId[project.guppy.id] = projectPath;
@@ -87,7 +87,7 @@ export default (state: State = initialState, action: Action) => {
       const { projectId } = action;
 
       return produce(state, draftState => {
-        delete draftState[projectId];
+        delete draftState.byId[projectId];
       });
     }
 

--- a/src/reducers/paths.reducer.test.js
+++ b/src/reducers/paths.reducer.test.js
@@ -1,0 +1,175 @@
+import reducer, { initialState } from './paths.reducer';
+import {
+  IMPORT_EXISTING_PROJECT_FINISH,
+  ADD_PROJECT,
+  SAVE_PROJECT_SETTINGS_FINISH,
+  CHANGE_PROJECT_HOME_PATH,
+  FINISH_DELETING_PROJECT,
+  RESET_ALL_STATE,
+} from '../actions';
+
+// The paths reducer initial state chooses a platform-specific home path.
+// To avoid dealing with all that, we'll just supply an initial state in
+// all tests
+const platformSafeInitialState = {
+  homePath: 'path/to/projects',
+  byId: {},
+};
+
+describe('Tasks reducer', () => {
+  it('should return initial state', () => {
+    expect(reducer()).toEqual(initialState);
+  });
+
+  describe(ADD_PROJECT, () => {
+    it('adds path info for new projects', () => {
+      const prevState = platformSafeInitialState;
+
+      const action = {
+        type: ADD_PROJECT,
+        project: {
+          name: 'Hello World',
+          guppy: { id: 'fds8fd7s97f', name: 'hello-world' },
+          scripts: {
+            start: 'react-scripts start',
+          },
+        },
+      };
+
+      expect(reducer(prevState, action)).toMatchInlineSnapshot(`
+Object {
+  "byId": Object {
+    "fds8fd7s97f": "path/to/projects/hello-world",
+  },
+  "homePath": "path/to/projects",
+}
+`);
+    });
+  });
+
+  describe(IMPORT_EXISTING_PROJECT_FINISH, () => {
+    it('adds path info for imported projects', () => {
+      const prevState = platformSafeInitialState;
+
+      const action = {
+        type: IMPORT_EXISTING_PROJECT_FINISH,
+        project: {
+          name: 'hello-world',
+          guppy: { id: 'abc123456789', name: 'Hello World' },
+          scripts: {
+            start: 'react-scripts start',
+          },
+        },
+        projectPath: 'Users/john_doe/work',
+      };
+
+      expect(reducer(prevState, action)).toMatchInlineSnapshot(`
+Object {
+  "byId": Object {
+    "abc123456789": "Users/john_doe/work",
+  },
+  "homePath": "path/to/projects",
+}
+`);
+    });
+  });
+
+  describe(SAVE_PROJECT_SETTINGS_FINISH, () => {
+    it('saves a new path for an existing project', () => {
+      const prevState = {
+        ...platformSafeInitialState,
+        byId: {
+          xyz789: 'some/outdated/path',
+        },
+      };
+
+      const action = {
+        type: SAVE_PROJECT_SETTINGS_FINISH,
+        project: {
+          name: 'goodbye-world',
+          guppy: { id: 'xyz789', name: 'Goodbye World' },
+          scripts: {
+            start: 'react-scripts start',
+          },
+        },
+        projectPath: 'Users/john_doe/work',
+      };
+
+      expect(reducer(prevState, action)).toMatchInlineSnapshot(`
+Object {
+  "byId": Object {
+    "xyz789": "Users/john_doe/work",
+  },
+  "homePath": "path/to/projects",
+}
+`);
+    });
+  });
+
+  describe(CHANGE_PROJECT_HOME_PATH, () => {
+    it('updates the `homePath` field', () => {
+      const prevState = {
+        byId: {
+          abcxyz: 'this/is/home',
+        },
+        homePath: 'this/is/home',
+      };
+
+      const action = {
+        type: CHANGE_PROJECT_HOME_PATH,
+        homePath: 'Users/john_doe/work',
+      };
+
+      expect(reducer(prevState, action)).toMatchInlineSnapshot(`
+Object {
+  "byId": Object {
+    "abcxyz": "this/is/home",
+  },
+  "homePath": "Users/john_doe/work",
+}
+`);
+    });
+  });
+
+  describe(FINISH_DELETING_PROJECT, () => {
+    it('removes the specified project ID from `byId`', () => {
+      const prevState = {
+        ...platformSafeInitialState,
+        byId: {
+          abcxyz: 'this/is/home',
+          defuvw: 'this/is/home',
+        },
+      };
+
+      const action = {
+        type: FINISH_DELETING_PROJECT,
+        projectId: 'defuvw',
+      };
+
+      expect(reducer(prevState, action)).toMatchInlineSnapshot(`
+Object {
+  "byId": Object {
+    "abcxyz": "this/is/home",
+  },
+  "homePath": "path/to/projects",
+}
+`);
+    });
+  });
+
+  describe(RESET_ALL_STATE, () => {
+    it('restores the original state', () => {
+      const prevState = {
+        ...platformSafeInitialState,
+        byId: {
+          abcxyz: 'this/is/home',
+          defuvw: 'this/is/home',
+        },
+      };
+
+      const action = { type: RESET_ALL_STATE };
+
+      expect(reducer(prevState, action)).toEqual(initialState);
+    });
+  });
+});

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -35,7 +35,7 @@ export const initialState = {
   selectedId: null,
 };
 
-const byIdReducer = (state: ById = initialState.byId, action: Action) => {
+const byIdReducer = (state: ById = initialState.byId, action: Action = {}) => {
   switch (action.type) {
     case REFRESH_PROJECTS_FINISH: {
       return action.projects;
@@ -89,7 +89,7 @@ const byIdReducer = (state: ById = initialState.byId, action: Action) => {
 
 const selectedIdReducer = (
   state: SelectedId = initialState.selectedId,
-  action: Action
+  action: Action = {}
 ) => {
   switch (action.type) {
     case ADD_PROJECT:

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -128,8 +128,18 @@ const selectedIdReducer = (
       return action.projectId;
     }
 
-    case RESET_ALL_STATE:
+    case FINISH_DELETING_PROJECT: {
+      // Right now, it is only possible to delete the currently-selected
+      // project, so this condition will always be true. This is a guard against
+      // future changes.
+      const justDeletedSelectedProject = action.projectId === state;
+
+      return justDeletedSelectedProject ? null : state;
+    }
+
+    case RESET_ALL_STATE: {
       return initialState.selectedId;
+    }
 
     default:
       return state;

--- a/src/reducers/queue.reducer.js
+++ b/src/reducers/queue.reducer.js
@@ -26,7 +26,7 @@ type State = {
 
 const initialState = {};
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case QUEUE_DEPENDENCY_INSTALL: {
       const { projectId, name, version, updating } = action;

--- a/src/reducers/queue.reducer.test.js
+++ b/src/reducers/queue.reducer.test.js
@@ -8,7 +8,7 @@ import {
 
 describe('queue reducer', () => {
   it('should return initial state', () => {
-    expect(reducer(undefined, {})).toEqual({});
+    expect(reducer()).toEqual({});
   });
 
   it(`should handle queue item start`, () => {

--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -42,7 +42,7 @@ type State = {
 
 export const initialState = {};
 
-export default (state: State = initialState, action: Action) => {
+export default (state: State = initialState, action: Action = {}) => {
   switch (action.type) {
     case REFRESH_PROJECTS_FINISH: {
       return produce(state, draftState => {

--- a/src/reducers/tasks.reducer.test.js
+++ b/src/reducers/tasks.reducer.test.js
@@ -11,7 +11,7 @@ import reducer, { getTaskDescription, initialState } from './tasks.reducer';
 describe('Tasks reducer', () => {
   describe(REFRESH_PROJECTS_FINISH, () => {
     it('captures task data from new projects', () => {
-      const prevState = reducer(undefined, {});
+      const prevState = reducer();
 
       const action = {
         type: REFRESH_PROJECTS_FINISH,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7672,6 +7672,10 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
+mixpanel-browser@2.22.4:
+  version "2.22.4"
+  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.22.4.tgz#f1d57a2c2f50801f57357fb16f38288bcee3cc7d"
+
 mkdirp@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7672,10 +7672,6 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mixpanel-browser@2.22.4:
-  version "2.22.4"
-  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.22.4.tgz#f1d57a2c2f50801f57357fb16f38288bcee3cc7d"
-
 mkdirp@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"


### PR DESCRIPTION
**Related Issue:** closes #246 


**Summary:**
Projects couldn't be deleted, as described in #246.

Additionally, this PR fixes an issue we've had with our tests: they weren't actually getting "realistic" initial state, since default values aren't used when you supply `undefined`. I updated all the reducers to make the `action` argument optional, so that the tests could actually use the initial state by running `reducer()`