### PR TITLE
Fixes ProjectTypeSelection in app preferences

### DIFF
--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -15,6 +15,7 @@ import ProjectName from './ProjectName';
 import ProjectPath from './ProjectPath';
 import SubmitButton from './SubmitButton';
 import ButtonWithIcon from '../ButtonWithIcon';
+import ProjectTypeSelection from '../ProjectTypeSelection';
 import Spacer from '../Spacer';
 
 import type { Field, Status } from './types';
@@ -75,39 +76,12 @@ class MainPane extends PureComponent<Props> {
 
               {currentStepIndex > 0 && (
                 <FadeIn>
-                  <FormField
-                    label="Project Type"
-                    isFocused={activeField === 'projectType'}
-                  >
-                    <ProjectTypeTogglesWrapper>
-                      {/* Todo: Make it easier to add new flows - e.g. map over an array to generate the UI*/}
-                      <ButtonWithIcon
-                        showStroke={projectType === 'create-react-app'}
-                        icon={<ReactIcon src={reactIconSrc} />}
-                        onClick={() =>
-                          this.updateProjectType('create-react-app')
-                        }
-                      >
-                        Vanilla React
-                      </ButtonWithIcon>
-                      <Spacer inline size={10} />
-                      <ButtonWithIcon
-                        showStroke={projectType === 'gatsby'}
-                        icon={<GatsbyIcon src={gatsbyIconSrc} />}
-                        onClick={() => this.updateProjectType('gatsby')}
-                      >
-                        Gatsby
-                      </ButtonWithIcon>
-                      <Spacer inline size={10} />
-                      <ButtonWithIcon
-                        showStroke={projectType === 'nextjs'}
-                        icon={<NextjsIcon src={nextjsIconSrc} />}
-                        onClick={() => this.updateProjectType('nextjs')}
-                      >
-                        Next.js
-                      </ButtonWithIcon>
-                    </ProjectTypeTogglesWrapper>
-                  </FormField>
+                  <ProjectTypeSelection
+                    projectType={projectType}
+                    onSelect={selectedProjectType =>
+                      this.updateProjectType(selectedProjectType)
+                    }
+                  />
                 </FadeIn>
               )}
 

--- a/src/components/CreateNewProjectWizard/SummaryPane.js
+++ b/src/components/CreateNewProjectWizard/SummaryPane.js
@@ -133,6 +133,34 @@ class SummaryPane extends PureComponent<Props> {
             );
             break;
           }
+          case 'nextjs': {
+            details = (
+              <Fragment>
+                <Paragraph>
+                  <strong>Next.js</strong>
+                </Paragraph>
+                <Paragraph>
+                  Next.js is a lightweight framework for static and
+                  server-rendered applications.
+                </Paragraph>
+                <Paragraph>
+                  Server-rendered by default. No need to worry about routing. A
+                  great choice for quickly getting products built with
+                  server-side rendering by a Node.js server.
+                </Paragraph>
+                <Paragraph>
+                  <ExternalLink
+                    color={COLORS.white}
+                    hoverColor={COLORS.white}
+                    href="https://nextjs.org/learn/"
+                  >
+                    <strong>Learn more about Next.js.</strong>
+                  </ExternalLink>
+                </Paragraph>
+              </Fragment>
+            );
+            break;
+          }
         }
         return (
           <Fragment>

--- a/src/components/ProjectTypeSelection/ProjectTypeSelection.js
+++ b/src/components/ProjectTypeSelection/ProjectTypeSelection.js
@@ -1,8 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import styled from 'styled-components';
 
 import reactIconSrc from '../../assets/images/react-icon.svg';
 import gatsbyIconSrc from '../../assets/images/gatsby_small.png';
+import nextjsIconSrc from '../../assets/images/nextjs_small.png';
 
 import FormField from '../FormField';
 import ButtonWithIcon from '../ButtonWithIcon';
@@ -33,23 +34,20 @@ class ProjectTypeSelection extends PureComponent<Props> {
       <FadeIn>
         <FormField label={label} isFocused={activeField === 'projectType'}>
           <ProjectTypeTogglesWrapper>
-            <ButtonWithIcon
-              showStroke={projectType === 'create-react-app'}
-              icon={<ReactIcon src={reactIconSrc} />}
-              onClick={(ev: SyntheticEvent<*>) =>
-                this.select(ev, 'create-react-app')
-              }
-            >
-              Vanilla React
-            </ButtonWithIcon>
-            <Spacer inline size={10} />
-            <ButtonWithIcon
-              showStroke={projectType === 'gatsby'}
-              icon={<GatsbyIcon src={gatsbyIconSrc} />}
-              onClick={(ev: SyntheticEvent<*>) => this.select(ev, 'gatsby')}
-            >
-              Gatsby
-            </ButtonWithIcon>
+            {mapProjectTypeToComponent.map((curProjectType, index) => (
+              <Fragment key={index}>
+                <ButtonWithIcon
+                  showStroke={projectType === curProjectType.type}
+                  icon={curProjectType.Component}
+                  onClick={(ev: SyntheticEvent<*>) =>
+                    this.select(ev, curProjectType.type)
+                  }
+                >
+                  {curProjectType.caption}
+                </ButtonWithIcon>
+                <Spacer inline size={10} />
+              </Fragment>
+            ))}
           </ProjectTypeTogglesWrapper>
         </FormField>
       </FadeIn>
@@ -67,9 +65,32 @@ const GatsbyIcon = styled.img`
   height: 22px;
 `;
 
+const NextjsIcon = styled.img`
+  width: 22px;
+  height: 22px;
+`;
+
 const ProjectTypeTogglesWrapper = styled.div`
   margin-top: 8px;
   margin-left: -8px;
 `;
+
+const mapProjectTypeToComponent = [
+  {
+    type: 'create-react-app',
+    Component: <ReactIcon src={reactIconSrc} />,
+    caption: 'Vanilla React',
+  },
+  {
+    type: 'gatsby',
+    Component: <GatsbyIcon src={gatsbyIconSrc} />,
+    caption: 'Gatsby',
+  },
+  {
+    type: 'nextjs',
+    Component: <NextjsIcon src={nextjsIconSrc} />,
+    caption: 'Next.js',
+  },
+];
 
 export default ProjectTypeSelection;


### PR DESCRIPTION
**Summary:**
As mentioned by @mathieudutour Next.js was missing in the app-settings modal because we haven't consistently used the `ProjectTypeSelection` component.

The PR is adding Next.js to the ProjectTypeSelection component and also uses it in `MainPane` for project creation.
Also the missing Summary copy for Next.js is added.

**Screenshots/GIFs:**
**Summary copy**
![grafik](https://user-images.githubusercontent.com/3046542/48222513-064ad580-e395-11e8-928d-07d275d8e20d.png)
**App preferences**
![grafik](https://user-images.githubusercontent.com/3046542/48222558-24b0d100-e395-11e8-86d5-075e8f76e379.png)
