### PR TITLE
[WIP] Install after eject

### DIFF
--- a/src/components/ProjectIconSelection/ProjectIconSelection.js
+++ b/src/components/ProjectIconSelection/ProjectIconSelection.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import importAll from 'import-all.macro';
 
 import { shuffle } from '../../utils';
-import { BREAKPOINTS } from '../../constants';
 
 import SelectableImage from '../SelectableImage';
 

--- a/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
+++ b/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
@@ -52,12 +52,10 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
         </StatusColumn>
 
         <LinkColumn>
-          {name !== 'eject' ? (
+          {name === 'eject' ? null : (
             <StrokeButton size="small" onClick={() => onViewDetails(name)}>
               View Details
             </StrokeButton>
-          ) : (
-            ''
           )}
         </LinkColumn>
 

--- a/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
+++ b/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
@@ -52,9 +52,13 @@ class TaskRunnerPaneRow extends PureComponent<Props> {
         </StatusColumn>
 
         <LinkColumn>
-          <StrokeButton size="small" onClick={() => onViewDetails(name)}>
-            View Details
-          </StrokeButton>
+          {name !== 'eject' ? (
+            <StrokeButton size="small" onClick={() => onViewDetails(name)}>
+              View Details
+            </StrokeButton>
+          ) : (
+            ''
+          )}
         </LinkColumn>
 
         <ActionsColumn>

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -134,9 +134,11 @@ export function* launchDevServer({ task }: Action): Saga<void> {
   }
 }
 
-export function runInstall(installCommand: any): Promise<void> {
+export function waitUntilChildProcessToComplete(
+  installCommand: any
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    installCommand.on('exit', (code: number, signal: string) => {
+    installCommand.on('exit', (code: number) => {
       if (code === 0) {
         resolve(undefined);
       } else {
@@ -247,9 +249,10 @@ export function* taskRun({ task }: Action): Saga<void> {
             }
           );
 
-          // `runInstall` waits for proper exit before moving on otherwise the next
-          // tasks (UI related) run too early before `yarn install` is finished
-          yield call(runInstall, installCommand);
+          // `waitUntilChildProcessToComplete` waits for proper exit before moving on
+          // otherwise the next tasks (UI related) run too early before `yarn install`
+          // is finished
+          yield call(waitUntilChildProcessToComplete, installCommand);
           yield put(loadDependencyInfoFromDisk(project.id, project.path));
         }
 

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -135,10 +135,10 @@ export function* launchDevServer({ task }: Action): Saga<void> {
 }
 
 export function waitForChildProcessToComplete(
-  installCommand: any
+  installProcess: any
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    installCommand.on('exit', (code: number) => {
+    installProcess.on('exit', (code: number) => {
       if (code === 0) {
         resolve(undefined);
       } else {
@@ -239,7 +239,7 @@ export function* taskRun({ task }: Action): Saga<void> {
         if (task.name === 'eject') {
           // Run a fresh install of dependencies after ejecting to get around issue
           // documented here https://github.com/facebook/create-react-app/issues/4433
-          const installCommand = yield call(
+          const installProcess = yield call(
             [childProcess, childProcess.spawn],
             PACKAGE_MANAGER_CMD,
             ['install'],
@@ -252,7 +252,7 @@ export function* taskRun({ task }: Action): Saga<void> {
           // `waitForChildProcessToComplete` waits for proper exit before moving on
           // otherwise the next tasks (UI related) run too early before `yarn install`
           // is finished
-          yield call(waitForChildProcessToComplete, installCommand);
+          yield call(waitForChildProcessToComplete, installProcess);
           yield put(loadDependencyInfoFromDisk(project.id, project.path));
         }
 

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -134,7 +134,7 @@ export function* launchDevServer({ task }: Action): Saga<void> {
   }
 }
 
-export function waitUntilChildProcessToComplete(
+export function waitForChildProcessToComplete(
   installCommand: any
 ): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -249,10 +249,10 @@ export function* taskRun({ task }: Action): Saga<void> {
             }
           );
 
-          // `waitUntilChildProcessToComplete` waits for proper exit before moving on
+          // `waitForChildProcessToComplete` waits for proper exit before moving on
           // otherwise the next tasks (UI related) run too early before `yarn install`
           // is finished
-          yield call(waitUntilChildProcessToComplete, installCommand);
+          yield call(waitForChildProcessToComplete, installCommand);
           yield put(loadDependencyInfoFromDisk(project.id, project.path));
         }
 

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -235,7 +235,7 @@ describe('task saga', () => {
       );
     });
 
-    describe('running', () => {
+    describe('ejecting', () => {
       const task = { name: 'eject', projectId: 'pickled-tulip' };
       const saga = cloneableGenerator(taskRun)({ task });
 
@@ -266,29 +266,14 @@ describe('task saga', () => {
         );
       });
 
-      it('should complete on exit', () => {
+      it('should reinstall dependencies and complete on exit', () => {
         const timestamp = new Date();
 
         // `take` a log message
         saga.next();
 
-        expect(
-          saga.next({ channel: 'exit', timestamp, wasSuccessful: true }).value
-        ).toEqual(call(displayTaskComplete, task, true));
-
-        expect(saga.next().value).toEqual(
-          put(completeTask(task, timestamp, true))
-        );
-      });
-
-      it('should reload dependencies after eject', () => {
-        // `loadDependencyInfoFromDisk` is a thunk, thus two copies
-        // constructed with identical arguments will return unique
-        // copies of the same anonymous function. As such, their JSON
-        // stringified representations are used for testing equality.
-        // TODO: remove `JSON.stringify` once `redux-thunk` is removed
-
-        const installCommand = call(
+        // ejecting requires that dependencies are reinstalled
+        const installProcessDescription = call(
           [childProcess, childProcess.spawn],
           PACKAGE_MANAGER_CMD,
           ['install'],
@@ -298,14 +283,30 @@ describe('task saga', () => {
           }
         );
 
-        expect(JSON.stringify(saga.next(installCommand).value)).toEqual(
-          JSON.stringify(call(waitForChildProcessToComplete, installCommand))
+        expect(
+          saga.next({ channel: 'exit', timestamp, wasSuccessful: true }).value
+        ).toEqual(installProcessDescription);
+
+        expect(saga.next(installProcessDescription).value).toEqual(
+          call(waitForChildProcessToComplete, installProcessDescription)
         );
 
+        // The next call is to `loadDependencyInfoFromDisk`, which is a thunk.
+        // Thunks produce anonymous functions, which means we can't easily
+        // test it. For now, just verify that it produces a function.
+        // TODO: remove `JSON.stringify` once `redux-thunk` is removed
         expect(JSON.stringify(saga.next().value)).toEqual(
           JSON.stringify(
             put(loadDependencyInfoFromDisk(task.projectId, projectPath))
           )
+        );
+
+        expect(
+          saga.next({ channel: 'exit', timestamp, wasSuccessful: true }).value
+        ).toEqual(call(displayTaskComplete, task, true));
+
+        expect(saga.next().value).toEqual(
+          put(completeTask(task, timestamp, true))
         );
       });
     });

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -11,6 +11,7 @@ import {
   displayTaskComplete,
   taskComplete,
   getDevServerCommand,
+  waitForChildProcessToComplete,
 } from './task.saga';
 import {
   attachTaskMetadata,
@@ -286,6 +287,21 @@ describe('task saga', () => {
         // copies of the same anonymous function. As such, their JSON
         // stringified representations are used for testing equality.
         // TODO: remove `JSON.stringify` once `redux-thunk` is removed
+
+        const installCommand = call(
+          [childProcess, childProcess.spawn],
+          PACKAGE_MANAGER_CMD,
+          ['install'],
+          {
+            cwd: projectPath,
+            env: getBaseProjectEnvironment(projectPath),
+          }
+        );
+
+        expect(JSON.stringify(saga.next(installCommand).value)).toEqual(
+          JSON.stringify(call(waitForChildProcessToComplete, installCommand))
+        );
+
         expect(JSON.stringify(saga.next().value)).toEqual(
           JSON.stringify(
             put(loadDependencyInfoFromDisk(task.projectId, projectPath))


### PR DESCRIPTION
**Related Issue:**
#68

**Summary:**

Addressing the issue where ejecting causes `babel-loader` to not be found. Didn't see anyone working on it so thought I'd take a stab at it!

Tests are failing but thought I'd get some feedback first before attempting to fix them, in case this approach isn't quite right...

**Test Plan:**

1. Create a test CRA project
2. Click `eject`
3. Task will run (with pending spinner) while promise is resolving. Once it's resolved, then the rest of the tasks will run (task pane will get deleted, dependency list will be updated which exposes `babel-loader` to the list because it's now installed)

Not sure if we want to modify things because right now there's a 'View Details' button in the UI for the eject task, but nothing gets piped to it. We may want to pipe all the `yarn install` stuff to it now that it runs because it's a longer process than the simple eject.