### PR TITLE
Remove node_modules before install after eject

### DIFF
--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -30,6 +30,7 @@ import {
   PACKAGE_MANAGER_CMD,
 } from '../services/platform.service';
 import { processLogger } from '../services/process-logger.service';
+import { waitForAsyncRimraf } from './delete-project.saga';
 
 import type { Saga } from 'redux-saga';
 import type { ChildProcess } from 'child_process';
@@ -282,6 +283,9 @@ export function* taskRun({ task }: ReturnType<typeof runTask>): Saga<void> {
                 'Oh no! In order to eject, git state must be clean. Please commit your changes and retry ejecting.',
             });
           }
+
+          // delete node_modules folder
+          yield call(waitForAsyncRimraf, projectPath);
 
           // Run a fresh install of dependencies after ejecting to get around issue
           // documented here https://github.com/facebook/create-react-app/issues/4433

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -20,6 +20,7 @@ import {
   completeTask,
   loadDependencyInfoFromDiskStart,
 } from '../actions';
+import { waitForAsyncRimraf } from './delete-project.saga';
 import killProcessId from '../services/kill-process-id.service';
 import { getProjectById } from '../reducers/projects.reducer';
 import { getPathForProjectId } from '../reducers/paths.reducer';
@@ -282,6 +283,16 @@ describe('task saga', () => {
 
         // `take` a log message
         saga.next();
+
+        // delete node_modules folder
+        expect(
+          saga.next({
+            channel: 'exit',
+            timestamp,
+            wasSuccessful: true,
+            uncleanRepo: false,
+          }).value
+        ).toEqual(call(waitForAsyncRimraf, projectPath));
 
         // ejecting requires that dependencies are reinstalled
         const installProcessDescription = call(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->

**Related PR:**
#318

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->
As discussed in the chat, have to remove `node_modules` after eject and before install, because it was not sensing there was anything to install ("Already up to date" output) and subsequently getting the previous dev server failure from missing packages.