### PR TITLE
added resolve & modified throw location

### DIFF
--- a/src/components/Initialization/Initialization.js
+++ b/src/components/Initialization/Initialization.js
@@ -31,19 +31,19 @@ class Initialization extends PureComponent<Props, State> {
 
       const nodeVersion = await getNodeJsVersion();
 
-      if (!nodeVersion) {
-        throw new Error('node-not-found');
-      }
-
       this.setState({ wasSuccessfullyInitialized: !!nodeVersion });
 
       logger.logEvent('load-application', {
         node_version: nodeVersion,
       });
 
+      if (!nodeVersion) {
+        throw new Error('node-not-found');
+      }
+
       ipcRenderer.on('app-will-close', this.appWillClose);
     } catch (e) {
-      switch (e) {
+      switch (e.message) {
         case 'node-not-found': {
           dialog.showErrorBox(
             'Node missing',

--- a/src/services/shell.service.js
+++ b/src/services/shell.service.js
@@ -16,7 +16,7 @@ export const openProjectInEditor = (project: Project) =>
 
 export const getNodeJsVersion = () =>
   new Promise(resolve =>
-    exec('node -v', (error, stdout) => {
+    exec('node -v', { env: window.process.env }, (error, stdout) => {
       if (error) {
         return resolve();
       }


### PR DESCRIPTION
**Summary:**
- Modified to always resolve inside `initializePath` & made it Mac only.
- Moved throw location in Init component so loading events are logged & app loading finshes even with missing node

Tested with Windows 10 & Ubuntu 16. Renaming the node.js folder on disk is the easiest way to get the node missing dialog.

Please check if this is working on Mac. @mathieudutour I like the idea of using shell:true and echoing the path but I can not test on Mac - that's why I haven't modified this.

For `fix-path` we can keep it for now and remove it in a release after 0.3.0. 