### PR TITLE
Add vscode styled-components syntax hightlighing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "flowtype.flow-for-vscode"
+    "flowtype.flow-for-vscode",
+    "jpoissonnier.vscode-styled-components"
   ]
 }


### PR DESCRIPTION
**Related Issue:**
#255 

**Summary:**
Just adding a suggested VScode extension to add styled-components syntax highligthing
