### PR TITLE
Fix issue with dependencies, among other selector issues

### DIFF
--- a/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
+++ b/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
@@ -28,7 +28,7 @@ const iconSrcs: Array<string> = Object.values(icons).map(src => String(src));
 type Props = {
   project: Project | null,
   isVisible: boolean,
-  dependenciesChangingForProject: boolean,
+  dependenciesChangingForProject: ?boolean,
   hideModal: () => void,
   saveProjectSettings: (string, string, Project) => void,
 };
@@ -193,14 +193,20 @@ const DisabledText = styled.div`
   color: ${COLORS.gray[500]};
 `;
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = state => {
   const project = getSelectedProject(state);
   const projectId = project && project.id;
+
+  // This component is rendered even when no project is selected.
+  // In that case, this prop isn't applicable.
+  const dependenciesChangingForProject = projectId
+    ? !isQueueEmpty(state, { projectId })
+    : null;
 
   return {
     project,
     isVisible: state.modal === 'project-settings',
-    dependenciesChangingForProject: !isQueueEmpty(state, projectId || ''),
+    dependenciesChangingForProject,
   };
 };
 

--- a/src/reducers/projects.reducer.js
+++ b/src/reducers/projects.reducer.js
@@ -186,8 +186,15 @@ const prepareProjectForConsumption = (
     color: project.guppy.color,
     icon: project.guppy.icon,
     createdAt: project.guppy.createdAt,
-    tasks,
-    dependencies,
+    // prettier-ignore
+    tasks: tasks
+      ? Object.keys(tasks).map(taskId => tasks[taskId])
+      : [],
+    dependencies: dependencies
+      ? Object.keys(dependencies).map(
+          dependencyId => dependencies[dependencyId]
+        )
+      : [],
     path,
   };
 };

