### PR TITLE
[WIP] Show fish spinner while project is getting deleted from disk

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -59,6 +59,7 @@ export const IMPORT_EXISTING_PROJECT_START = 'IMPORT_EXISTING_PROJECT_START';
 export const IMPORT_EXISTING_PROJECT_ERROR = 'IMPORT_EXISTING_PROJECT_ERROR';
 export const IMPORT_EXISTING_PROJECT_FINISH = 'IMPORT_EXISTING_PROJECT_FINISH';
 export const SHOW_DELETE_PROJECT_PROMPT = 'SHOW_DELETE_PROJECT_PROMPT';
+export const START_DELETING_PROJECT = 'START_DELETING_PROJECT';
 export const FINISH_DELETING_PROJECT = 'FINISH_DELETING_PROJECT';
 export const SHOW_RESET_STATE_PROMPT = 'SHOW_RESET_STATE_PROMPT';
 export const RESET_ALL_STATE = 'RESET_ALL_STATE';
@@ -368,6 +369,10 @@ export const saveProjectSettingsFinish = (
   type: SAVE_PROJECT_SETTINGS_FINISH,
   project,
   projectPath,
+});
+
+export const startDeletingProject = () => ({
+  type: START_DELETING_PROJECT,
 });
 
 export const finishDeletingProject = (projectId: string) => ({

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import styled, { keyframes } from 'styled-components';
 
 import { COLORS } from '../../constants';
 import { getSelectedProjectId } from '../../reducers/projects.reducer';
+import { getBlockingStatus } from '../../reducers/app-status.reducer';
 
 import IntroScreen from '../IntroScreen';
 import Sidebar from '../Sidebar';
@@ -14,34 +15,33 @@ import ProjectPage from '../ProjectPage';
 import CreateNewProjectWizard from '../CreateNewProjectWizard';
 import ProjectConfigurationModal from '../ProjectConfigurationModal';
 import Initialization from '../Initialization';
+import LoadingScreen from '../LoadingScreen';
 
 import type { Project } from '../../types';
 
 type Props = {
   selectedProjectId: ?Project,
+  showLoadingScreen: boolean,
 };
 
 class App extends PureComponent<Props> {
   render() {
-    const { selectedProjectId } = this.props;
-
+    const { selectedProjectId, showLoadingScreen } = this.props;
+    console.log(showLoadingScreen);
     return (
       <Initialization>
         {wasSuccessfullyInitialized =>
           wasSuccessfullyInitialized && (
             <Fragment>
               <Titlebar />
-
               <Wrapper>
                 <ApplicationMenu />
-
+                {showLoadingScreen && <LoadingScreen />}
                 <Sidebar />
-
                 <MainContent>
                   {selectedProjectId ? <ProjectPage /> : <IntroScreen />}
                 </MainContent>
               </Wrapper>
-
               <CreateNewProjectWizard />
               <ProjectConfigurationModal />
             </Fragment>
@@ -74,6 +74,7 @@ const MainContent = styled.div`
 
 const mapStateToProps = state => ({
   selectedProjectId: getSelectedProjectId(state),
+  showLoadingScreen: getBlockingStatus(state),
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/components/LoadingScreen/LoadingScreen.js
+++ b/src/components/LoadingScreen/LoadingScreen.js
@@ -1,0 +1,29 @@
+// @flow
+import React from 'react';
+import styled from 'styled-components';
+
+import guppyLoaderSrc from '../../assets/images/guppy-loader.gif';
+import { COLORS, Z_INDICES } from '../../constants';
+
+const LoadingScreen = () => (
+  <Window>
+    <FishSpinner src={guppyLoaderSrc} alt="Fish loader" />
+  </Window>
+);
+
+const Window = styled.div`
+  align-items: center;
+  background: ${COLORS.transparentWhite[300]};
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  position: fixed;
+  width: 100vw;
+  z-index: ${Z_INDICES.loadingScreen};
+`;
+
+const FishSpinner = styled.img`
+  width: 150px;
+`;
+
+export default LoadingScreen;

--- a/src/components/LoadingScreen/index.js
+++ b/src/components/LoadingScreen/index.js
@@ -1,0 +1,1 @@
+export { default } from './LoadingScreen';

--- a/src/constants.js
+++ b/src/constants.js
@@ -111,6 +111,7 @@ export const BREAKPOINTS = {
 export const Z_INDICES = {
   sidebar: 100,
   modal: 1000,
+  loadingScreen: 2000,
   titlebar: 10000,
 };
 

--- a/src/reducers/app-status.reducer.js
+++ b/src/reducers/app-status.reducer.js
@@ -1,0 +1,36 @@
+// @flow
+import { START_DELETING_PROJECT, FINISH_DELETING_PROJECT } from '../actions';
+
+import type { Action } from 'redux';
+
+type State = {
+  blockingActionActive: boolean,
+};
+
+const initialState = {
+  blockingActionActive: false,
+};
+
+export default (state: State = initialState, action: Action = {}) => {
+  switch (action.type) {
+    case START_DELETING_PROJECT:
+      return {
+        blockingActionActive: true,
+      };
+
+    case FINISH_DELETING_PROJECT:
+      return {
+        blockingActionActive: false,
+      };
+
+    default:
+      return initialState;
+  }
+};
+
+//
+//
+//
+// Helpers
+export const getBlockingStatus = (state: any) =>
+  state.appStatus.blockingActionActive;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 
 import appLoaded from './app-loaded.reducer';
+import appStatus from './app-status.reducer';
 import projects from './projects.reducer';
 import tasks from './tasks.reducer';
 import dependencies from './dependencies.reducer';
@@ -11,6 +12,7 @@ import queue from './queue.reducer';
 
 export default combineReducers({
   appLoaded,
+  appStatus,
   projects,
   tasks,
   dependencies,

--- a/src/sagas/delete-project.saga.js
+++ b/src/sagas/delete-project.saga.js
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import {
   SHOW_DELETE_PROJECT_PROMPT,
+  startDeletingProject,
   finishDeletingProject,
   selectProject,
   createNewProjectStart,
@@ -82,6 +83,9 @@ export function* deleteProject({ project }: Action): Saga<void> {
   const nextSelectedProjectId = getNextProjectId(projects, project.id);
 
   if (shouldDeleteFromDisk) {
+    // Delete from disk tasks some time, so show a loading screen
+    yield put(startDeletingProject());
+
     // Run the deletion from disk
     // first delete node_modules folder permanently (faster than moving to trash)
     yield call([rimraf, rimraf.sync], path.join(project.path, 'node_modules'));

--- a/src/sagas/delete-project.saga.test.js
+++ b/src/sagas/delete-project.saga.test.js
@@ -13,6 +13,7 @@ import {
   finishDeletingProject,
   selectProject,
   createNewProjectStart,
+  startDeletingProject,
 } from '../actions';
 import { getProjectsArray } from '../reducers/projects.reducer';
 
@@ -58,6 +59,9 @@ describe('delete-project saga', () => {
       // Next, we select the projects, passing in `1` to confirm the prompt
       // (`1` is the ID of the "Delete from Disk" option).
       expect(saga.next(1).value).toEqual(select(getProjectsArray));
+
+      // Show fish spinner (loading) screen
+      expect(saga.next(projects).value).toEqual(put(startDeletingProject()));
 
       expect(saga.next(projects).value).toEqual(
         call([rimraf, rimraf.sync], path.join(project.path, 'node_modules'))
@@ -162,7 +166,9 @@ describe('delete-project saga', () => {
       saga.next();
       // Confirm dialog
       saga.next(1);
+
       // Pass in the projects to the select call
+      saga.next(projects); // Fish spinner (loading) screen
       saga.next(projects); // node_modules
       saga.next(projects); // project folder
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
#282

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->

Show a fish spinner loading screen when the project is getting deleted. This is almost ready to go.

When it comes time to delete from disk, it seems like something (maybe rimraf?) is causing things to freeze and the screen cannot be rendered in time before things move on.

I don't think it's an issue with the `LoadingScreen` component since you can render it fine if you set the `initialState` in `app-status.reducer.js` to true. And the reducer seems to work fine (I'm doing a console.log in App.js and it's updating true/false as expected).

Any ideas? :/

**Screenshots/GIFs:**
<!--
For changes that affect the UI, please include a screenshot of the change. If the change is related to part of a flow, please include a GIF screen recording.

Free software to create screen-recording GIFs:
- Giphy Capture (MacOS only): https://giphy.com/apps/giphycapture
- Licecap (MacOS / Win): https://www.cockos.com/licecap/
- Peek (Linux): https://github.com/phw/peek
-->

LoadingScreen component:

<img width="860" alt="screen shot 2018-10-15 at 7 05 21 pm" src="https://user-images.githubusercontent.com/17421347/46988397-4af09300-d0ad-11e8-8f70-684f4968ac2b.png">
