### PR TITLE
Initialize path before checking Node installation

### DIFF
--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -31,19 +31,19 @@ class Initialization extends PureComponent<Props, State> {
 
       const nodeVersion = await getNodeJsVersion();
 
-      if (!nodeVersion) {
-        throw new Error('node-not-found');
-      }
-
       this.setState({ wasSuccessfullyInitialized: !!nodeVersion });
 
       logger.logEvent('load-application', {
         node_version: nodeVersion,
       });
 
+      if (!nodeVersion) {
+        throw new Error('node-not-found');
+      }
+
       ipcRenderer.on('app-will-close', this.appWillClose);
     } catch (e) {
-      switch (e) {
+      switch (e.message) {
         case 'node-not-found': {
           dialog.showErrorBox(
             'Node missing',

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -32,13 +32,7 @@ class Initialization extends PureComponent<Props, State> {
       const nodeVersion = await getNodeJsVersion();
 
       if (!nodeVersion) {
-        dialog.showErrorBox(
-          'Node missing',
-          'It looks like Node.js isn\'t installed. Node is required to use Guppy.\nWhen you click "OK", you\'ll be directed to instructions to download and install Node.'
-        );
-        shell.openExternal(
-          `${GUPPY_REPO_URL}/blob/master/README.md#installation`
-        );
+        throw new Error('node-not-found');
       }
 
       this.setState({ wasSuccessfullyInitialized: !!nodeVersion });
@@ -49,8 +43,22 @@ class Initialization extends PureComponent<Props, State> {
 
       ipcRenderer.on('app-will-close', this.appWillClose);
     } catch (e) {
-      // Path initialization can reject if no valid Node version is found.
-      // This isn't really an error, though, so we can swallow it.
+      switch (e) {
+        case 'node-not-found': {
+          dialog.showErrorBox(
+            'Node missing',
+            'It looks like Node.js isn\'t installed. Node is required to use Guppy.\nWhen you click "OK", you\'ll be directed to instructions to download and install Node.'
+          );
+          shell.openExternal(
+            `${GUPPY_REPO_URL}/blob/master/README.md#installation`
+          );
+          break;
+        }
+        default: {
+          // Path initialization can reject if no valid Node version is found.
+          // This isn't really an error, though, so we can swallow it.
+        }
+      }
     }
   }
 

--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -42,7 +42,6 @@ class Initialization extends PureComponent<Props, State> {
         ipcRenderer.on('app-will-close', this.appWillClose);
       })
       .catch(e => {
-        console.log('Caught', e);
         switch (e.message) {
           case 'node-not-found': {
             dialog.showErrorBox(

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -72,8 +72,6 @@ export const getBaseProjectEnvironment = (
   };
 };
 
-window.childProcess = childProcess;
-
 // HACK: With electron-builder, we're having some issues on mac finding Node.
 // This is because for some reason, the PATH is not updated properly :(
 // 'fix-path' is supposed to do this for us, but it doesn't work, for unknown

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -79,26 +79,33 @@ window.childProcess = childProcess;
 // 'fix-path' is supposed to do this for us, but it doesn't work, for unknown
 // reasons.
 export const initializePath = () => {
-  childProcess.exec('which node', { env: window.process.env }, (_, version) => {
-    if (!version && isMac) {
-      // For users with a standard Node installation, node will be in
-      // /usr/local/bin
-      // For users using NVM, the path to Node will be added to `.bashrc`.
-      // Add both to the PATH.
-      try {
-        childProcess.exec(
-          'source ~/.bashrc && echo $PATH',
-          (err, updatedPath) => {
-            if (updatedPath) {
-              window.process.env.PATH = `/usr/local/bin:${updatedPath}`;
-            }
+  return new Promise((resolve, reject) => {
+    childProcess.exec(
+      'which node',
+      { env: window.process.env },
+      (_, version) => {
+        if (!version && isMac) {
+          // For users with a standard Node installation, node will be in
+          // /usr/local/bin
+          // For users using NVM, the path to Node will be added to `.bashrc`.
+          // Add both to the PATH.
+          try {
+            childProcess.exec(
+              'source ~/.bashrc && echo $PATH',
+              (err, updatedPath) => {
+                if (updatedPath) {
+                  window.process.env.PATH = `/usr/local/bin:${updatedPath}`;
+                }
+
+                resolve();
+              }
+            );
+          } catch (e) {
+            reject(e);
           }
-        );
-      } catch (e) {
-        // If no `.bashrc` exists, we have no work to do.
-        // The PATH should already be set correctly.
+        }
       }
-    }
+    );
   });
 };
 

--- a/src/services/platform.service.js
+++ b/src/services/platform.service.js
@@ -77,30 +77,38 @@ export const getBaseProjectEnvironment = (
 // 'fix-path' is supposed to do this for us, but it doesn't work, for unknown
 // reasons.
 export const initializePath = () => {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
+    if (!isMac) {
+      return resolve();
+    }
+
+    // Check if we need to fix the Path (Mac only)
     childProcess.exec(
       'which node',
       { env: window.process.env },
-      (_, version) => {
-        if (!version && isMac) {
-          // For users with a standard Node installation, node will be in
-          // /usr/local/bin
-          // For users using NVM, the path to Node will be added to `.bashrc`.
-          // Add both to the PATH.
-          try {
-            childProcess.exec(
-              'source ~/.bashrc && echo $PATH',
-              (err, updatedPath) => {
-                if (updatedPath) {
-                  window.process.env.PATH = `/usr/local/bin:${updatedPath}`;
-                }
+      (_, nodePath) => {
+        if (nodePath) {
+          // Node found
+          return resolve();
+        }
 
-                resolve();
+        // For users with a standard Node installation, node will be in
+        // /usr/local/bin
+        // For users using NVM, the path to Node will be added to `.bashrc`.
+        // Add both to the PATH.
+        try {
+          childProcess.exec(
+            'source ~/.bashrc && echo $PATH',
+            (err, updatedPath) => {
+              if (updatedPath) {
+                window.process.env.PATH = `/usr/local/bin:${updatedPath}`;
               }
-            );
-          } catch (e) {
-            reject(e);
-          }
+
+              resolve();
+            }
+          );
+        } catch (e) {
+          resolve(e);
         }
       }
     );

--- a/src/services/shell.service.js
+++ b/src/services/shell.service.js
@@ -16,11 +16,11 @@ export const openProjectInEditor = (project: Project) =>
 
 export const getNodeJsVersion = () =>
   new Promise(resolve =>
-    exec('node -v', (error, stdout) => {
+    exec('node -v', { env: window.process.env }, (error, stdout) => {
       if (error) {
         return resolve();
       }
 
-      resolve(stdout.trim());
+      resolve(stdout.toString().trim());
     })
   );


### PR DESCRIPTION
Final fix for the electron-builder switch. Needed to reconfigure my `initializePath` method to return a promise, and then wait for it to complete before checking the Node version.