--- a/src/reducers/queue.reducer.js
+++ b/src/reducers/queue.reducer.js
@@ -132,8 +132,10 @@ export default (state: State = initialState, action: Action = {}) => {
 //
 //
 // Selectors
-export const getNextActionForProjectId = (state: any, projectId: string) =>
-  state.queue[projectId] && state.queue[projectId][0];
+export const getNextActionForProjectId = (
+  state: any,
+  props: { projectId: string }
+) => state.queue[props.projectId] && state.queue[props.projectId][0];
 
-export const isQueueEmpty = (state: any, projectId: string) =>
-  !getNextActionForProjectId(state, projectId);
+export const isQueueEmpty = (state: any, props: { projectId: string }) =>
+  !getNextActionForProjectId(state, props);

--- a/src/reducers/queue.reducer.test.js
+++ b/src/reducers/queue.reducer.test.js
@@ -298,7 +298,7 @@ Object {
 
       const projectId = 'foo';
 
-      expect(getNextActionForProjectId(state, projectId))
+      expect(getNextActionForProjectId(state, { projectId }))
         .toMatchInlineSnapshot(`
 Object {
   "action": "install",
@@ -318,7 +318,7 @@ Object {
 
       const projectId = 'foo';
 
-      expect(getNextActionForProjectId(state, projectId)).toBe(undefined);
+      expect(getNextActionForProjectId(state, { projectId })).toBe(undefined);
     });
   });
 });

--- a/src/sagas/dependency.saga.js
+++ b/src/sagas/dependency.saga.js
@@ -30,7 +30,7 @@ export function* handleAddDependency({
   dependencyName,
   version,
 }: Action): Saga<void> {
-  const queuedAction = yield select(getNextActionForProjectId, projectId);
+  const queuedAction = yield select(getNextActionForProjectId, { projectId });
 
   yield put(queueDependencyInstall(projectId, dependencyName, version));
 
@@ -45,7 +45,7 @@ export function* handleUpdateDependency({
   dependencyName,
   latestVersion,
 }: Action): Saga<void> {
-  const queuedAction = yield select(getNextActionForProjectId, projectId);
+  const queuedAction = yield select(getNextActionForProjectId, { projectId });
 
   yield put(
     queueDependencyInstall(projectId, dependencyName, latestVersion, true)
@@ -60,7 +60,7 @@ export function* handleDeleteDependency({
   projectId,
   dependencyName,
 }: Action): Saga<void> {
-  const queuedAction = yield select(getNextActionForProjectId, projectId);
+  const queuedAction = yield select(getNextActionForProjectId, { projectId });
 
   yield put(queueDependencyUninstall(projectId, dependencyName));
 
@@ -73,7 +73,7 @@ export function* handleInstallDependenciesStart({
   projectId,
   dependencies,
 }: Action): Saga<void> {
-  const projectPath = yield select(getPathForProjectId, projectId);
+  const projectPath = yield select(getPathForProjectId, { projectId });
 
   try {
     yield call(installDependencies, projectPath, dependencies);
@@ -93,7 +93,7 @@ export function* handleUninstallDependenciesStart({
   projectId,
   dependencies,
 }: Action): Saga<void> {
-  const projectPath = yield select(getPathForProjectId, projectId);
+  const projectPath = yield select(getPathForProjectId, { projectId });
 
   try {
     yield call(uninstallDependencies, projectPath, dependencies);

--- a/src/sagas/dependency.saga.test.js
+++ b/src/sagas/dependency.saga.test.js
@@ -52,7 +52,7 @@ describe('Dependency sagas', () => {
       const queuedAction = null;
 
       expect(saga.next().value).toEqual(
-        select(getNextActionForProjectId, projectId)
+        select(getNextActionForProjectId, { projectId })
       );
       expect(saga.next(queuedAction).value).toEqual(
         put(
@@ -71,7 +71,7 @@ describe('Dependency sagas', () => {
       };
 
       expect(saga.next().value).toEqual(
-        select(getNextActionForProjectId, projectId)
+        select(getNextActionForProjectId, { projectId })
       );
       expect(saga.next(queuedAction).value).toEqual(
         put(
@@ -103,7 +103,7 @@ describe('Dependency sagas', () => {
       const queuedAction = false;
 
       expect(saga.next().value).toEqual(
-        select(getNextActionForProjectId, projectId)
+        select(getNextActionForProjectId, { projectId })
       );
       expect(saga.next(queuedAction).value).toEqual(
         put(
@@ -127,7 +127,7 @@ describe('Dependency sagas', () => {
       };
 
       expect(saga.next().value).toEqual(
-        select(getNextActionForProjectId, projectId)
+        select(getNextActionForProjectId, { projectId })
       );
       expect(saga.next(queuedAction).value).toEqual(
         put(
@@ -162,7 +162,7 @@ describe('Dependency sagas', () => {
       const queuedAction = null;
 
       expect(saga.next().value).toEqual(
-        select(getNextActionForProjectId, projectId)
+        select(getNextActionForProjectId, { projectId })
       );
       expect(saga.next(queuedAction).value).toEqual(
         put(queueDependencyUninstall(projectId, dependency.name))
@@ -179,7 +179,7 @@ describe('Dependency sagas', () => {
       };
 
       expect(saga.next().value).toEqual(
-        select(getNextActionForProjectId, projectId)
+        select(getNextActionForProjectId, { projectId })
       );
       expect(saga.next(queuedAction).value).toEqual(
         put(queueDependencyUninstall(projectId, dependency.name))
@@ -218,7 +218,9 @@ describe('Dependency sagas', () => {
         },
       ];
 
-      expect(saga.next().value).toEqual(select(getPathForProjectId, projectId));
+      expect(saga.next().value).toEqual(
+        select(getPathForProjectId, { projectId })
+      );
       expect(saga.next(projectPath).value).toEqual(
         call(installDependencies, projectPath, action.dependencies)
       );
@@ -234,7 +236,9 @@ describe('Dependency sagas', () => {
     it('should handle error', () => {
       const error = new Error('oops');
 
-      expect(saga.next().value).toEqual(select(getPathForProjectId, projectId));
+      expect(saga.next().value).toEqual(
+        select(getPathForProjectId, { projectId })
+      );
       saga.next(projectPath);
       expect(saga.throw(error).value).toEqual(
         call([console, console.error], 'Failed to install dependencies', error)
@@ -258,7 +262,9 @@ describe('Dependency sagas', () => {
     });
 
     it('should uninstall dependencies', () => {
-      expect(saga.next().value).toEqual(select(getPathForProjectId, projectId));
+      expect(saga.next().value).toEqual(
+        select(getPathForProjectId, { projectId })
+      );
       expect(saga.next(projectPath).value).toEqual(
         call(uninstallDependencies, projectPath, action.dependencies)
       );
@@ -271,7 +277,9 @@ describe('Dependency sagas', () => {
     it('should handle error', () => {
       const error = new Error('oops');
 
-      expect(saga.next().value).toEqual(select(getPathForProjectId, projectId));
+      expect(saga.next().value).toEqual(
+        select(getPathForProjectId, { projectId })
+      );
       saga.next(projectPath);
       expect(saga.throw(error).value).toEqual(
         call(

--- a/src/sagas/queue.saga.js
+++ b/src/sagas/queue.saga.js
@@ -16,7 +16,7 @@ import type { Action } from 'redux';
 import type { Saga } from 'redux-saga';
 
 export function* handleQueueActionCompleted({ projectId }: Action): Saga<void> {
-  const nextAction = yield select(getNextActionForProjectId, projectId);
+  const nextAction = yield select(getNextActionForProjectId, { projectId });
 
   // if there is another item in the queue, start it
   if (nextAction) {
@@ -27,7 +27,7 @@ export function* handleQueueActionCompleted({ projectId }: Action): Saga<void> {
 export function* handleStartNextActionInQueue({
   projectId,
 }: Action): Saga<void> {
-  const nextAction = yield select(getNextActionForProjectId, projectId);
+  const nextAction = yield select(getNextActionForProjectId, { projectId });
 
   // if the queue is empty, take no further action
   if (!nextAction) return;

--- a/src/sagas/queue.saga.test.js
+++ b/src/sagas/queue.saga.test.js
@@ -29,7 +29,7 @@ describe('handleQueueActionCompleted saga', () => {
     };
 
     expect(saga.next().value).toEqual(
-      select(getNextActionForProjectId, projectId)
+      select(getNextActionForProjectId, { projectId })
     );
     expect(saga.next(nextAction).value).toEqual(
       put(startNextActionInQueue(projectId))
@@ -41,7 +41,7 @@ describe('handleQueueActionCompleted saga', () => {
     const saga = handleQueueActionCompleted({ projectId });
 
     expect(saga.next().value).toEqual(
-      select(getNextActionForProjectId, projectId)
+      select(getNextActionForProjectId, { projectId })
     );
     expect(saga.next().done).toBe(true);
   });
@@ -57,7 +57,7 @@ describe('handleStartNextActionInQueue saga', () => {
 
   it('should do nothing if the queue is empty', () => {
     expect(saga.next().value).toEqual(
-      select(getNextActionForProjectId, projectId)
+      select(getNextActionForProjectId, { projectId })
     );
     expect(saga.next().done).toBe(true);
   });
@@ -69,7 +69,7 @@ describe('handleStartNextActionInQueue saga', () => {
     };
 
     expect(saga.next().value).toEqual(
-      select(getNextActionForProjectId, projectId)
+      select(getNextActionForProjectId, { projectId })
     );
     expect(saga.next(nextAction).value).toEqual(
       put(installDependenciesStart(projectId, nextAction.dependencies))
@@ -83,7 +83,7 @@ describe('handleStartNextActionInQueue saga', () => {
     };
 
     expect(saga.next().value).toEqual(
-      select(getNextActionForProjectId, projectId)
+      select(getNextActionForProjectId, { projectId })
     );
     expect(saga.next(nextAction).value).toEqual(
       put(uninstallDependenciesStart(projectId, nextAction.dependencies))

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -136,7 +136,9 @@ export function* launchDevServer({ task }: Action): Saga<void> {
 
 export function* taskRun({ task }: Action): Saga<void> {
   const project = yield select(getProjectById, { projectId: task.projectId });
-  const projectPath = yield select(getPathForProjectId, task.projectId);
+  const projectPath = yield select(getPathForProjectId, {
+    projectId: task.projectId,
+  });
   const { name } = task;
 
   // TEMPORARY HACK


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
closes #251 

**Summary:**
Shoot, so yesterday I merged some code that memoized our redux selectors. Kinda late in that PR I changed it so that selectors had a new format: `selector(state, props: {arg1, arg2})` (instead of `selector(state, arg1, arg2, ...)`). This is how `reselect` wants it to be formatted, since it can easily do a shallow-compare on the `props` object and use that for memoization (I'm guessing, at least? I didn't dig into this).

Unfortunately, I didn't do a very good job checking that everything still worked. Part of this was after merging master, but some of it was just my own negligence :/ I kinda thought Flow would catch anything I missed, but it's not smart enough to unpack saga `select` statements.

This PR fixes a number of issues around that, including:
- Missing dependency pane
- Dependencies installing to Guppy instead of the target project
- Build/test/eject tasks not able to run