### PR TITLE
make sure lifecycle tasks are hidden

### DIFF
--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -269,6 +269,7 @@ const preExistingTasks = [
 ];
 
 export const isLifeCycleHook = (name: string, tasks: Array<Task>) => {
+  // a lifecycle hook  always start with `pre` or `post`
   if (!name.startsWith('pre') && !name.startsWith('post')) {
     return false;
   }


### PR DESCRIPTION
**Summary:**
Make sure tasks like `postinstall`, `pretests`, `prepublish`, etc. are not listed in the task panel. It might be interesting to actually show them in their respective task panel.
