### PR TITLE
Warn onexit about pending actions

### DIFF
--- a/src/components/Initialization/Initialization.helpers.test.js
+++ b/src/components/Initialization/Initialization.helpers.test.js
@@ -1,0 +1,114 @@
+import {
+  mapTasksPerProjectToString,
+  mapActionsToString,
+} from './Initialization';
+
+describe('Initialization helpers', () => {
+  it('should map install task to string', () => {
+    let task = {
+      action: 'install',
+      active: true,
+      dependencies: [
+        {
+          name: 'test',
+          version: null,
+          updating: null,
+        },
+      ],
+    };
+
+    expect(mapTasksPerProjectToString(task)).toEqual('- Installing 1 task');
+
+    task.dependencies.push({
+      name: 'test2',
+      version: null,
+      updating: null,
+    });
+    expect(mapTasksPerProjectToString(task)).toEqual('- Installing 2 tasks');
+  });
+
+  it('should map uninstall task to string', () => {
+    let task = {
+      action: 'uninstall',
+      active: true,
+      dependencies: [
+        {
+          name: 'test',
+          version: null,
+          updating: null,
+        },
+      ],
+    };
+
+    expect(mapTasksPerProjectToString(task)).toEqual('- Uninstalling 1 task');
+  });
+
+  it('should map project actions to string', () => {
+    const activeActions = [
+      {
+        name: 'My Dummy Project',
+        pending: [
+          {
+            action: 'install',
+            active: true,
+            dependencies: [
+              {
+                name: 'test',
+                version: null,
+                updating: null,
+              },
+            ],
+          },
+          {
+            action: 'install',
+            active: false, // pending installation
+            dependencies: [
+              {
+                name: 'test2',
+                version: null,
+                updating: null,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'My Second Project',
+        pending: [
+          {
+            action: 'install',
+            active: true,
+            dependencies: [
+              {
+                name: 'test',
+                version: null,
+                updating: null,
+              },
+            ],
+          },
+          {
+            action: 'uninstall',
+            active: false, // pending installation
+            dependencies: [
+              {
+                name: 'test2',
+                version: null,
+                updating: null,
+              },
+              {
+                name: 'test3',
+                version: null,
+                updating: null,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(mapActionsToString(activeActions)).toEqual(
+      'Tasks in project My Dummy Project:\n- Installing 1 task\n- Queued 1 task\n\n' +
+        'Tasks in project My Second Project:\n- Installing 1 task\n- Queued 2 tasks\n'
+    );
+  });
+});

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -76,7 +76,6 @@ class Initialization extends PureComponent<Props, State> {
     const { children, isAppLoaded } = this.props;
     const { wasSuccessfullyInitialized } = this.state;
 
-    console.log('app init', this.props.isQueueEmpty);
     return children(wasSuccessfullyInitialized && isAppLoaded);
   }
 }

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -53,6 +53,7 @@ class Initialization extends PureComponent<Props, State> {
 
     const actionCaption = {
       install: 'Installing',
+      uninstall: 'Uninstalling',
     };
 
     // Map actions to the following string format (multiple projects & multiple queued tasks). For each project it will be a string like:

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -60,9 +60,9 @@ class Initialization extends PureComponent<Props, State> {
     // Task in project <project.name>:\n
     // - <Installing or Queued> <count> task(s)\n
     const mapActionsToString = activeActions
-      .map(
-        actionItem =>
-          `Tasks in project ${actionItem.name}:\n` +
+      .map(actionItem =>
+        [
+          `Tasks in project ${actionItem.name}:`,
           actionItem.pending
             .map(
               task =>
@@ -74,7 +74,9 @@ class Initialization extends PureComponent<Props, State> {
                 task.dependencies.length +
                 ' task(s)'
             )
-            .join('\n')
+            .join('\n'),
+          '',
+        ].join('\n')
       )
       .join('\n');
 

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -82,7 +82,7 @@ class Initialization extends PureComponent<Props, State> {
       const result = dialog.showMessageBox({
         type: 'warning',
         message:
-          'mapActionsToStringThere are active tasks. Do you really want to quit?\n\n' +
+          'There are active tasks. Do you really want to quit?\n\n' +
           mapActionsToString,
         buttons: ['Abort', 'Yes, proceed (UNSAFE)'],
       });

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -58,23 +58,24 @@ class Initialization extends PureComponent<Props, State> {
     // Map actions to the following string format (multiple projects & multiple queued tasks). For each project it will be a string like:
     // Task in project <project.name>:\n
     // - <Installing or Queued> <count> task(s)\n
-    const mapActionsToString = activeActions.map(
-      actionItem =>
-        'Tasks in project ' +
-        actionItem.name +
-        ':\n' +
-        actionItem.pending.map(
-          task =>
-            '* ' +
-            (task.active
-              ? actionCaption[task.action] || task.action
-              : 'Queued') +
-            ' ' +
-            task.dependencies.length +
-            ' task(s)\n'
-        ) +
-        '\n'
-    );
+    const mapActionsToString = activeActions
+      .map(
+        actionItem =>
+          `Tasks in project ${actionItem.name}:\n` +
+          actionItem.pending
+            .map(
+              task =>
+                '* ' +
+                (task.active
+                  ? actionCaption[task.action] || task.action
+                  : 'Queued') +
+                ' ' +
+                task.dependencies.length +
+                ' task(s)'
+            )
+            .join('\n')
+      )
+      .join('\n');
 
     if (!isQueueEmpty) {
       // warn user

--- a/src/main.js
+++ b/src/main.js
@@ -106,13 +106,13 @@ app.on('window-all-closed', function() {
   }
 });
 
-app.on('before-quit', ev => {
-  if (processIds.length) {
-    ev.preventDefault();
-    killAllRunningProcesses();
-    app.quit();
-  }
-});
+// app.on('before-quit', ev => {
+//   if (processIds.length) {
+//     ev.preventDefault();
+//     killAllRunningProcesses();
+//     app.quit();
+//   }
+// });
 
 app.on('activate', function() {
   // On OS X it's common to re-create a window in the app when the
@@ -131,7 +131,11 @@ ipcMain.on('removeProcessId', (event, processId) => {
 });
 
 ipcMain.on('killAllRunningProcesses', event => {
-  killAllRunningProcesses();
+  if (processIds.length) {
+    event.preventDefault();
+    killAllRunningProcesses();
+  }
+  app.quit();
 });
 
 const killAllRunningProcesses = () => {

--- a/src/main.js
+++ b/src/main.js
@@ -117,14 +117,6 @@ app.on('window-all-closed', function() {
   }
 });
 
-// app.on('before-quit', ev => {
-//   if (processIds.length) {
-//     ev.preventDefault();
-//     killAllRunningProcesses();
-//     app.quit();
-//   }
-// });
-
 app.on('activate', function() {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.


### PR DESCRIPTION
**Related Issue:**
#211

**Summary:**
- Added on close handling with IPC communication between mainWindow and renderer. Handled with channel `appWillClose` & `triggerClose`
- Created a pending task list to the modal that will be triggered if queue is not empty

**Todos**
- [x] Remove commented `before-quit` handler. Not needed anymore.
- [x] Add a `\n` beween the projects in the dialog message to have a better separation.

**Things to discuss**
- Copy text OK, or should we modify something? Also is the information reduction OK? Or should we show what's installing/uninstalling?
- As mentiond `CreateProject` build process can be closed with-out dialog. We need to tackle this later as this transition state is not tracked yet.
- Is there an easier way to handle the dialog on exit? The problem is that we need to stop the event in the main process. That's why everything I've added in renderer/component wasn't working. 

**Screenshots/GIFs:**
![grafik](https://user-images.githubusercontent.com/3046542/46833316-9dc60400-cda8-11e8-9d46-ac5e85002378.png)
