### PR TITLE
Create project exists check

### DIFF
--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -3,12 +3,9 @@ import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { check } from 'react-icons-kit/feather/check';
-import { remote } from 'electron';
 
 import { COLORS } from '../../constants';
-import createProject, {
-  checkIfProjectExists,
-} from '../../services/create-project.service';
+import createProject from '../../services/create-project.service';
 
 import Spacer from '../Spacer';
 import WhimsicalInstaller from '../WhimsicalInstaller';
@@ -16,8 +13,6 @@ import BuildStepProgress from './BuildStepProgress';
 
 import type { BuildStep, Status } from './types';
 import type { ProjectType, ProjectInternal } from '../../types';
-
-const { dialog } = remote;
 
 const BUILD_STEPS = {
   installingCliTool: {
@@ -102,32 +97,13 @@ class BuildPane extends PureComponent<Props, State> {
       );
     }
 
-    // todo: How to add this earlier because the build pane already transitioned to installation panel?
-    if (checkIfProjectExists(projectHomePath, projectName)) {
-      // show warning that it will override the project folder
-      dialog.showMessageBox(
-        {
-          type: 'warning',
-          title: 'Project directory exists',
-          message:
-            'Do you like to override the project at the specified location? (No undo possible)',
-          buttons: ['No', 'Yes'],
-        },
-        result => {
-          if (result === 0) {
-            return; // exit creation
-          }
-
-          createProject(
-            { projectName, projectType, projectIcon },
-            this.props.projectHomePath,
-            this.handleStatusUpdate,
-            this.handleError,
-            this.handleComplete
-          );
-        }
-      );
-    }
+    createProject(
+      { projectName, projectType, projectIcon },
+      this.props.projectHomePath,
+      this.handleStatusUpdate,
+      this.handleError,
+      this.handleComplete
+    );
   };
 
   handleStatusUpdate = (output: any) => {

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -83,7 +83,6 @@ class BuildPane extends PureComponent<Props, State> {
       projectName,
       projectType,
       projectIcon,
-      projectHomePath,
     } = this.props;
 
     if (!projectName || !projectType || !projectIcon) {

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -103,14 +103,14 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
     return new Promise((resolve, reject) => {
       const projectName = getProjectNameSlug(this.state.projectName);
       if (checkIfProjectExists(this.props.projectHomePath, projectName)) {
-        // show warning that it will override the project folder
+        // show warning that the project folder already exists & stop creation
         dialog.showMessageBox(
           {
             type: 'warning',
             title: 'Project directory exists',
             message:
-              'Do you like to override the project at the specified location? (No undo possible)',
-            buttons: ['No', 'Yes'],
+              'Please pick a different location or name.\nYou could also manually delete the project from disk and create the project with that name.',
+            buttons: ['OK'],
           },
           result => {
             if (result === 0) {
@@ -132,7 +132,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
     if (!nextStep) {
       return this.checkProjectLocationUsage()
         .then(() => {
-          // not in use or accepted to override
+          // not in use
           this.setState({
             activeField: null,
             status: 'building-project',

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -2,12 +2,14 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Transition from 'react-transition-group/Transition';
+import { remote } from 'electron';
 
 import * as actions from '../../actions';
 import { getById } from '../../reducers/projects.reducer';
 import { getProjectHomePath } from '../../reducers/paths.reducer';
 import { getOnboardingCompleted } from '../../reducers/onboarding-status.reducer';
 import { getProjectNameSlug } from '../../services/create-project.service';
+import { checkIfProjectExists } from '../../services/create-project.service';
 
 import TwoPaneModal from '../TwoPaneModal';
 import Debounced from '../Debounced';
@@ -21,6 +23,7 @@ import type { Field, Status, Step } from './types';
 import type { ProjectType, ProjectInternal } from '../../types';
 
 const FORM_STEPS: Array<Field> = ['projectName', 'projectType', 'projectIcon'];
+const { dialog } = remote;
 
 type Props = {
   projects: { [projectId: string]: ProjectInternal },
@@ -96,16 +99,46 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
     }
   };
 
+  checkProjectLocationUsage = () => {
+    return new Promise((resolve, reject) => {
+      const projectName = getProjectNameSlug(this.state.projectName);
+      if (checkIfProjectExists(this.props.projectHomePath, projectName)) {
+        // show warning that it will override the project folder
+        dialog.showMessageBox(
+          {
+            type: 'warning',
+            title: 'Project directory exists',
+            message:
+              'Do you like to override the project at the specified location? (No undo possible)',
+            buttons: ['No', 'Yes'],
+          },
+          result => {
+            if (result === 0) {
+              return reject();
+            }
+
+            resolve();
+          }
+        );
+      } else {
+        resolve();
+      }
+    });
+  };
   handleSubmit = () => {
     const currentStepIndex = FORM_STEPS.indexOf(this.state.currentStep);
     const nextStep = FORM_STEPS[currentStepIndex + 1];
 
     if (!nextStep) {
-      this.setState({
-        activeField: null,
-        status: 'building-project',
-      });
-      return;
+      return this.checkProjectLocationUsage()
+        .then(() => {
+          // not in use or accepted to override
+          this.setState({
+            activeField: null,
+            status: 'building-project',
+          });
+        })
+        .catch(() => {});
     }
 
     this.setState({

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -109,7 +109,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
             type: 'warning',
             title: 'Project directory exists',
             message:
-              'Please pick a different location or name.\nYou could also manually delete the project from disk and create the project with that name.',
+              "Looks like there's already a project with that name. Did you mean to import it instead?",
             buttons: ['OK'],
           },
           result => {
@@ -138,7 +138,9 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
             status: 'building-project',
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          // Swallow any errors, as the promise above will have shown the appropriate dialog on error
+        });
     }
 
     this.setState({

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -30,7 +30,7 @@ type Props = {
   isProjectNameTaken: boolean,
   updateFieldValue: (field: Field, value: any) => void,
   focusField: (field: ?Field) => void,
-  handleSubmit: () => void,
+  handleSubmit: () => Promise<any> | void,
 };
 
 class MainPane extends PureComponent<Props> {

--- a/src/components/CreateNewProjectWizard/ProjectName.js
+++ b/src/components/CreateNewProjectWizard/ProjectName.js
@@ -21,7 +21,7 @@ type Props = {
   handleFocus: () => void,
   handleBlur: () => void,
   handleChange: (val: string) => void,
-  handleSubmit: () => void,
+  handleSubmit: () => Promise<any> | void,
 };
 
 type State = {

--- a/src/components/CreateNewProjectWizard/SubmitButton.js
+++ b/src/components/CreateNewProjectWizard/SubmitButton.js
@@ -14,7 +14,7 @@ type Props = {
   readyToBeSubmitted: boolean,
   hasBeenSubmitted: boolean,
   isDisabled: boolean,
-  onSubmit: () => void,
+  onSubmit: () => ?Promise<any>,
 };
 
 const SubmitButton = ({

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -25,7 +25,7 @@ type ProjectInfo = {
   projectIcon: string,
 };
 
-export const checkIfProjectExists = (dir, projectName) =>
+export const checkIfProjectExists = (dir: string, projectName: string) =>
   fs.existsSync(path.join(dir, projectName));
 
 /**

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -25,6 +25,9 @@ type ProjectInfo = {
   projectIcon: string,
 };
 
+export const checkIfProjectExists = (dir, projectName) =>
+  fs.existsSync(path.join(dir, projectName));
+
 /**
  * This service manages the creation of a new project.
  * It is in charge of interfacing with the host machine to:


### PR DESCRIPTION
**Related Issue:**
#179

**Summary:**
Added a dialog before project creation starts if the project folder exists and blocks creation.
I don't like the overriding because a user could accidentally destroy an existing project.

I think blocking creation is OK as this is a rare use-case. 

**Screenshots/GIFs:**
![dialog](https://files.gitter.im/AWolf81/7Yl2/image.png)