### PR TITLE
Commit after CRA project creation

### DIFF
--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -123,6 +123,14 @@ export default (
             onComplete(packageJson);
           }
         );
+
+        if (projectType === 'create-react-app') {
+          // CRA 2.0 introduces functionality to immediately init a git repo
+          // Need to do a commit after creation to make sure the repo is clean
+          childProcess.exec('git add -A && git commit -m "Add to Guppy"', {
+            cwd: projectPath,
+          });
+        }
       }
     );
   });

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -125,11 +125,18 @@ export default (
         );
 
         if (projectType === 'create-react-app') {
-          // CRA 2.0 introduces functionality to immediately init a git repo
-          // Need to do a commit after creation to make sure the repo is clean
-          childProcess.exec('git add -A && git commit -m "Add to Guppy"', {
-            cwd: projectPath,
-          });
+          try {
+            // CRA 2.0 immediately initializes a git repo upon project creation
+            // so we need to immediately commit the Guppy updates to package.json
+            childProcess.exec(
+              'git add package.json && git commit -m "Add Guppy data to package.json"',
+              {
+                cwd: projectPath,
+              }
+            );
+          } catch (err) {
+            // Ignore
+          }
         }
       }
     );


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
<!--
Please provide the related issue #. Note that in most cases, you should only be opening a pull request that implements a solution discussed in an issue. See our contribution guidelines for more info
-->
Fixes #285

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->

Since CRA 2.0 automatically does a `git init` after project creation, the `package.json` with the Guppy info gets picked up as an uncommitted change, preventing functionality like Eject from running. 

Handling this is as simple as using exec to do a `git add` and `git commit`. The resulting git log for the project is:

```
commit 5664397208c9bda6110efd0f5755f6ccd54e4ea2 (HEAD -> master)
Author: Melanie Seltzer <melleh11@gmail.com>
Date:   Tue Oct 9 15:08:21 2018 -0700

    Add to Guppy

commit 2014d676bff55e6d895722cc425b4a18ce1f1eca
Author: Melanie Seltzer <melleh11@gmail.com>
Date:   Tue Oct 9 15:08:21 2018 -0700

    Initial commit from Create React App
```

I kept the commits separate but if we want to minimize the log, we could just do a `git commit --amend --no-edit` and lump the Guppy change in with CRA's initial commit. However I feel like we should probably keep things separate, to make sure they can tell when the Guppy change comes in... but I don't feel strongly either way.

Haven't added this check to importing functionality yet, because I'm not sure how to handle it since we need to check for CRA AND whether there's a git repo. Maybe read the directory and check for `.git` folder... ?