### PR TITLE
Fixes failing test of delete-project.saga

### DIFF
--- a/src/sagas/delete-project.saga.js
+++ b/src/sagas/delete-project.saga.js
@@ -120,7 +120,7 @@ export function* deleteProject({ project }: Action): Saga<void> {
       // can happen if the filesystem can't delete it (maybe if file is open?).
       yield put(deleteProjectError());
 
-      dialog.showMessageBox({
+      yield call([dialog, dialog.showMessageBox], {
         type: 'warning',
         buttons: ['Ok'],
         defaultId: 0,

--- a/src/sagas/delete-project.saga.test.js
+++ b/src/sagas/delete-project.saga.test.js
@@ -16,8 +16,14 @@ import {
   selectProject,
   createNewProjectStart,
   startDeletingProject,
+  deleteProjectError,
+  loadDependencyInfoFromDisk,
 } from '../actions';
 import { getProjectsArray } from '../reducers/projects.reducer';
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+}));
 
 describe('delete-project saga', () => {
   describe('root delete-project saga', () => {
@@ -154,7 +160,7 @@ describe('delete-project saga', () => {
       expect(saga.next().done).toEqual(true);
     });
 
-    it("logs an error when the project can't be deleted", () => {
+    it("displays an error when the project can't be deleted", () => {
       const project = {
         id: 'a',
         name: 'apple',
@@ -176,14 +182,26 @@ describe('delete-project saga', () => {
       // Pass in the projects to the select call
       saga.next(projects); // Fish spinner (loading) screen
       saga.next(projects); // node_modules
-      saga.next(projects); // project folder
+      saga.next(projects); // moveItemToTrash - project folder
 
-      // Return `false` to `successfullyDeleted`
-      expect(saga.next(false).value).toEqual(
-        call(
-          [console, console.error],
-          'Project could not be deleted. Please make sure no tasks are running, ' +
-            'and no applications are using files in that directory.'
+      expect(saga.throw().value).toEqual(put(deleteProjectError()));
+
+      expect(saga.next().value).toEqual(
+        call([electron.remote.dialog, electron.remote.dialog.showMessageBox], {
+          type: 'warning',
+          buttons: ['Ok'],
+          defaultId: 0,
+          cancelId: 0,
+          title: 'Error!',
+          message: `Could not delete ${project.name}`,
+          detail:
+            'Please make sure no tasks are running and no applications are using files in that directory.',
+        })
+      );
+
+      expect(JSON.stringify(saga.next().value)).toEqual(
+        JSON.stringify(
+          put(loadDependencyInfoFromDisk(project.id, project.path))
         )
       );
 


### PR DESCRIPTION
**Summary:**
Fixes failing test for new catch case in `delete-project.saga.`

Just one point is a bit hacky. But I'm not sure why I need to use `JSON.stringify` at `loadDependencyInfoFromDisk` test step.