### PR TITLE
Fix `CircularOutline` performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "react-icons-kit": "1.1.5",
     "react-instantsearch": "5.1.0",
     "react-motion": "0.5.2",
+    "react-powerplug": "1.0.0-rc.1",
     "react-redux": "5.0.7",
     "react-spring": "5.3.8",
     "react-tippy": "1.2.2",

--- a/src/components/AddDependencySearchResult/AddDependencySearchResult.js
+++ b/src/components/AddDependencySearchResult/AddDependencySearchResult.js
@@ -115,8 +115,7 @@ class AddDependencySearchResult extends PureComponent<Props> {
     return (
       <StrokeButton
         size="small"
-        color1={COLORS.green[700]}
-        color2={COLORS.lightGreen[500]}
+        strokeColors={[COLORS.green[700], COLORS.lightGreen[500]]}
         textColor={COLORS.green[700]}
         onClick={() => addDependency(projectId, hit.name, hit.version)}
       >

--- a/src/components/Button/ButtonBase.js
+++ b/src/components/Button/ButtonBase.js
@@ -86,14 +86,6 @@ const ButtonBaseStyles = styled.button`
     opacity: 0.75;
   }
 
-  /*
-    HACK: We want to double the border-thickness of StrokeButton when active.
-    This feels hacky, but it would also be hacky to manage this state in React.
-  */
-  &:not(:disabled):active rect {
-    stroke-width: 4;
-  }
-
   &:not(:disabled):active {
     transform-origin: center center;
     transform: ${props => props.activeSplat && 'scale(1.1)'};

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import styled from 'styled-components';
 
 import { COLORS } from '../../constants';

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -1,41 +1,114 @@
 // @flow
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import styled from 'styled-components';
 
 import { COLORS } from '../../constants';
 
-import CircularOutline from '../CircularOutline';
 import ButtonBase from './ButtonBase';
 
 type Props = {
-  color1: string,
-  color2: string,
+  fillColor: string,
+  strokeColors: Array<string>,
   showStroke: boolean,
   children: React$Node,
 };
 
-class StrokeButton extends Component<Props> {
+type State = {
+  isActive: boolean,
+};
+
+class StrokeButton extends Component<Props, State> {
+  state = {
+    isActive: false,
+  };
+
   static defaultProps = {
-    color1: COLORS.purple[500],
-    color2: COLORS.violet[500],
+    fillColor: COLORS.white,
+    strokeColors: [COLORS.purple[500], COLORS.violet[500]],
     showStroke: true,
   };
 
+  handleMouseDown = ev => {
+    if (typeof this.props.onMouseDown === 'function') {
+      this.props.onMouseDown(ev);
+    }
+
+    this.setState({ isActive: true });
+  };
+
+  handleMouseUp = ev => {
+    if (typeof this.props.onMouseUp === 'function') {
+      this.props.onMouseUp(ev);
+    }
+
+    this.setState({ isActive: false });
+  };
+
+  handleMouseLeave = ev => {
+    if (typeof this.props.onMouseLeave === 'function') {
+      this.props.onMouseLeave(ev);
+    }
+
+    this.setState({ isActive: false });
+  };
+
   render() {
-    const { color1, color2, showStroke, children, ...delegated } = this.props;
+    const {
+      fillColor,
+      strokeColors,
+      showStroke,
+      children,
+      ...delegated
+    } = this.props;
+    const { isActive } = this.state;
 
     return (
-      <ButtonBase background="transparent" {...delegated}>
-        <CircularOutline
-          isShown={showStroke}
-          animateChanges
-          color1={color1}
-          color2={color2}
-        />
+      <Wrapper>
+        <Foreground>
+          <ButtonBase
+            background={fillColor}
+            {...delegated}
+            onMouseDown={this.handleMouseDown}
+            onMouseUp={this.handleMouseUp}
+            onMouseLeave={this.handleMouseLeave}
+          >
+            <span style={{ display: 'block' }}>{children}</span>
+          </ButtonBase>
+        </Foreground>
 
-        <span style={{ display: 'block' }}>{children}</span>
-      </ButtonBase>
+        <Background
+          colors={strokeColors}
+          isVisible={showStroke}
+          isActive={isActive}
+        />
+      </Wrapper>
     );
   }
 }
+
+const Wrapper = styled.div`
+  position: relative;
+  display: inline-block;
+  padding: 2px;
+`;
+
+const Foreground = styled.span`
+  display: block;
+  position: relative;
+  z-index: 1;
+`;
+
+const Background = styled.div`
+  position: absolute;
+  z-index: 0;
+  top: ${props => (props.isActive ? -2 : 0)}px;
+  left: ${props => (props.isActive ? -2 : 0)}px;
+  right: ${props => (props.isActive ? -2 : 0)}px;
+  bottom: ${props => (props.isActive ? -2 : 0)}px;
+  border-radius: 100px;
+  background: linear-gradient(25deg, ${props => props.colors.join(', ')});
+  opacity: ${props => (props.isVisible ? 1 : 0)};
+  transition: opacity 350ms;
+`;
 
 export default StrokeButton;

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { COLORS } from '../../constants';
 
+import DetectActive from '../DetectActive';
 import ButtonBase from './ButtonBase';
 
 type Props = {
@@ -13,43 +14,11 @@ type Props = {
   children: React$Node,
 };
 
-type State = {
-  isActive: boolean,
-};
-
-class StrokeButton extends Component<Props, State> {
-  state = {
-    isActive: false,
-  };
-
+class StrokeButton extends Component<Props> {
   static defaultProps = {
     fillColor: COLORS.white,
     strokeColors: [COLORS.purple[500], COLORS.violet[500]],
     showStroke: true,
-  };
-
-  handleMouseDown = ev => {
-    if (typeof this.props.onMouseDown === 'function') {
-      this.props.onMouseDown(ev);
-    }
-
-    this.setState({ isActive: true });
-  };
-
-  handleMouseUp = ev => {
-    if (typeof this.props.onMouseUp === 'function') {
-      this.props.onMouseUp(ev);
-    }
-
-    this.setState({ isActive: false });
-  };
-
-  handleMouseLeave = ev => {
-    if (typeof this.props.onMouseLeave === 'function') {
-      this.props.onMouseLeave(ev);
-    }
-
-    this.setState({ isActive: false });
   };
 
   render() {
@@ -60,28 +29,25 @@ class StrokeButton extends Component<Props, State> {
       children,
       ...delegated
     } = this.props;
-    const { isActive } = this.state;
 
     return (
-      <Wrapper>
-        <Foreground>
-          <ButtonBase
-            background={fillColor}
-            {...delegated}
-            onMouseDown={this.handleMouseDown}
-            onMouseUp={this.handleMouseUp}
-            onMouseLeave={this.handleMouseLeave}
-          >
-            <span style={{ display: 'block' }}>{children}</span>
-          </ButtonBase>
-        </Foreground>
+      <DetectActive>
+        {isActive => (
+          <Wrapper>
+            <Foreground>
+              <ButtonBase background={fillColor} {...delegated}>
+                <span style={{ display: 'block' }}>{children}</span>
+              </ButtonBase>
+            </Foreground>
 
-        <Background
-          colors={strokeColors}
-          isVisible={showStroke}
-          isActive={isActive}
-        />
-      </Wrapper>
+            <Background
+              colors={strokeColors}
+              isVisible={showStroke}
+              isActive={isActive}
+            />
+          </Wrapper>
+        )}
+      </DetectActive>
     );
   }
 }

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -10,8 +10,7 @@ import { COLORS } from '../../constants';
 
 type Props = {
   size: number,
-  color1: string,
-  color2: string,
+  colors?: string[],
   strokeWidth: number,
   isShown: boolean,
 };
@@ -28,15 +27,14 @@ const springSettings = {
 
 class CircularOutline extends Component<Props> {
   static defaultProps = {
-    color1: COLORS.purple[500],
-    color2: COLORS.violet[500],
+    colors: [COLORS.purple[500], COLORS.violet[500]],
     strokeWidth: 2,
   };
 
   render() {
-    const { size, color1, color2, strokeWidth, isShown } = this.props;
+    const { size, colors, strokeWidth, isShown } = this.props;
 
-    const svgId = `${color1.replace('#', '')}-${color2.replace('#', '')}`;
+    const svgId = `${colors.map(color => color.replace('#', '')).join('-')}`;
 
     // Yay middle-school maths
     const radius = size / 2;
@@ -53,14 +51,23 @@ class CircularOutline extends Component<Props> {
                 <stop
                   offset="0%"
                   style={{
-                    stopColor: color1,
+                    stopColor: colors[0] || COLORS.purple[500],
                     stopOpacity: 1,
                   }}
                 />
+                {colors.slice(1, colors.length - 1).map((color, i, colorsInTheMiddle) => (
+                  <stop
+                    offset={`${(i * 100 / (colorsInTheMiddle.length + 1)).toFixed(2)}%`}
+                    style={{
+                      stopColor: color,
+                      stopOpacity: 1,
+                    }}
+                  />
+                ))}
                 <stop
                   offset="100%"
                   style={{
-                    stopColor: color2,
+                    stopColor: colors[colors.length - 1] || COLORS.purple[500],
                     stopOpacity: 1,
                   }}
                 />

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -1,132 +1,50 @@
 // @flow
 /**
- * Draws a totally-rounded rectangle inside the parent node.
- *
- * NOTE: This turned out to be a surprisingly hard problem! I had to use an
- * SVG since I needed a gradient border, and because the SVG is computed
- * dynamically, a few re-renders need to take place.
- *
- * Here's the flow:
- *   - Initial render:  Capture a reference to the SVG, so we can work out the
- *                      width and height of the parent container
- *
- *   - Path length:     Now that we have the length/height, we can add our SVG
- *                      <rect> that fills the space. After that update is
- *                      flushed to the DOM, we can figure out the length of the
- *                      path with `getTotalLength`.
- *                      TODO: I can probably use math to work out that path
- *                      so that I can skip this update cycle?
- *
- *   - Enabling trans:  We don't want the 'self-drawing' transition to happen
- *                      on mount. Because of this, transition starts as
- *                      disabled.
- *                      Once we make it to this stage, though, we can set
- *                      `finishedAllMountingSteps` to indicate that all this
- *                      stuff is done, so that any future changes to `isShown`
- *                      can be animated
- *
- * There's surely a lot of room for improvement with this flow.
+ * Draws a totally-rounded circle inside the parent node.
  */
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import { Motion, spring } from 'react-motion';
+import { Spring } from 'react-spring';
 
 import { COLORS } from '../../constants';
 
 type Props = {
+  size: number,
   color1: string,
   color2: string,
   strokeWidth: number,
   isShown: boolean,
-  animateChanges: boolean,
 };
 
-type State = {
-  width: ?number,
-  height: ?number,
-  pathLength: number,
-  finishedAllMountingSteps: boolean,
+const springSettings = {
+  tension: 150,
+  friction: 22,
+  restSpeedThreshold: 3,
+  restDisplacementThreshold: 10,
 };
 
-const springSettings = { stiffness: 150, damping: 22, precision: 5 };
-
-class RoundedOutline extends Component<Props, State> {
-  state = {
-    width: null,
-    height: null,
-    pathLength: 0,
-    finishedAllMountingSteps: false,
-  };
-
-  wrapperNode: HTMLElement;
-  shapeNode: any; // "SVGPathElement" (which cannot be resolved), we need "getTotalLength()"
-
+class RoundedOutline extends Component<Props> {
   static defaultProps = {
     color1: COLORS.purple[500],
     color2: COLORS.violet[500],
     strokeWidth: 2,
-    animateChanges: true,
   };
 
-  componentDidMount() {
-    // On first mount, we need to figure out how big the available area is.
-    // This will affect how large the outline is.
-    const { width, height } = this.wrapperNode.getBoundingClientRect();
-
-    this.setState({ width, height });
-  }
-
-  componentDidUpdate(_: Props, prevState: State) {
-    if (this.state.width !== null && this.state.height !== null) {
-      if (prevState.width == null && prevState.height == null) {
-        const pathLength = this.shapeNode.getTotalLength();
-
-        this.setState({ pathLength });
-      } else {
-        const { width, height } = this.wrapperNode.getBoundingClientRect();
-
-        if (this.state.width !== width || this.state.height !== height) {
-          this.setState({ width, height });
-        }
-      }
-    }
-
-    if (this.state.pathLength !== null) {
-      const newPathLength = this.shapeNode.getTotalLength();
-
-      if (this.state.pathLength !== newPathLength) {
-        this.setState({ pathLength: newPathLength });
-      }
-    }
-
-    if (prevState.pathLength === 0 && this.state.pathLength !== 0) {
-      this.setState({ finishedAllMountingSteps: true });
-    }
-  }
-
   render() {
-    const { color1, color2, strokeWidth, isShown, animateChanges } = this.props;
-    const { width, height, pathLength, finishedAllMountingSteps } = this.state;
+    const { size, color1, color2, strokeWidth, isShown } = this.props;
 
     const svgId = `${color1.replace('#', '')}-${color2.replace('#', '')}`;
 
-    const dashOffset = isShown ? 0 : pathLength;
+    // Yay middle-school maths
+    const radius = size / 2;
+    const circumference = 2 * Math.PI * radius;
+
+    const dashOffset = isShown ? circumference : 0;
 
     return (
-      <Motion
-        style={{
-          interpolatedDashOffset:
-            animateChanges && finishedAllMountingSteps
-              ? spring(dashOffset, springSettings)
-              : dashOffset,
-        }}
-      >
-        {({ interpolatedDashOffset }) => (
-          <Svg
-            innerRef={node => (this.wrapperNode = node)}
-            width="100%"
-            height="100%"
-          >
+      <Spring config={springSettings} to={{ dashOffset }}>
+        {interpolated => (
+          <Svg width={size} height={size}>
             <defs>
               <linearGradient id={svgId} x1="0%" y1="100%" x2="100%" y2="0%">
                 <stop
@@ -145,29 +63,27 @@ class RoundedOutline extends Component<Props, State> {
                 />
               </linearGradient>
             </defs>
-            {typeof width === 'number' &&
-              typeof height === 'number' && (
-                <Rect
-                  innerRef={node => (this.shapeNode = node)}
-                  x={0}
-                  y={0}
-                  width={width}
-                  height={height}
-                  rx={height / 2}
-                  ry={height / 2}
-                  fill="none"
-                  stroke={`url(#${svgId})`}
-                  strokeWidth={strokeWidth}
-                  strokeLinecap="round"
-                  style={{
-                    strokeDasharray: `${pathLength}, ${pathLength + 1}`,
-                    strokeDashoffset: interpolatedDashOffset,
-                  }}
-                />
-              )}
+
+            <ellipse
+              cx={radius}
+              cy={radius}
+              rx={radius}
+              ry={radius}
+              fill="none"
+              stroke={`url(#${svgId})`}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              style={{
+                strokeDasharray: `
+                  ${circumference},
+                  ${circumference + 1}
+                `,
+                strokeDashoffset: interpolated.dashOffset,
+              }}
+            />
           </Svg>
         )}
