### PR TITLE
Improve delete performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "fix-path": "2.1.0",
     "gatsby-cli": "1.1.58",
     "ps-tree": "1.1.0",
-    "rimraf": "^2.6.2",
+    "rimraf": "2.6.2",
     "yarn": "1.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "fix-path": "2.1.0",
     "gatsby-cli": "1.1.58",
     "ps-tree": "1.1.0",
+    "rimraf": "^2.6.2",
     "yarn": "1.9.2"
   },
   "devDependencies": {

--- a/src/sagas/delete-project.saga.js
+++ b/src/sagas/delete-project.saga.js
@@ -1,6 +1,8 @@
 // @flow
 import { remote } from 'electron';
 import { call, put, select, takeEvery } from 'redux-saga/effects';
+import rimraf from 'rimraf';
+import * as path from 'path';
 
 import {
   SHOW_DELETE_PROJECT_PROMPT,
@@ -81,6 +83,10 @@ export function* deleteProject({ project }: Action): Saga<void> {
 
   if (shouldDeleteFromDisk) {
     // Run the deletion from disk
+    // first delete node_modules folder permanently (faster than moving to trash)
+    yield call([rimraf, rimraf.sync], path.join(project.path, 'node_modules'));
+
+    // delete project folder
     const successfullyDeletedFromDisk = yield call(
       [shell, shell.moveItemToTrash],
       project.path

--- a/src/sagas/delete-project.saga.test.js
+++ b/src/sagas/delete-project.saga.test.js
@@ -1,5 +1,7 @@
 import electron from 'electron'; // Mocked
 import { call, put, select, takeEvery } from 'redux-saga/effects';
+import rimraf from 'rimraf';
+import * as path from 'path';
 
 import rootSaga, {
   deleteProject,
@@ -54,8 +56,12 @@ describe('delete-project saga', () => {
       );
 
       // Next, we select the projects, passing in `1` to confirm the prompt
-      // (`0` is the ID of the "Delete from Disk" option).
+      // (`1` is the ID of the "Delete from Disk" option).
       expect(saga.next(1).value).toEqual(select(getProjectsArray));
+
+      expect(saga.next(projects).value).toEqual(
+        call([rimraf, rimraf.sync], path.join(project.path, 'node_modules'))
+      );
 
       expect(saga.next(projects).value).toEqual(
         call(
@@ -157,7 +163,8 @@ describe('delete-project saga', () => {
       // Confirm dialog
       saga.next(1);
       // Pass in the projects to the select call
-      saga.next(projects);
+      saga.next(projects); // node_modules
+      saga.next(projects); // project folder
 
       // Return `false` to `successfullyDeleted`
       expect(saga.next(false).value).toEqual(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9965,7 +9965,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.0, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@2.6.2, rimraf@^2.2.8, rimraf@^2.5.0, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
**Related Issue:**
#277

**Summary:**
- Added [rimraf](https://www.npmjs.com/package/rimraf) for fast cross-platform delete 
- Splitted delete into two parts:
  - Delete `node_modules` permanently as this can be restored from `npm`
  - Move project to trash afterwards (as before)

Performance is better with-out freezing ~26sec now vs. before ~36sec . Deleting a project in terminal with rimraf takes 14sec. Not sure why it's slower in Guppy. File size in trash shrinked from ~120MB to 611kB for a newly created project.

One point we should do separately and we have to discuss is that we're needing a spinner that the delete is in progress as nothing is clickable during deletion (see screenrecording below). Just the application menu is clickable.
Maybe changing the mouse pointer to a glass would be the easiest - I don't know why that's not happening at the moment.

**Screenshots/GIFs:**
**Improved delete**
![screenrecording_delete_project_improved](https://user-images.githubusercontent.com/3046542/46586944-a0adb580-ca85-11e8-8d87-37beb3177162.gif)