### PR TITLE
Show dialog if project delete fails

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -61,6 +61,7 @@ export const IMPORT_EXISTING_PROJECT_FINISH = 'IMPORT_EXISTING_PROJECT_FINISH';
 export const SHOW_DELETE_PROJECT_PROMPT = 'SHOW_DELETE_PROJECT_PROMPT';
 export const START_DELETING_PROJECT = 'START_DELETING_PROJECT';
 export const FINISH_DELETING_PROJECT = 'FINISH_DELETING_PROJECT';
+export const DELETE_PROJECT_ERROR = 'DELETE_PROJECT_ERROR';
 export const SHOW_RESET_STATE_PROMPT = 'SHOW_RESET_STATE_PROMPT';
 export const RESET_ALL_STATE = 'RESET_ALL_STATE';
 
@@ -378,6 +379,10 @@ export const startDeletingProject = () => ({
 export const finishDeletingProject = (projectId: string) => ({
   type: FINISH_DELETING_PROJECT,
   projectId,
+});
+
+export const deleteProjectError = () => ({
+  type: DELETE_PROJECT_ERROR,
 });
 
 export const showResetStatePrompt = () => ({

--- a/src/reducers/app-status.reducer.js
+++ b/src/reducers/app-status.reducer.js
@@ -1,5 +1,9 @@
 // @flow
-import { START_DELETING_PROJECT, FINISH_DELETING_PROJECT } from '../actions';
+import {
+  START_DELETING_PROJECT,
+  FINISH_DELETING_PROJECT,
+  DELETE_PROJECT_ERROR,
+} from '../actions';
 
 import type { Action } from 'redux';
 
@@ -19,6 +23,7 @@ export default (state: State = initialState, action: Action = {}) => {
       };
 
     case FINISH_DELETING_PROJECT:
+    case DELETE_PROJECT_ERROR:
       return {
         blockingActionActive: false,
       };

--- a/src/sagas/delete-project.saga.js
+++ b/src/sagas/delete-project.saga.js
@@ -120,7 +120,7 @@ export function* deleteProject({ project }: Action): Saga<void> {
       // can happen if the filesystem can't delete it (maybe if file is open?).
       yield put(deleteProjectError());
 
-      dialog.showMessageBox({
+      yield call([dialog, dialog.showMessageBox], {
         type: 'warning',
         buttons: ['Ok'],
         defaultId: 0,

--- a/src/sagas/delete-project.saga.js
+++ b/src/sagas/delete-project.saga.js
@@ -8,6 +8,7 @@ import {
   SHOW_DELETE_PROJECT_PROMPT,
   startDeletingProject,
   finishDeletingProject,
+  deleteProjectError,
   selectProject,
   createNewProjectStart,
 } from '../actions';
@@ -95,29 +96,33 @@ export function* deleteProject({ project }: Action): Saga<void> {
   const nextSelectedProjectId = getNextProjectId(projects, project.id);
 
   if (shouldDeleteFromDisk) {
-    // Delete from disk tasks some time, so show a loading screen
-    yield put(startDeletingProject());
+    try {
+      // Delete from disk tasks some time, so show a loading screen
+      yield put(startDeletingProject());
 
-    // Run the deletion from disk
-    // first delete node_modules folder permanently (faster than moving to trash)
-    yield call(waitForAsyncRimraf, project.path);
+      // Run the deletion from disk
+      // first delete node_modules folder permanently (faster than moving to trash)
+      yield call(waitForAsyncRimraf, project.path);
 
-    // delete project folder
-    const successfullyDeletedFromDisk = yield call(
-      [shell, shell.moveItemToTrash],
-      project.path
-    );
+      // delete project folder
+      yield call([shell, shell.moveItemToTrash], project.path);
+    } catch (err) {
+      // If for some reason it was _not_ successfully deleted, show error and return,
+      // so project isn't removed from Guppy state. Failure to delete from disk
+      // can happen if the filesystem can't delete it (maybe if file is open?).
+      yield put(deleteProjectError());
 
-    // If for some reason it was _not_ successfully deleted, bail early and log
-    // an error. This can happen if the filesystem can't delete it (maybe if
-    // a file is open?)
-    // TODO: Actually show something in the UI in this case.
-    if (!successfullyDeletedFromDisk) {
-      yield call(
-        [console, console.error],
-        'Project could not be deleted. Please make sure no tasks are running, ' +
-          'and no applications are using files in that directory.'
-      );
+      dialog.showMessageBox({
+        type: 'warning',
+        buttons: ['Ok'],
+        defaultId: 0,
+        cancelId: 0,
+        title: 'Error!',
+        message: `Could not delete ${project.name}`,
+        detail:
+          'Please make sure no tasks are running and no applications are using files in that directory.',
+      });
+
       return;
     }
   }

--- a/src/sagas/delete-project.saga.test.js
+++ b/src/sagas/delete-project.saga.test.js
@@ -16,8 +16,14 @@ import {
   selectProject,
   createNewProjectStart,
   startDeletingProject,
+  deleteProjectError,
+  loadDependencyInfoFromDisk,
 } from '../actions';
 import { getProjectsArray } from '../reducers/projects.reducer';
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+}));
 
 describe('delete-project saga', () => {
   describe('root delete-project saga', () => {
@@ -154,7 +160,7 @@ describe('delete-project saga', () => {
       expect(saga.next().done).toEqual(true);
     });
 
-    it("logs an error when the project can't be deleted", () => {
+    it("displays an error when the project can't be deleted", () => {
       const project = {
         id: 'a',
         name: 'apple',
@@ -176,14 +182,26 @@ describe('delete-project saga', () => {
       // Pass in the projects to the select call
       saga.next(projects); // Fish spinner (loading) screen
       saga.next(projects); // node_modules
-      saga.next(projects); // project folder
+      saga.next(projects); // moveItemToTrash - project folder
 
-      // Return `false` to `successfullyDeleted`
-      expect(saga.next(false).value).toEqual(
-        call(
-          [console, console.error],
-          'Project could not be deleted. Please make sure no tasks are running, ' +
-            'and no applications are using files in that directory.'
+      expect(saga.throw().value).toEqual(put(deleteProjectError()));
+
+      expect(saga.next().value).toEqual(
+        call([electron.remote.dialog, electron.remote.dialog.showMessageBox], {
+          type: 'warning',
+          buttons: ['Ok'],
+          defaultId: 0,
+          cancelId: 0,
+          title: 'Error!',
+          message: `Could not delete ${project.name}`,
+          detail:
+            'Please make sure no tasks are running and no applications are using files in that directory.',
+        })
+      );
+
+      expect(JSON.stringify(saga.next().value)).toEqual(
+        JSON.stringify(
+          put(loadDependencyInfoFromDisk(project.id, project.path))
         )
       );
 

--- a/src/sagas/delete-project.saga.test.js
+++ b/src/sagas/delete-project.saga.test.js
@@ -1,6 +1,7 @@
 import electron from 'electron'; // Mocked
 import { call, put, select, takeEvery } from 'redux-saga/effects';
 import rimraf from 'rimraf';
+import * as fs from 'fs';
 import * as path from 'path';
 
 import rootSaga, {
@@ -75,7 +76,11 @@ describe('delete-project saga', () => {
         )
       );
 
-      expect(saga.next(true).value).toEqual(
+      expect(saga.next(projects).value).toEqual(
+        call([fs, fs.existsSync], project.path)
+      );
+
+      expect(saga.next(false).value).toEqual(
         put(finishDeletingProject(project.id))
       );
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**

Fixes #279 

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->
Show a dialog to the user if the project delete fails for some reason.

I ended up wrapping rimraf + moveItemToTrash into a try/catch because I was getting `uncaught at callee` if I simply rejected with `false`. Not sure if this is good or if it should be structured differently.

Also, not sure I like that the fish spinner freezes while waiting for the dialog to get clicked. Is there a way around that or is that how it should be?


**To do**

- [ ] Fix tests

**Screenshots**

![kapture 2018-10-23 at 21 20 14](https://user-images.githubusercontent.com/17421347/47406072-802e5e00-d709-11e8-8cc7-c5eb5ef3eb4a.gif)