### PR TITLE
[WIP] Check git status before ejecting

### DIFF
--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -147,7 +147,7 @@ export default (state: State = initialState, action: Action = {}) => {
         // For the eject task, we simply want to delete this task altogether.
         // TODO: We should probably do this in `REFRESH_PROJECTS_FINISH`, which
         // is called right after the eject task succeeds!
-        if (task.name === 'eject') {
+        if (task.name === 'eject' && wasSuccessful) {
           delete draftState[task.projectId][task.name];
           return;
         }

--- a/src/reducers/tasks.reducer.js
+++ b/src/reducers/tasks.reducer.js
@@ -145,8 +145,6 @@ export default (state: State = initialState, action: Action = {}) => {
 
       return produce(state, draftState => {
         // For the eject task, we simply want to delete this task altogether.
-        // TODO: We should probably do this in `REFRESH_PROJECTS_FINISH`, which
-        // is called right after the eject task succeeds!
         if (task.name === 'eject' && wasSuccessful) {
           delete draftState[task.projectId][task.name];
           return;

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -264,7 +264,7 @@ export function* taskRun({ task }: Action): Saga<void> {
               title: 'Oops!',
               message: 'Dirty git state detected',
               detail:
-                'Oh no! In order to eject, git state must be clean. Please commit your changes to continue ejecting.',
+                'Oh no! In order to eject, git state must be clean. Please commit your changes and retry ejecting.',
             });
           }
 

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -1,7 +1,7 @@
 // @flow
 import { select, call, put, take, takeEvery } from 'redux-saga/effects';
 import { eventChannel, END } from 'redux-saga';
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, remote } from 'electron';
 import * as childProcess from 'child_process';
 import chalkRaw from 'chalk';
 
@@ -30,6 +30,7 @@ import { processLogger } from '../services/process-logger.service';
 import type { Action } from 'redux';
 import type { Saga } from 'redux-saga';
 import type { Task, ProjectType } from '../types';
+const { dialog } = remote;
 
 const chalk = new chalkRaw.constructor({ level: 3 });
 
@@ -218,7 +219,17 @@ export function* taskRun({ task }: Action): Saga<void> {
     stderr: emitter => data => {
       const text = stripUnusableControlCharacters(data.toString());
 
-      emitter({ channel: 'stderr', text });
+      // When trying to eject, there will be an error from CRA if git state
+      // isn't clean. We can use this.
+      const uncleanRepo = text.includes(
+        'git repository has untracked files or uncommitted changes'
+      );
+
+      emitter({
+        channel: uncleanRepo === true ? 'exit' : 'stderr',
+        text,
+        uncleanRepo,
+      });
     },
     exit: emitter => code => {
       const timestamp = new Date();
@@ -230,6 +241,7 @@ export function* taskRun({ task }: Action): Saga<void> {
 
   while (true) {
     const message = yield take(stdioChannel);
+    const { uncleanRepo } = message;
 
     switch (message.channel) {
       case 'stdout':
@@ -242,6 +254,20 @@ export function* taskRun({ task }: Action): Saga<void> {
 
       case 'exit':
         if (task.name === 'eject') {
+          // If ejecting failed due to unclean repo, then throw up a dialog
+          if (uncleanRepo === true) {
+            dialog.showMessageBox({
+              type: 'warning',
+              buttons: ['Ok'],
+              defaultId: 0,
+              cancelId: 0,
+              title: 'Oops!',
+              message: 'Dirty git state detected',
+              detail:
+                'Oh no! In order to eject, git state must be clean. Please commit your changes to continue ejecting.',
+            });
+          }
+
           // Run a fresh install of dependencies after ejecting to get around issue
           // documented here https://github.com/facebook/create-react-app/issues/4433
           const installProcess = yield call(

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -226,7 +226,7 @@ export function* taskRun({ task }: Action): Saga<void> {
       );
 
       emitter({
-        channel: uncleanRepo === true ? 'exit' : 'stderr',
+        channel: uncleanRepo ? 'exit' : 'stderr',
         text,
         uncleanRepo,
       });
@@ -255,7 +255,7 @@ export function* taskRun({ task }: Action): Saga<void> {
       case 'exit':
         if (task.name === 'eject') {
           // If ejecting failed due to unclean repo, then throw up a dialog
-          if (uncleanRepo === true) {
+          if (uncleanRepo) {
             dialog.showMessageBox({
               type: 'warning',
               buttons: ['Ok'],

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -284,7 +284,12 @@ describe('task saga', () => {
         );
 
         expect(
-          saga.next({ channel: 'exit', timestamp, wasSuccessful: true }).value
+          saga.next({
+            channel: 'exit',
+            timestamp,
+            wasSuccessful: true,
+            uncleanRepo: false,
+          }).value
         ).toEqual(installProcessDescription);
 
         expect(saga.next(installProcessDescription).value).toEqual(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
#285

**Summary:**
Checking git status before ejecting because ejecting will not work with a dirty repo. It's working as is but I'm classifying this as WIP because I wanted to get some opinions on a few things:

- @AWolf81 you mentioned adding a try/catch during eject but I wasn't clear where to add that (maybe I misread) - any thoughts after seeing this PR code?
- We needed some way to track whether the repo was clean (because the installation in the exit shouldn't run if ejecting failed due to repo being dirty). So I did this:

```js
emitter({
  channel: uncleanRepo === true ? 'exit' : 'stderr',
  text,
  uncleanRepo,
});
```

Then used `uncleanRepo` in some if statements. Weirdly, I had to get super specific or it would always run the installation. For e.g. something like this wouldn't work:

```js
if (uncleanRepo === true) {
 ....
} else {
 ...
}
```

Had to get specific with `uncleanRepo === false` as you can see in the code. What are people's opinions on that?

- We can also do this in the reducer to make it idle again instead of a fail status. Let me know if that would be preferable.

```js
// If Eject task was not successful, make it idle 
if (task.name === 'eject' && !wasSuccessful) {
  nextStatus = 'idle';
}
```

**Screenshot**

![kapture 2018-10-12 at 19 41 21](https://user-images.githubusercontent.com/17421347/46900437-dd4b2980-ce56-11e8-82cb-df2efecef722.gif)
