### PR TITLE
Update eject task UI to failed if git state dirty

### DIFF
--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -362,6 +362,7 @@ export function* displayTaskComplete(
 
 export function* taskComplete({
   task,
+  wasSuccessful,
 }: ReturnType<typeof completeTask>): Saga<void> {
   if (task.processId) {
     yield call(
@@ -375,7 +376,7 @@ export function* taskComplete({
   // have changed.
   // TODO: We should really have a `EJECT_PROJECT_COMPLETE` action that does
   // this instead.
-  if (task.name === 'eject') {
+  if (task.name === 'eject' && wasSuccessful) {
     const project = yield select(getProjectById, { projectId: task.projectId });
 
     yield put(loadDependencyInfoFromDiskStart(project.id, project.path));

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -282,6 +282,10 @@ export function* taskRun({ task }: ReturnType<typeof runTask>): Saga<void> {
               detail:
                 'Oh no! In order to eject, git state must be clean. Please commit your changes and retry ejecting.',
             });
+
+            // Update the UI to failed
+            yield put(completeTask(task, message.timestamp, false));
+            return;
           }
 
           // delete node_modules folder

--- a/src/sagas/task.saga.test.js
+++ b/src/sagas/task.saga.test.js
@@ -414,7 +414,7 @@ describe('task saga', () => {
       const processId = 12345;
       const project = { id: 'tangy-blueberry', path: '/path/to/project' };
       const task = { processId, name: 'eject', projectId: project.id };
-      const saga = taskComplete({ task });
+      const saga = taskComplete({ task, wasSuccessful: true });
       saga.next();
 
       expect(saga.next().value).toEqual(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
<!--
Please provide the related issue #. Note that in most cases, you should only be opening a pull request that implements a solution discussed in an issue. See our contribution guidelines for more info
-->

PR #331 identified the problem.

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->

If git state is dirty we need to update the UI to failed, so it's not pending forever.

Is there some way to not have the window refresh afterwards? Would be good if when the UI is updated, the window sits still so user isn't jumped up.