### PR TITLE
Remove path.replace for leading slash

### DIFF
--- a/src/components/DirectoryPicker/DirectoryPicker.js
+++ b/src/components/DirectoryPicker/DirectoryPicker.js
@@ -45,30 +45,21 @@ class DirectoryPicker extends PureComponent<Props> {
     );
   };
 
-  getFullProjectPath(path: string) {
-    return path.replace(/^\//, '');
-  }
-
   render() {
     const { path, inputEditable, onFocus, onSelect, isFocused } = this.props;
-
-    // Join the projectHome with the prospective project ID
-    // Hide the leading forward-slash, on Mac/Linux
-    const fullProjectPath = this.getFullProjectPath(path);
 
     return (
       <Wrapper>
         {!inputEditable ? (
           <DirectoryButton onClick={this.updatePath} hideCursor={true}>
-            {fullProjectPath}
+            {path}
           </DirectoryButton>
         ) : (
           <TextInput
             onFocus={onFocus}
             isFocused={isFocused}
-            value={fullProjectPath}
+            value={path}
             onChange={ev => onSelect(ev.target.value)}
-            autoFocus
           >
             <ButtonPositionAdjuster>
               <IconWrapper onClick={this.updatePath}>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**

Fixes #320

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->

Removing the leading slash was not working for me on Mac. Removing this behavior fixes the issue, but I am not sure why it was there in the first place. Is it necessary on Linux? Should we put it behind a check for OS?