### PR TITLE
Disable build while the queue is active

### DIFF
--- a/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
+++ b/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
@@ -28,7 +28,7 @@ const iconSrcs: Array<string> = Object.values(icons).map(src => String(src));
 type Props = {
   project: Project | null,
   isVisible: boolean,
-  dependenciesChangingForProject: ?boolean,
+  dependenciesChangingForProject: boolean,
   hideModal: () => void,
   saveProjectSettings: (string, string, Project) => void,
 };

--- a/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
+++ b/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
@@ -8,7 +8,7 @@ import * as actions from '../../actions';
 
 import { COLORS } from '../../constants';
 import { getSelectedProject } from '../../reducers/projects.reducer';
-import { isQueueEmpty } from '../../reducers/queue.reducer';
+import { getIsQueueEmpty } from '../../reducers/queue.reducer';
 
 import Modal from '../Modal';
 import ModalHeader from '../ModalHeader';
@@ -197,7 +197,7 @@ const mapStateToProps = state => {
   const project = getSelectedProject(state);
   const projectId = project && project.id;
 
-  const dependenciesChangingForProject = isQueueEmpty(state, { projectId });
+  const dependenciesChangingForProject = getIsQueueEmpty(state, { projectId });
 
   return {
     project,

--- a/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
+++ b/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
@@ -197,7 +197,7 @@ const mapStateToProps = state => {
   const project = getSelectedProject(state);
   const projectId = project && project.id;
 
-  const dependenciesChangingForProject = getIsQueueEmpty(state, { projectId });
+  const dependenciesChangingForProject = !getIsQueueEmpty(state, { projectId });
 
   return {
     project,

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -106,7 +106,7 @@ class ProjectPage extends PureComponent<Props> {
           <DevelopmentServerPane leftSideWidth={300} />
 
           <Spacer size={30} />
-          <TaskRunnerPane leftSideWidth={200} projectId={project.id} />
+          <TaskRunnerPane leftSideWidth={200} />
 
           {project.dependencies.length > 0 && (
             <Fragment>

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -106,7 +106,7 @@ class ProjectPage extends PureComponent<Props> {
           <DevelopmentServerPane leftSideWidth={300} />
 
           <Spacer size={30} />
-          <TaskRunnerPane leftSideWidth={200} />
+          <TaskRunnerPane leftSideWidth={200} projectId={project.id} />
 
           {project.dependencies.length > 0 && (
             <Fragment>

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -7,7 +7,12 @@ import moment from 'moment';
 import * as actions from '../../actions';
 import { COLORS } from '../../constants';
 import { capitalize } from '../../utils';
-import { getTaskByProjectIdAndTaskName } from '../../reducers/tasks.reducer';
+import { getSelectedProjectId } from '../../reducers/projects.reducer';
+import {
+  getTaskByProjectIdAndTaskName,
+  isTaskDisabled,
+} from '../../reducers/tasks.reducer';
+import { getIsQueueEmpty } from '../../reducers/queue.reducer';
 
 import Modal from '../Modal';
 import ModalHeader from '../ModalHeader';
@@ -23,6 +28,7 @@ type Props = {
   projectId: string,
   taskName: ?string,
   isVisible: boolean,
+  isDisabled: boolean,
   onDismiss: () => void,
   // From Redux:
   task: Task,
@@ -114,7 +120,7 @@ class TaskDetailsModal extends PureComponent<Props> {
   };
 
   renderContents() {
-    const { task, isVisible } = this.props;
+    const { task, isVisible, isDisabled } = this.props;
 
     if (!isVisible) {
       return null;
@@ -148,6 +154,7 @@ class TaskDetailsModal extends PureComponent<Props> {
             ) : (
               <Toggle
                 size={32}
+                isDisabled={isDisabled}
                 isToggled={isRunning}
                 onToggle={this.handleToggle}
               />
@@ -226,9 +233,21 @@ const HorizontalRule = styled.div`
   border-bottom: 1px solid ${COLORS.gray[200]};
 `;
 
-const mapStateToProps = (state, ownProps) => ({
-  task: getTaskByProjectIdAndTaskName(state, ownProps),
-});
+const mapStateToProps = (state, ownProps) => {
+  const selectedProjectId = getSelectedProjectId(state);
+
+  const dependenciesChangingForProject =
+    !!selectedProjectId && !getIsQueueEmpty(state, selectedProjectId);
+
+  const task = getTaskByProjectIdAndTaskName(state, ownProps);
+
+  const isDisabled =
+    task && isTaskDisabled(task, dependenciesChangingForProject);
+  return {
+    task,
+    isDisabled,
+  };
+};
 
 export default connect(
   mapStateToProps,

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -7,7 +7,6 @@ import moment from 'moment';
 import * as actions from '../../actions';
 import { COLORS } from '../../constants';
 import { capitalize } from '../../utils';
-import { getSelectedProjectId } from '../../reducers/projects.reducer';
 import {
   getTaskByProjectIdAndTaskName,
   isTaskDisabled,

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -234,12 +234,9 @@ const HorizontalRule = styled.div`
 `;
 
 const mapStateToProps = (state, ownProps) => {
-  const selectedProjectId = getSelectedProjectId(state);
-
-  const dependenciesChangingForProject =
-    !!selectedProjectId && !getIsQueueEmpty(state, selectedProjectId);
-
+  const dependenciesChangingForProject = !getIsQueueEmpty(state, ownProps);
   const task = getTaskByProjectIdAndTaskName(state, ownProps);
+
   const isDisabled =
     task && isTaskDisabled(task, dependenciesChangingForProject);
 

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -240,9 +240,9 @@ const mapStateToProps = (state, ownProps) => {
     !!selectedProjectId && !getIsQueueEmpty(state, selectedProjectId);
 
   const task = getTaskByProjectIdAndTaskName(state, ownProps);
-
   const isDisabled =
     task && isTaskDisabled(task, dependenciesChangingForProject);
+
   return {
     task,
     isDisabled,

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -5,7 +5,10 @@ import { connect } from 'react-redux';
 import * as actions from '../../actions';
 import { GUPPY_REPO_URL } from '../../constants';
 import { getSelectedProjectId } from '../../reducers/projects.reducer';
-import { getTasksInTaskListForProjectId } from '../../reducers/tasks.reducer';
+import {
+  getTasksInTaskListForProjectId,
+  isTaskDisabled,
+} from '../../reducers/tasks.reducer';
 import { getIsQueueEmpty } from '../../reducers/queue.reducer';
 
 import Module from '../Module';
@@ -43,18 +46,6 @@ class TaskRunnerPane extends Component<Props, State> {
     }
   }
 
-  isTaskDisabled = (taskName: string) => {
-    const { dependenciesChangingForProject } = this.props;
-
-    // We want to lock the 'build' task while dependencies are being changed,
-    // as builds will likely fail during this time.
-    if (taskName === 'build') {
-      return dependenciesChangingForProject;
-    }
-
-    return false;
-  };
-
   handleToggleTask = (taskName: string) => {
     const { tasks, runTask, abortTask } = this.props;
 
@@ -82,7 +73,7 @@ class TaskRunnerPane extends Component<Props, State> {
   };
 
   render() {
-    const { tasks } = this.props;
+    const { tasks, dependenciesChangingForProject } = this.props;
     const { selectedTaskName } = this.state;
 
     if (tasks.length === 0) {
@@ -106,7 +97,7 @@ class TaskRunnerPane extends Component<Props, State> {
             description={task.description}
             status={task.status}
             processId={task.processId}
-            disabled={this.isTaskDisabled(task.name)}
+            isDisabled={isTaskDisabled(task, dependenciesChangingForProject)}
             onToggleTask={this.handleToggleTask}
             onViewDetails={this.handleViewDetails}
           />

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -18,6 +18,7 @@ import TaskDetailsModal from '../TaskDetailsModal';
 import type { Task } from '../../types';
 
 type Props = {
+  projectId: string,
   tasks: Array<Task>,
   runTask: Function,
   abortTask: Function,
@@ -114,14 +115,12 @@ class TaskRunnerPane extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = state => {
-  const selectedProjectId = getSelectedProjectId(state);
-
+const mapStateToProps = (state, ownProps) => {
   const dependenciesChangingForProject =
-    selectedProjectId && !getIsQueueEmpty(state, selectedProjectId);
+    ownProps.projectId && !getIsQueueEmpty(state, ownProps);
 
-  const tasks = selectedProjectId
-    ? getTasksInTaskListForProjectId(state, { projectId: selectedProjectId })
+  const tasks = ownProps.projectId
+    ? getTasksInTaskListForProjectId(state, ownProps)
     : [];
 
   return { tasks, dependenciesChangingForProject };

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -115,13 +115,13 @@ class TaskRunnerPane extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = state => {
   const projectId = getSelectedProjectId(state);
 
   const dependenciesChangingForProject =
     projectId && !getIsQueueEmpty(state, { projectId });
 
-  const tasks = ownProps.projectId
+  const tasks = projectId
     ? getTasksInTaskListForProjectId(state, { projectId })
     : [];
 

--- a/src/components/TaskRunnerPane/TaskRunnerPane.js
+++ b/src/components/TaskRunnerPane/TaskRunnerPane.js
@@ -116,11 +116,13 @@ class TaskRunnerPane extends Component<Props, State> {
 }
 
 const mapStateToProps = (state, ownProps) => {
+  const projectId = getSelectedProjectId(state);
+
   const dependenciesChangingForProject =
-    ownProps.projectId && !getIsQueueEmpty(state, ownProps);
+    projectId && !getIsQueueEmpty(state, { projectId });
 
   const tasks = ownProps.projectId
-    ? getTasksInTaskListForProjectId(state, ownProps)
+    ? getTasksInTaskListForProjectId(state, { projectId })
     : [];
 
   return { tasks, dependenciesChangingForProject };

--- a/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
+++ b/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
@@ -22,7 +22,7 @@ type Props = {
   description: string,
   status: TaskStatus,
   processId?: number,
-  disabled: boolean,
+  isDisabled: boolean,
   onToggleTask: (taskId: string) => void,
   onViewDetails: (taskId: string) => void,
 };
@@ -34,7 +34,7 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
       description,
       status,
       processId,
-      disabled,
+      isDisabled,
       onToggleTask,
       onViewDetails,
     } = this.props;
@@ -63,14 +63,14 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
               width={40}
               height={34}
               isRunning={!!processId}
-              disabled={disabled}
+              disabled={isDisabled}
               onClick={() => onToggleTask(name)}
             />
           ) : (
             <Toggle
               size={24}
               isToggled={!!processId}
-              disabled={disabled}
+              isDisabled={isDisabled}
               onToggle={() => onToggleTask(name)}
             />
           )}

--- a/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
+++ b/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
@@ -22,6 +22,7 @@ type Props = {
   description: string,
   status: TaskStatus,
   processId?: number,
+  disabled: boolean,
   onToggleTask: (taskId: string) => void,
   onViewDetails: (taskId: string) => void,
 };
@@ -33,6 +34,7 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
       description,
       status,
       processId,
+      disabled,
       onToggleTask,
       onViewDetails,
     } = this.props;
@@ -61,12 +63,14 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
               width={40}
               height={34}
               isRunning={!!processId}
+              disabled={disabled}
               onClick={() => onToggleTask(name)}
             />
           ) : (
             <Toggle
               size={24}
               isToggled={!!processId}
+              disabled={disabled}
               onToggle={() => onToggleTask(name)}
             />
           )}

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -9,7 +9,7 @@ type Props = {
   isToggled: boolean,
   size: number,
   padding: number,
-  disabled: boolean,
+  isDisabled: boolean,
   onToggle: (isToggled: boolean) => void,
 };
 
@@ -55,7 +55,7 @@ class Toggle extends PureComponent<Props> {
   };
 
   render() {
-    const { isToggled, size, padding, disabled, onToggle } = this.props;
+    const { isToggled, size, padding, isDisabled, onToggle } = this.props;
     const doublePadding = padding * 2;
 
     return (
@@ -63,8 +63,8 @@ class Toggle extends PureComponent<Props> {
         height={size + doublePadding}
         width={size * 2 + doublePadding}
         padding={padding}
-        disabled={disabled}
-        onClick={() => !disabled && onToggle(!isToggled)}
+        isDisabled={isDisabled}
+        onClick={() => !isDisabled && onToggle(!isToggled)}
       >
         <OnBackground isVisible={isToggled}>
           <Pulsing />
@@ -106,8 +106,8 @@ const Wrapper = styled.button`
   overflow: hidden; /* Hide 'OnBackground' corners */
   outline: none; /* TODO: better a11y story */
   box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2);
-  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-  opacity: ${props => (props.disabled ? 0.5 : 1)};
+  cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
+  opacity: ${props => (props.isDisabled ? 0.5 : 1)};
 `;
 
 const OnBackground = styled.div`

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -9,6 +9,7 @@ type Props = {
   isToggled: boolean,
   size: number,
   padding: number,
+  disabled: boolean,
   onToggle: (isToggled: boolean) => void,
 };
 
@@ -54,7 +55,7 @@ class Toggle extends PureComponent<Props> {
   };
 
   render() {
-    const { isToggled, size, padding, onToggle } = this.props;
+    const { isToggled, size, padding, disabled, onToggle } = this.props;
     const doublePadding = padding * 2;
 
     return (
@@ -62,7 +63,8 @@ class Toggle extends PureComponent<Props> {
         height={size + doublePadding}
         width={size * 2 + doublePadding}
         padding={padding}
-        onClick={() => onToggle(!isToggled)}
+        disabled={disabled}
+        onClick={() => !disabled && onToggle(!isToggled)}
       >
         <OnBackground isVisible={isToggled}>
           <Pulsing />
@@ -104,7 +106,8 @@ const Wrapper = styled.button`
   overflow: hidden; /* Hide 'OnBackground' corners */
   outline: none; /* TODO: better a11y story */
   box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2);
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${props => (props.disabled ? 0.5 : 1)};
 `;
 
 const OnBackground = styled.div`

--- a/src/components/Toggle/Toggle.stories.js
+++ b/src/components/Toggle/Toggle.stories.js
@@ -1,0 +1,54 @@
+// @flow
+import React, { Component, Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Showcase from '../../../.storybook/components/Showcase';
+import Toggle from './Toggle';
+
+class StatefulToggle extends Component<any, any> {
+  state = {
+    isToggled: true,
+  };
+
+  toggle = () => {
+    this.setState(state => ({ isToggled: !state.isToggled }));
+  };
+
+  render() {
+    return (
+      <Toggle
+        onToggle={this.toggle}
+        isToggled={this.state.isToggled}
+        {...this.props}
+      />
+    );
+  }
+}
+
+storiesOf('Toggle', module).add(
+  'default',
+  withInfo()(() => (
+    <Fragment>
+      <Showcase label="default">
+        <StatefulToggle />
+      </Showcase>
+
+      <Showcase label="Small">
+        <StatefulToggle size={24} />
+      </Showcase>
+
+      <Showcase label="Large">
+        <StatefulToggle size={64} />
+      </Showcase>
+
+      <Showcase label="Extra padding">
+        <StatefulToggle padding={6} />
+      </Showcase>
+
+      <Showcase label="Disabled">
+        <StatefulToggle isDisabled />
+      </Showcase>
+    </Fragment>
+  ))
+);

--- a/src/reducers/dependencies.reducer.js
+++ b/src/reducers/dependencies.reducer.js
@@ -1,6 +1,5 @@
 // @flow
 import produce from 'immer';
-import { createSelector } from 'reselect';
 
 import {
   LOAD_DEPENDENCY_INFO_FROM_DISK,

--- a/src/reducers/queue.reducer.js
+++ b/src/reducers/queue.reducer.js
@@ -1,5 +1,6 @@
 // @flow
 import produce from 'immer';
+
 import {
   QUEUE_DEPENDENCY_INSTALL,
   QUEUE_DEPENDENCY_UNINSTALL,

--- a/src/reducers/queue.reducer.js
+++ b/src/reducers/queue.reducer.js
@@ -137,7 +137,7 @@ export const getNextActionForProjectId = (
   props: { projectId: string }
 ) => state.queue[props.projectId] && state.queue[props.projectId][0];
 
-export const isQueueEmpty = (
+export const getIsQueueEmpty = (
   state: any,
   { projectId }: { projectId?: ?string }
 ) => projectId && !getNextActionForProjectId(state, { projectId });

--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -267,6 +267,19 @@ const getTaskType = name => {
   return sustainedTasks.includes(name) ? 'sustained' : 'short-term';
 };
 
+export const isTaskDisabled = (
+  task: Task,
+  dependenciesChangingForProject: boolean
+) => {
+  // We want to lock the 'build' task while dependencies are being changed,
+  // as builds will likely fail during this time.
+  if (task.name === 'build') {
+    return dependenciesChangingForProject;
+  }
+
+  return false;
+};
+
 // TODO: A lot of this stuff shouldn't be done here :/ maybe best to resolve
 // this in an action before it hits the reducer?
 const buildNewTask = (


### PR DESCRIPTION
**Related Issue:**
closes #49 

**Summary:**
When installing/deleting/updating dependencies, we shouldn't allow builds to be started; they'll likely fail, as the project's `node_modules` are updated during the process.

This change disables the "build" toggle while the project has an active item in the queue.

Note that it doesn't affect it the other way around; you can still start installing dependencies while a build is in progress. I think we should create another issue to track it separately, to keep this PR small.

I also took the liberty to add Toggle stories.

**Test Plan:**
- Install a new dependency. Verify that the "Build" toggle is disabled (both in TaskRunnerRow, as well as TaskDetailsModal). Try clicking it.
- Make sure the "Build" toggle turns back on afterwards
- Delete the new dependency, and tab over to a new project. Ensure the new project isn't affected.

**Screenshots/GIFs:**
In action:
![delete](https://user-images.githubusercontent.com/6692932/45596619-8273fe80-b98c-11e8-8a13-6a5f93b2512f.gif)

Toggle stories:
<img width="444" alt="screen shot 2018-09-16 at 8 40 09 am" src="https://user-images.githubusercontent.com/6692932/45596621-86078580-b98c-11e8-8c3b-b2ed091b2af7.png">
