### PR TITLE
reset onboarding state when deleting project folder

### DIFF
--- a/src/reducers/dependencies.reducer.js
+++ b/src/reducers/dependencies.reducer.js
@@ -12,6 +12,7 @@ import {
   UNINSTALL_DEPENDENCIES_START,
   UNINSTALL_DEPENDENCIES_ERROR,
   UNINSTALL_DEPENDENCIES_FINISH,
+  REFRESH_PROJECTS_FINISH,
   RESET_ALL_STATE,
 } from '../actions';
 
@@ -138,6 +139,20 @@ export default (state: State = initialState, action: Action = {}) => {
       return produce(state, draftState => {
         dependencies.forEach(dependency => {
           delete draftState[projectId][dependency.name];
+        });
+      });
+    }
+
+    case REFRESH_PROJECTS_FINISH: {
+      // check if project still exists
+      return produce(state, draftState => {
+        const depIds = Object.keys(draftState);
+        const ids = Object.keys(action.projects);
+        depIds.forEach(id => {
+          if (ids.indexOf(id) === -1) {
+            // project removed
+            delete draftState[id];
+          }
         });
       });
     }

--- a/src/reducers/dependencies.reducer.test.js
+++ b/src/reducers/dependencies.reducer.test.js
@@ -13,6 +13,7 @@ import {
   UNINSTALL_DEPENDENCIES_START,
   UNINSTALL_DEPENDENCIES_ERROR,
   UNINSTALL_DEPENDENCIES_FINISH,
+  REFRESH_PROJECTS_FINISH,
   RESET_ALL_STATE,
 } from '../actions';
 
@@ -548,6 +549,33 @@ Object {
 Object {
   "foo": Object {},
 }
+`);
+  });
+
+  it(`should handle ${REFRESH_PROJECTS_FINISH} and remove nonn-existing projects`, () => {
+    const prevState = {
+      foo: {
+        redux: {
+          name: 'redux',
+          status: 'queued-delete',
+          location: 'dependencies',
+          description: 'dependency description',
+          keywords: ['key', 'words'],
+          version: '3.2',
+          homepage: 'https://dependency-homepage.io',
+          license: 'MIT',
+          repository: { type: 'git', url: 'https://github.com/foo/bar.git' },
+        },
+      },
+    };
+
+    const action = {
+      type: REFRESH_PROJECTS_FINISH,
+      projects: [],
+    };
+
+    expect(reducer(prevState, action)).toMatchInlineSnapshot(`
+Object {}
 `);
   });
 

--- a/src/reducers/onboarding-status.reducer.js
+++ b/src/reducers/onboarding-status.reducer.js
@@ -46,6 +46,15 @@ export default (state: State = initialState, action: Action = {}) => {
     }
 
     case REFRESH_PROJECTS_FINISH: {
+      const projectKeys = Object.keys(action.projects);
+
+      if (
+        !projectKeys.length &&
+        (state === 'done' || state === 'introducing-sidebar')
+      ) {
+        return 'brand-new';
+      }
+
       // In earlier versions of the app, we would automatically parse the
       // Guppy project directory for projects.
       //
@@ -58,8 +67,6 @@ export default (state: State = initialState, action: Action = {}) => {
       // scanning directories for projects, this shouldn't be an issue anymore.
       // This change is for older clients, and can safely be removed in
       // winter 2018.
-      const projectKeys = Object.keys(action.projects);
-
       return projectKeys.length > 0 ? 'done' : state;
     }
 


### PR DESCRIPTION
If you delete the entire projects folder, guppy will end up in a weird state where we show an empty sidebar.

This makes sure that if the onboarding state expect at least one project and that there is none, it gets reset