-      </Motion>
+      </Spring>
     );
   }
 }
@@ -177,8 +93,7 @@ const Svg = styled.svg`
   position: absolute;
   top: 0;
   left: 0;
+  transform: rotate(-90deg);
 `;
-
-const Rect = styled.rect``;
 
 export default RoundedOutline;

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -10,7 +10,7 @@ import { COLORS } from '../../constants';
 
 type Props = {
   size: number,
-  colors?: string[],
+  colors: Array<string>,
   strokeWidth: number,
   isShown: boolean,
 };
@@ -31,6 +31,57 @@ class CircularOutline extends Component<Props> {
     strokeWidth: 2,
   };
 
+  renderGradientStop = (
+    color: string,
+    index: number,
+    colors: Array<string>
+  ) => {
+    // Each stop needs a unique key, and we'll create one from the available
+    // data
+    const key = `${index}-${color}`;
+
+    // For the offsets, we want to ensure even spacing from 0 to 100.
+    // With 2 colors, we want [0, 100]
+    // With 3 colors, we want [0, 50, 100]
+    //
+    // In a 3-color example, we need to divide the current index (0, 1, 2)
+    // by 2, and then multiply by 100, to get the values we want:
+    //
+    // 0 / 2 = 0        * 100 = 0
+    // 1 / 2 = 0.5      * 100 = 50              Perfect :D
+    // 2 / 2 = 1        * 100 = 100
+    //
+    // Where did the denominator `2` come from? It's 1 less than the number of
+    // colors we're iterating through.
+    const denominator = colors.length - 1;
+
+    // The reason for it being 1 less is because we want to be inclusive of
+    // both the lower AND upper bounds. Without it, our numbers don't climb
+    // high enough:
+    //
+    // 0 / 3 = 0        * 100 = 0
+    // 1 / 3 = 0.333    * 100 = 33.3              Not good :/
+    // 2 / 3 = 0.666    * 100 = 66.6
+    //
+    // Having the denominator be 1 less means that our first value is at 0,
+    // our last value is at 100, and the midpoint values are spread evenly
+    // between them.
+
+    const offset = (index / denominator) * 100;
+    const offsetPercentage = `${offset}%`;
+
+    return (
+      <stop
+        key={key}
+        offset={offsetPercentage}
+        style={{
+          stopColor: color,
+          stopOpacity: 1,
+        }}
+      />
+    );
+  };
+
   render() {
     const { size, colors, strokeWidth, isShown } = this.props;
 
@@ -42,35 +93,22 @@ class CircularOutline extends Component<Props> {
 
     const dashOffset = isShown ? 0 : circumference;
 
+    // CircularOutline features a gradient, which means we need at least 2
+    // colors for this to work.
+    // If the user only supplied 1 color, we can fake it by having a gradient
+    // with the same value in both positions.
+    let gradientColors = colors;
+    if (gradientColors.length === 1) {
+      gradientColors = [colors[0], colors[0]];
+    }
+
     return (
       <Spring native config={springSettings} to={{ dashOffset }}>
         {interpolated => (
           <Svg width={size} height={size}>
             <defs>
               <linearGradient id={svgId} x1="0%" y1="100%" x2="100%" y2="0%">
-                <stop
-                  offset="0%"
-                  style={{
-                    stopColor: colors[0] || COLORS.purple[500],
-                    stopOpacity: 1,
-                  }}
-                />
-                {colors.slice(1, colors.length - 1).map((color, i, colorsInTheMiddle) => (
-                  <stop
-                    offset={`${(i * 100 / (colorsInTheMiddle.length + 1)).toFixed(2)}%`}
-                    style={{
-                      stopColor: color,
-                      stopOpacity: 1,
-                    }}
-                  />
-                ))}
-                <stop
-                  offset="100%"
-                  style={{
-                    stopColor: colors[colors.length - 1] || COLORS.purple[500],
-                    stopOpacity: 1,
-                  }}
-                />
+                {gradientColors.map(this.renderGradientStop)}
               </linearGradient>
             </defs>
 

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -39,7 +39,7 @@ class CircularOutline extends Component<Props> {
     const radius = size / 2;
     const circumference = 2 * Math.PI * radius;
 
-    const dashOffset = isShown ? circumference : 0;
+    const dashOffset = isShown ? 0 : circumference;
 
     return (
       <Spring native config={springSettings} to={{ dashOffset }}>

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -23,7 +23,7 @@ const springSettings = {
   restDisplacementThreshold: 10,
 };
 
-class RoundedOutline extends Component<Props> {
+class CircularOutline extends Component<Props> {
   static defaultProps = {
     color1: COLORS.purple[500],
     color2: COLORS.violet[500],
@@ -96,4 +96,4 @@ const Svg = styled.svg`
   transform: rotate(-90deg);
 `;
 
-export default RoundedOutline;
+export default CircularOutline;

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import { Spring } from 'react-spring';
+import { Spring, animated } from 'react-spring';
 
 import { COLORS } from '../../constants';
 
@@ -42,7 +42,7 @@ class CircularOutline extends Component<Props> {
     const dashOffset = isShown ? circumference : 0;
 
     return (
-      <Spring config={springSettings} to={{ dashOffset }}>
+      <Spring native config={springSettings} to={{ dashOffset }}>
         {interpolated => (
           <Svg width={size} height={size}>
             <defs>
@@ -64,7 +64,7 @@ class CircularOutline extends Component<Props> {
               </linearGradient>
             </defs>
 
-            <ellipse
+            <animated.ellipse
               cx={radius}
               cy={radius}
               rx={radius}

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -19,6 +19,9 @@ type Props = {
 const springSettings = {
   tension: 150,
   friction: 22,
+  // We want to tweak the 'onRest' timing so that the animation ends a bit
+  // earlier. Otherwise, we wind up with a surprisingly long wait while the
+  // very end of the stroke disappears, when hiding the stroke.
   restSpeedThreshold: 3,
   restDisplacementThreshold: 10,
 };
@@ -93,6 +96,7 @@ const Svg = styled.svg`
   position: absolute;
   top: 0;
   left: 0;
+  /* Have the animation start from the top, not the right */
   transform: rotate(-90deg);
 `;
 

--- a/src/components/CircularOutline/CircularOutline.stories.js
+++ b/src/components/CircularOutline/CircularOutline.stories.js
@@ -47,12 +47,29 @@ storiesOf('CircularOutline', module).add(
           )}
         </Toggleable>
       </Showcase>
-      <Showcase label="Different colors">
+      <Showcase label="Single color">
+        <Toggleable size={40} background="#555">
+          {isShown => (
+            <CircularOutline colors={['yellow']} size={40} isShown={isShown} />
+          )}
+        </Toggleable>
+      </Showcase>
+      <Showcase label="Two colors">
         <Toggleable size={40} background="#555">
           {isShown => (
             <CircularOutline
-              color1="hotpink"
-              color2="yellow"
+              colors={['yellow', 'hotpink']}
+              size={40}
+              isShown={isShown}
+            />
+          )}
+        </Toggleable>
+      </Showcase>
+      <Showcase label="Three colors">
+        <Toggleable size={40} background="#555">
+          {isShown => (
+            <CircularOutline
+              colors={['yellow', 'hotpink', 'purple']}
               size={40}
               isShown={isShown}
             />

--- a/src/components/CircularOutline/CircularOutline.stories.js
+++ b/src/components/CircularOutline/CircularOutline.stories.js
@@ -2,96 +2,40 @@
 import React, { Fragment, Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { Toggle as ToggleState } from 'react-powerplug';
 
 import Showcase from '../../../.storybook/components/Showcase';
 import CircularOutline from './CircularOutline';
+import FillButton from '../Button/FillButton';
 import styled from 'styled-components';
 
-type Props = { children: (data: any) => React$Node };
-type State = { copyIndex: number };
-
-const BUTTON_COPY = [
-  'hello',
-  'hello world',
-  '!',
-  'Wow this is so long why is it so long ahhhhhhhhhhhh',
-];
-class CopyManager extends Component<Props, State> {
-  state = {
-    copyIndex: 0,
-  };
-
-  cycleCopy = () => {
-    // This line means we always get a value between 0-3:
-    const nextCopyIndex = (this.state.copyIndex + 1) % BUTTON_COPY.length;
-
-    this.setState({ copyIndex: nextCopyIndex });
-  };
-
-  render() {
-    const { children } = this.props;
-    const { copyIndex } = this.state;
-
-    const copy = BUTTON_COPY[copyIndex];
-
-    return (
-      <Fragment>
-        <button onClick={this.cycleCopy}>Change Size</button>
-        <br />
-        <br />
-        <ButtonElem>
-          <OutlineWrapper>{children(copy)}</OutlineWrapper>
-          {copy}
-        </ButtonElem>
-      </Fragment>
-    );
-  }
-}
-
 storiesOf('CircularOutline', module).add(
-  'dynamicSizing',
+  'default',
   withInfo()(() => (
-    <Fragment>
-      <Showcase label="Dynamic Sizing">
-        <CopyManager>
-          {copy => (
-            <CircularOutline
-              color1={'red'}
-              color2={'blue'}
-              strokeWidth={2}
-              isShown={true}
-              animateChanges={true}
-            >
-              {copy}
-            </CircularOutline>
-          )}
-        </CopyManager>
-      </Showcase>
-    </Fragment>
+    <Showcase label="Toggleable">
+      <ToggleState>
+        {({ on, toggle }) => (
+          <Fragment>
+            <Wrapper>
+              <CircularOutline size={40} strokeWidth={2} isShown={on} />
+            </Wrapper>
+
+            <br />
+            <br />
+            <FillButton colors={['#333']} onClick={toggle}>
+              Toggle
+            </FillButton>
+          </Fragment>
+        )}
+      </ToggleState>
+    </Showcase>
   ))
 );
 
-const ButtonElem = styled.button`
+const Wrapper = styled.div`
   position: relative;
-  width: ${props => props.size}px;
-  height: ${props => props.size}px;
-  border: none;
-  background: none;
-  outline: none;
-  padding: 0;
-  cursor: pointer;
-
-  &:active rect {
-    stroke-width: 4;
-  }
-`;
-
-const OutlineWrapper = styled.div`
-  position: absolute;
-  z-index: 3;
-  top: -3px;
-  left: -3px;
-  right: -3px;
-  bottom: -3px;
-  pointer-events: none;
+  width: 40px;
+  height: 40px;
+  background: #eee;
+  border-radius: 50%;
 `;

--- a/src/components/CircularOutline/CircularOutline.stories.js
+++ b/src/components/CircularOutline/CircularOutline.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Fragment, Component } from 'react';
+import React, { Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { Toggle as ToggleState } from 'react-powerplug';

--- a/src/components/CircularOutline/CircularOutline.stories.js
+++ b/src/components/CircularOutline/CircularOutline.stories.js
@@ -9,33 +9,64 @@ import CircularOutline from './CircularOutline';
 import FillButton from '../Button/FillButton';
 import styled from 'styled-components';
 
+type Props = {
+  size: number,
+  background?: string,
+  children: (isShown: boolean) => React$Node,
+};
+const Toggleable = ({ size, background = '#EEE', children }: Props) => (
+  <ToggleState>
+    {({ on, toggle }) => (
+      <Fragment>
+        <Wrapper background={background} size={size}>
+          {children(on)}
+        </Wrapper>
+        <br />
+        <br />
+        <FillButton colors={['#333']} onClick={toggle}>
+          Toggle
+        </FillButton>
+      </Fragment>
+    )}
+  </ToggleState>
+);
+
 storiesOf('CircularOutline', module).add(
   'default',
   withInfo()(() => (
-    <Showcase label="Toggleable">
-      <ToggleState>
-        {({ on, toggle }) => (
-          <Fragment>
-            <Wrapper>
-              <CircularOutline size={40} strokeWidth={2} isShown={on} />
-            </Wrapper>
-
-            <br />
-            <br />
-            <FillButton colors={['#333']} onClick={toggle}>
-              Toggle
-            </FillButton>
-          </Fragment>
-        )}
-      </ToggleState>
-    </Showcase>
+    <Fragment>
+      <Showcase label="Default">
+        <Toggleable size={40}>
+          {isShown => <CircularOutline size={40} isShown={isShown} />}
+        </Toggleable>
+      </Showcase>
+      <Showcase label="Larger">
+        <Toggleable size={70}>
+          {isShown => (
+            <CircularOutline size={70} strokeWidth={4} isShown={isShown} />
+          )}
+        </Toggleable>
+      </Showcase>
+      <Showcase label="Different colors">
+        <Toggleable size={40} background="#555">
+          {isShown => (
+            <CircularOutline
+              color1="hotpink"
+              color2="yellow"
+              size={40}
+              isShown={isShown}
+            />
+          )}
+        </Toggleable>
+      </Showcase>
+    </Fragment>
   ))
 );
 
 const Wrapper = styled.div`
   position: relative;
-  width: 40px;
-  height: 40px;
-  background: #eee;
+  width: ${props => props.size}px;
+  height: ${props => props.size}px;
+  background: ${props => props.background};
   border-radius: 50%;
 `;

--- a/src/components/DetectActive/DetectActive.js
+++ b/src/components/DetectActive/DetectActive.js
@@ -1,0 +1,42 @@
+// @flow
+import React, { Component } from 'react';
+
+type Props = {
+  children: (isActive: boolean) => React$Node,
+};
+
+type State = {
+  isActive: boolean,
+};
+
+class DetectActive extends Component<Props, State> {
+  state = {
+    isActive: false,
+  };
+
+  handleMouseDown = (ev: SyntheticEvent<*>) => {
+    this.setState({ isActive: true });
+  };
+
+  handleMouseUp = (ev: SyntheticEvent<*>) => {
+    this.setState({ isActive: false });
+  };
+
+  handleMouseLeave = (ev: SyntheticEvent<*>) => {
+    this.setState({ isActive: false });
+  };
+
+  render() {
+    return (
+      <div
+        onMouseDown={this.handleMouseDown}
+        onMouseUp={this.handleMouseUp}
+        onMouseLeave={this.handleMouseLeave}
+      >
+        {this.props.children(this.state.isActive)}
+      </div>
+    );
+  }
+}
+
+export default DetectActive;

--- a/src/components/DetectActive/DetectActive.js
+++ b/src/components/DetectActive/DetectActive.js
@@ -28,13 +28,13 @@ class DetectActive extends Component<Props, State> {
 
   render() {
     return (
-      <div
+      <span
         onMouseDown={this.handleMouseDown}
         onMouseUp={this.handleMouseUp}
         onMouseLeave={this.handleMouseLeave}
       >
         {this.props.children(this.state.isActive)}
-      </div>
+      </span>
     );
   }
 }

--- a/src/components/DetectActive/index.js
+++ b/src/components/DetectActive/index.js
@@ -1,0 +1,1 @@
+export { default } from './DetectActive';

--- a/src/components/HoverableOutlineButton/HoverableOutlineButton.js
+++ b/src/components/HoverableOutlineButton/HoverableOutlineButton.js
@@ -3,8 +3,6 @@ import React, { Component } from 'react';
 import { StrokeButton } from '../Button';
 
 type Props = {
-  color1: string,
-  color2: string,
   handleMouseEnter: () => void,
   handleMouseLeave: () => void,
   children: React$Node,
@@ -29,13 +27,11 @@ class HoverableOutlineButton extends Component<Props, State> {
   };
 
   render() {
-    const { color1, color2, children, ...delegated } = this.props;
+    const { children, ...delegated } = this.props;
     const { isHovered } = this.state;
 
     return (
       <StrokeButton
-        color1={color1}
-        color2={color2}
         showStroke={isHovered}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}

--- a/src/components/SelectableItem/SelectableItem.js
+++ b/src/components/SelectableItem/SelectableItem.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 
 import CircularOutline from '../CircularOutline';
+import DetectActive from '../DetectActive';
 
 type Status = 'default' | 'highlighted' | 'faded';
 
@@ -19,18 +20,23 @@ class SelectableItem extends Component<Props> {
     const { size, color1, color2, status, children, ...delegated } = this.props;
 
     return (
-      <ButtonElem size={size} {...delegated}>
-        <OutlineWrapper size={size}>
-          <CircularOutline
-            color1={color1}
-            color2={color2}
-            size={size + 6}
-            isShown={status === 'highlighted'}
-          />
-        </OutlineWrapper>
+      <DetectActive>
+        {isActive => (
+          <ButtonElem size={size} {...delegated}>
+            <OutlineWrapper size={size}>
+              <CircularOutline
+                color1={color1}
+                color2={color2}
+                size={size + 6}
+                strokeWidth={isActive ? 4 : 2}
+                isShown={status === 'highlighted'}
+              />
+            </OutlineWrapper>
 
-        {children(status)}
-      </ButtonElem>
+            {children(status)}
+          </ButtonElem>
+        )}
+      </DetectActive>
     );
   }
 }

--- a/src/components/SelectableItem/SelectableItem.js
+++ b/src/components/SelectableItem/SelectableItem.js
@@ -9,15 +9,14 @@ type Status = 'default' | 'highlighted' | 'faded';
 
 type Props = {
   size: number,
-  color1: string,
-  color2: string,
+  colors: Array<string>,
   status: Status,
   children: (status: Status) => React$Node,
 };
 
 class SelectableItem extends Component<Props> {
   render() {
-    const { size, color1, color2, status, children, ...delegated } = this.props;
+    const { size, colors, status, children, ...delegated } = this.props;
 
     return (
       <DetectActive>
@@ -25,8 +24,7 @@ class SelectableItem extends Component<Props> {
           <ButtonElem size={size} {...delegated}>
             <OutlineWrapper size={size}>
               <CircularOutline
-                color1={color1}
-                color2={color2}
+                colors={colors}
                 size={size + 6}
                 strokeWidth={isActive ? 4 : 2}
                 isShown={status === 'highlighted'}

--- a/src/components/Sidebar/AddProjectButton.js
+++ b/src/components/Sidebar/AddProjectButton.js
@@ -13,13 +13,7 @@ type Props = {
 };
 
 const AddProjectButton = ({ size, isVisible, onClick }: Props) => (
-  <Button
-    size={size}
-    isVisible={isVisible}
-    color1="rgba(255, 255, 255, 0.1)"
-    color2="rgba(255, 255, 255, 0.1)"
-    onClick={onClick}
-  >
+  <Button size={size} isVisible={isVisible} onClick={onClick}>
     <IconWrapper>
       <IconBase size={30} icon={plus} style={{ color: COLORS.white }} />
     </IconWrapper>

--- a/src/components/Sidebar/SidebarProjectIcon.js
+++ b/src/components/Sidebar/SidebarProjectIcon.js
@@ -28,8 +28,7 @@ const SidebarProjectIcon = ({
 }: Props) => {
   const sharedProps = {
     size,
-    color1: COLORS.white,
-    color2: COLORS.white,
+    colors: [COLORS.white],
     status: isSelected ? 'highlighted' : 'faded',
     onClick: handleSelect,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9313,6 +9313,12 @@ react-motion@0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
+react-powerplug@1.0.0-rc.1:
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/react-powerplug/-/react-powerplug-1.0.0-rc.1.tgz#6b3bc57e31684e8bc36baa7a65af602ba0e31145"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.49"
+
 react-pure-render@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-pure-render/-/react-pure-render-1.0.2.tgz#9d8a928c7f2c37513c2d064e57b3e3c356e9fabb"


### PR DESCRIPTION
**Related Issue:** closes #225 

**Summary:**
Our <CircularOutline> component triggered an immediate re-render after mount, since it needed to read the SVG created by React. This was causing performance issues (Stuttery modal opens, mostly). It was also causing a weird issue where the outlines would disappear sometimes, due to a Chrome bug (most likely).

This change creates a new division between two types of outlines:

- Truly circular ones, like the ones used in ProjectIcon. Round circles with an outline
- Outlined buttons, which are really just rounded rectangles

For the former, the behaviour is unchanged. This is possible because we know the width/height of those icons, so we can use geometry to work out the path length instead of relying on the DOM.

While it may be possible to do the same for rounded rectangles, we don't currently have any way of knowing the width of buttons, and because our buttons can change widths dynamically, it felt like too much trouble. Instead, I went for a new approach: using a background gradient.

Essentially now the StrokeButtons have a "background" layer, and a "foreground" layer that holds the actual button. The background layer has a solid background gradient, but the foreground layer has a background colour that overrides it, and some padding so that the background layer is larger. Because of this, it appears to just be an outline.

The downside is there's no clear way to do the "self-drawing" effect on click... but I don't feel too sad about it. Instead I added a simple fade in/out. The only place that uses this effect in the app is the project-type selection in the new project wizard, and I actually prefer the new effect here, it's less "busy":

![hover](https://user-images.githubusercontent.com/6692932/46076580-f0be7b00-c15b-11e8-9eb2-d443afbb33dc.gif)

(oh, also the random generator button uses it too, but I want to replace it anyway. Created a new issue, #264)

### Profile diff:

Here's the difference in speed when opening the "Project configuration" modal:

Before: 
<img width="1030" alt="screen shot 2018-09-26 at 8 06 39 am" src="https://user-images.githubusercontent.com/6692932/46078786-2adf4b00-c163-11e8-9068-9c787226d653.png">

After:
<img width="890" alt="screen shot 2018-09-26 at 8 06 04 am" src="https://user-images.githubusercontent.com/6692932/46078791-2dda3b80-c163-11e8-9caa-7926b85d4083.png">

This makes the modal feel like it opens more quickly. I imagine the difference is even more stark on less-powerful machines (I work from an iMac Pro)

### GIFs:

Here's the storybook for the new stories:
![stories](https://user-images.githubusercontent.com/6692932/46076855-d5a03b00-c15c-11e8-971c-6aa3a4c5173d.gif)
