### PR TITLE
Node available check to inform the user that it's required

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,13 +1,14 @@
 // @flow
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, remote } from 'electron';
 import styled, { keyframes } from 'styled-components';
 
 import { COLORS } from '../../constants';
 import { getSelectedProjectId } from '../../reducers/projects.reducer';
 import { getAppLoaded } from '../../reducers/app-loaded.reducer';
 import logger from '../../services/analytics.service';
+import { checkIfNodeIsAvailable } from '../../services/shell.service';
 
 import IntroScreen from '../IntroScreen';
 import Sidebar from '../Sidebar';
@@ -24,11 +25,44 @@ type Props = {
   selectedProjectId: ?Project,
 };
 
-class App extends PureComponent<Props> {
-  componentDidMount() {
-    window.addEventListener('beforeunload', this.killAllRunningProcesses);
+type State = {
+  isNodeJsMissing: boolean,
+};
 
-    logger.logEvent('load-application');
+const { dialog, shell } = remote;
+
+class App extends PureComponent<Props, State> {
+  state = {
+    isNodeJsMissing: false,
+  };
+
+  componentDidMount() {
+    const logAppLoaded = node_version => {
+      logger.logEvent('load-application', {
+        node_version: node_version || 'missing',
+      });
+    };
+
+    checkIfNodeIsAvailable()
+      .then(result => {
+        logAppLoaded(result.trim());
+        this.setState({ isNodeJsMissing: false });
+      })
+      .catch(error => {
+        this.setState({
+          isNodeJsMissing: true,
+        });
+        dialog.showErrorBox(
+          'Node missing',
+          'It looks like Node.js isn\'t installed. Node is required to use Guppy.\nWhen you click "OK", you\'ll be directed to instructions to download and install Node.'
+        );
+        shell.openExternal(
+          'https://github.com/joshwcomeau/guppy/blob/master/README.md#installation'
+        );
+        logAppLoaded();
+      });
+
+    window.addEventListener('beforeunload', this.killAllRunningProcesses);
   }
 
   componentWillUnmount() {
@@ -41,6 +75,7 @@ class App extends PureComponent<Props> {
 
   render() {
     const { isAppLoaded, selectedProjectId } = this.props;
+    const { isNodeJsMissing } = this.state;
 
     return (
       <Fragment>
@@ -58,7 +93,8 @@ class App extends PureComponent<Props> {
           </Wrapper>
         )}
 
-        <CreateNewProjectWizard />
+        {/* Only show wizard if Node.js is available */}
+        {!isNodeJsMissing && <CreateNewProjectWizard />}
         <ProjectConfigurationModal />
       </Fragment>
     );

--- a/src/sagas/refresh-projects.saga.js
+++ b/src/sagas/refresh-projects.saga.js
@@ -8,33 +8,9 @@ import {
 } from '../actions';
 import { loadGuppyProjects } from '../services/read-from-disk.service';
 import { getPathsArray } from '../reducers/paths.reducer';
-import { checkIfNodeIsAvailable } from '../services/shell.service';
-import { showCustomError } from '../services/custom-dialog.service';
 import type { Saga } from 'redux-saga';
 
 export function* refreshProjects(): Saga<void> {
-  try {
-    yield call(checkIfNodeIsAvailable); // returns node version string
-  } catch (err) {
-    // Node not available bail early
-    // yield call(
-    //   showErrorBox,
-    //   'Node missing',
-    //   "Egad! Seems like Node is not installed. Please install Node.js and that it is available on your system path. Please have a look at our installation guide: https://github.com/joshwcomeau/guppy/blob/master/README.md#installation"
-    // );
-    yield call(
-      showCustomError,
-      'Node missing',
-      'Egad! Seems like Node is not installed. Please install Node.js and check that it is available on your system path. Please have a look at our installation guide:',
-      {
-        href:
-          'https://github.com/joshwcomeau/guppy/blob/master/README.md#installation',
-        text:
-          ' https://github.com/joshwcomeau/guppy/blob/master/README.md#installation',
-      }
-    );
-    return;
-  }
   const pathsArray = yield select(getPathsArray);
 
   try {

--- a/src/sagas/refresh-projects.saga.js
+++ b/src/sagas/refresh-projects.saga.js
@@ -8,11 +8,35 @@ import {
 } from '../actions';
 import { loadGuppyProjects } from '../services/read-from-disk.service';
 import { getPathsArray } from '../reducers/paths.reducer';
-
+import { checkIfNodeIsAvailable } from '../services/shell.service';
+import { showCustomError } from '../services/custom-dialog.service';
 import type { Saga } from 'redux-saga';
 
 export function* refreshProjects(): Saga<void> {
   const pathsArray = yield select(getPathsArray);
+
+  try {
+    yield call(checkIfNodeIsAvailable); // returns node version string
+  } catch (err) {
+    // Node not available bail early
+    // yield call(
+    //   showErrorBox,
+    //   'Node missing',
+    //   "Egad! Seems like Node is not installed. Please install Node.js and that it is available on your system path. Please have a look at our installation guide: https://github.com/joshwcomeau/guppy/blob/master/README.md#installation"
+    // );
+    yield call(
+      showCustomError,
+      'Node missing',
+      'Egad! Seems like Node is not installed. Please install Node.js and check that it is available on your system path. Please have a look at our installation guide:',
+      {
+        href:
+          'https://github.com/joshwcomeau/guppy/blob/master/README.md#installation',
+        text:
+          ' https://github.com/joshwcomeau/guppy/blob/master/README.md#installation',
+      }
+    );
+    return;
+  }
 
   try {
     const projectsFromDisk = yield call(loadGuppyProjects, pathsArray);

--- a/src/sagas/refresh-projects.saga.js
+++ b/src/sagas/refresh-projects.saga.js
@@ -13,8 +13,6 @@ import { showCustomError } from '../services/custom-dialog.service';
 import type { Saga } from 'redux-saga';
 
 export function* refreshProjects(): Saga<void> {
-  const pathsArray = yield select(getPathsArray);
-
   try {
     yield call(checkIfNodeIsAvailable); // returns node version string
   } catch (err) {
@@ -37,6 +35,7 @@ export function* refreshProjects(): Saga<void> {
     );
     return;
   }
+  const pathsArray = yield select(getPathsArray);
 
   try {
     const projectsFromDisk = yield call(loadGuppyProjects, pathsArray);

--- a/src/sagas/refresh-projects.saga.test.js
+++ b/src/sagas/refresh-projects.saga.test.js
@@ -9,6 +9,7 @@ import {
 } from '../actions';
 import { getPathsArray } from '../reducers/paths.reducer';
 import { loadGuppyProjects } from '../services/read-from-disk.service';
+import { checkIfNodeIsAvailable } from '../services/shell.service';
 
 describe('refresh-projects saga', () => {
   describe('root import-project saga', () => {
@@ -23,6 +24,8 @@ describe('refresh-projects saga', () => {
   describe('refreshProjects', () => {
     it('fetches and dispatches project info', () => {
       const saga = refreshProjects();
+
+      expect(saga.next().value).toEqual(call(checkIfNodeIsAvailable));
 
       // select the paths from Redux state
       expect(saga.next().value).toEqual(select(getPathsArray));
@@ -66,6 +69,8 @@ describe('refresh-projects saga', () => {
 
     it('dispatches an error when it cannot fetch the projects', () => {
       const saga = refreshProjects();
+
+      expect(saga.next().value).toEqual(call(checkIfNodeIsAvailable));
 
       // select the paths from Redux state
       expect(saga.next().value).toEqual(select(getPathsArray));

--- a/src/sagas/refresh-projects.saga.test.js
+++ b/src/sagas/refresh-projects.saga.test.js
@@ -9,7 +9,6 @@ import {
 } from '../actions';
 import { getPathsArray } from '../reducers/paths.reducer';
 import { loadGuppyProjects } from '../services/read-from-disk.service';
-import { checkIfNodeIsAvailable } from '../services/shell.service';
 
 describe('refresh-projects saga', () => {
   describe('root import-project saga', () => {
@@ -24,8 +23,6 @@ describe('refresh-projects saga', () => {
   describe('refreshProjects', () => {
     it('fetches and dispatches project info', () => {
       const saga = refreshProjects();
-
-      expect(saga.next().value).toEqual(call(checkIfNodeIsAvailable));
 
       // select the paths from Redux state
       expect(saga.next().value).toEqual(select(getPathsArray));
@@ -69,8 +66,6 @@ describe('refresh-projects saga', () => {
 
     it('dispatches an error when it cannot fetch the projects', () => {
       const saga = refreshProjects();
-
-      expect(saga.next().value).toEqual(call(checkIfNodeIsAvailable));
 
       // select the paths from Redux state
       expect(saga.next().value).toEqual(select(getPathsArray));

--- a/src/services/custom-dialog.service.js
+++ b/src/services/custom-dialog.service.js
@@ -1,0 +1,67 @@
+import { remote } from 'electron';
+import * as path from 'path';
+
+const { BrowserWindow } = remote;
+
+export function showCustomError(title, message, link) {
+  // so we can add hyperlinks
+  let child = new BrowserWindow({
+    titleBarStyle: 'hidden',
+    parent: window.mainWindow,
+    modal: true,
+    show: false,
+    alwayOnTop: true,
+    icon: path.join(__dirname, 'assets/icons/png/256x256.png'),
+  });
+  const content = `data:text/html,
+  <html>
+    <head>
+      <title>${title}</title>
+      <style>
+        body {
+          font-family: Arial,Helvetica Neue,Helvetica,sans-serif; 
+        }
+        div {
+          padding: 1em;
+          margin: 10%;
+          background: lightgray;
+          border-radius: 10px;
+        }
+        .wrapper {
+          margin: 0 auto;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="wrapper">
+        <div class="message">
+          ${message}
+          <br/><a href="${link.href}">${link.text}</a>
+        </div>
+        <button onclick="window.close()">OK</button>
+      </div>
+    <body>
+  </html>`;
+
+  child.setMenu(null); // remove menu bar
+  child.loadURL(content.trim());
+
+  // dialog.showErrorBox('Node missing', content); // not possible to add a hyperlink
+
+  // todo: open link in default browser
+  // function isSafeishURL(url) {
+  //   return url.startsWith('http:') || url.startsWith('https:');
+  // }
+
+  // child.webContents.on('will-navigate', (event, url) => {
+  //   event.preventDefault();
+  //   if (isSafeishURL(url)) {
+  //     shell.openExternal(url);
+  //   }
+  // });
+
+  child.once('ready-to-show', () => {
+    child.show();
+  });
+  // child.openDevTools();
+}

--- a/src/services/shell.service.js
+++ b/src/services/shell.service.js
@@ -4,6 +4,7 @@
  */
 import { shell } from 'electron';
 import launchEditor from 'react-dev-utils/launchEditor';
+import { exec } from 'child_process';
 
 import type { Project } from '../types';
 
@@ -12,3 +13,14 @@ export const openProjectInFolder = (project: Project) =>
 
 export const openProjectInEditor = (project: Project) =>
   launchEditor(project.path, 1, 1);
+
+export const checkIfNodeIsAvailable = () =>
+  new Promise((resolve, reject) =>
+    exec('node -v', (error, stdout) => {
+      if (error) {
+        return reject(error);
+      }
+
+      resolve(stdout);
+    })
+  );


### PR DESCRIPTION
**Related Issue:**
#263 

**Summary:**
Added a check if `node -v` can be executed with-out a failure. If it fails it will show an error dialog and direct the user to `README.md` installation section.

It also adds a new property to `Mixpanel` so we know the used Node.js version & if node is missing. So we know how often it happens that a user starts Guppy with-out installing Node.js first.
(Maybe we have to update our privacy.md to have the new information there.)

The local state `isNodeMissing` is used to disable the `Create new project wizard`. The create button won't have an effect - we could add a tooltip there & disable the button but I'm not sure if it's worth it to add.  As this is a very rare use-case, node not installed and then clicking around in the app.

**How to test?**
I've tested it on Windows by renaming the path to Node binary. e.g. `C:\Program Files\nodejs\missing`.
Then start the Guppy binary to see the dialog from the screenshot below & the redirection.

**Screenshots/GIFs:**
![screenshot_node_missing_test](https://user-images.githubusercontent.com/3046542/46315994-31d8e400-c5cf-11e8-8c65-5bc209cf105a.PNG)

