### PR TITLE
Fix bundled Mac app

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -8,6 +8,7 @@ import { COLORS } from '../../constants';
 import { getSelectedProjectId } from '../../reducers/projects.reducer';
 import { getAppLoaded } from '../../reducers/app-loaded.reducer';
 import logger from '../../services/analytics.service';
+import { initializePath } from '../../services/platform.service';
 
 import IntroScreen from '../IntroScreen';
 import Sidebar from '../Sidebar';
@@ -26,6 +27,8 @@ type Props = {
 
 class App extends PureComponent<Props> {
   componentDidMount() {
+    initializePath();
+
     window.addEventListener('beforeunload', this.killAllRunningProcesses);
 
     logger.logEvent('load-application');

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -73,7 +73,7 @@ export const getBaseProjectEnvironment = (
 // When using NVM on a Mac, node is added to the PATH in .bashrc, but this
 // file isn't read in production.
 // NOTE: This is something that fix-path is supposed to do for us, but it
-// isn't working :/
+// isn't working :/ so this is just a quick fix.
 export const initializePath = () => {
   childProcess.exec('which node', { env: window.process.env }, (_, version) => {
     if (!version) {
@@ -81,7 +81,9 @@ export const initializePath = () => {
         childProcess.exec(
           'source ~/.bashrc && echo $PATH',
           (err, updatedPath) => {
-            window.process.env.PATH = updatedPath;
+            if (updatedPath) {
+              window.process.env.PATH = updatedPath;
+            }
           }
         );
       } catch (e) {

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -70,23 +70,26 @@ export const getBaseProjectEnvironment = (
   };
 };
 
-// For some reason, MacOS doesn't get the PATH initialzied properly, since
-// .bashrc (a file meant to be sourced for interactive shells) isn't read.
-// This helper method fixes that.
+// When using NVM on a Mac, node is added to the PATH in .bashrc, but this
+// file isn't read in production.
+// NOTE: This is something that fix-path is supposed to do for us, but it
+// isn't working :/
 export const initializePath = () => {
-  if (process.env.NODE_ENV !== 'development' && isMac) {
-    try {
-      childProcess.exec(
-        'source ~/.bashrc && echo $PATH',
-        (err, updatedPath) => {
-          window.process.env.PATH = updatedPath;
-        }
-      );
-    } catch (e) {
-      // If no `.bashrc` exists, we have no work to do.
-      // The PATH should already be set correctly.
+  childProcess.exec('which node', (_, version) => {
+    if (!version) {
+      try {
+        childProcess.exec(
+          'source ~/.bashrc && echo $PATH',
+          (err, updatedPath) => {
+            window.process.env.PATH = updatedPath;
+          }
+        );
+      } catch (e) {
+        // If no `.bashrc` exists, we have no work to do.
+        // The PATH should already be set correctly.
+      }
     }
-  }
+  });
 };
 
 export const getCopyForOpeningFolder = () =>

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -75,7 +75,7 @@ export const getBaseProjectEnvironment = (
 // NOTE: This is something that fix-path is supposed to do for us, but it
 // isn't working :/
 export const initializePath = () => {
-  childProcess.exec('which node', (_, version) => {
+  childProcess.exec('which node', { env: window.process.env }, (_, version) => {
     if (!version) {
       try {
         childProcess.exec(


### PR DESCRIPTION
We noticed when using the built application (with Electron Builder), Node wasn't found in the Path on MacOS, on computers that use NVM.

An issue with electron-builder (I think?) meant that the `.bashrc` file wasn't being sourced when creating new processes with `childProcess`.

`.bashrc` is _meant_ to be sourced for shells processes like this - NVM (Node Version Manager) assumes that it will be, and so that's where it adds the path to Node.

This change tries to read `.bashrc` when the app mounts, which updates the PATH based on stuff in that file.

This is a hacky fix, but to be honest, I just want to get 0.3 out. We can circle back to this and come up with a nicer fix later =)