### PR TITLE
[WIP] Gatsby starter

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,11 @@
     "electron-updater": "3.1.2",
     "fix-path": "2.1.0",
     "gatsby-cli": "1.1.58",
+    "js-yaml": "3.12.0",
+    "node-fetch": "2.3.0",
     "ps-tree": "1.1.0",
     "react-custom-scrollbars": "4.2.1",
+    "react-redux-toastr": "7.4.1",
     "rimraf": "2.6.2",
     "yarn": "1.9.2"
   },

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -2,6 +2,7 @@
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
 import styled, { keyframes } from 'styled-components';
+import ReduxToastr from 'react-redux-toastr';
 
 import { COLORS } from '../../constants';
 import { getSelectedProjectId } from '../../reducers/projects.reducer';
@@ -43,6 +44,7 @@ class App extends PureComponent<Props> {
               <CreateNewProjectWizard />
               <ProjectConfigurationModal />
               <AppSettingsModal />
+              <ReduxToastr />
             </Fragment>
           )
         }

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -79,7 +79,12 @@ class BuildPane extends PureComponent<Props, State> {
   }
 
   buildProject = () => {
-    const { projectName, projectType, projectIcon } = this.props;
+    const {
+      projectName,
+      projectType,
+      projectIcon,
+      projectStarter: projectStarterInput,
+    } = this.props;
 
     if (!projectName || !projectType || !projectIcon) {
       console.error('Missing one of:', {
@@ -92,8 +97,15 @@ class BuildPane extends PureComponent<Props, State> {
       );
     }
 
+    // Add url to starter if not passed
+    // Todo: We need error handling to show a notification that it failed to use the starter
+    //       --> Just needed if we allow the user to enter an url to a starter.
+    const projectStarter = !projectStarterInput.includes('http')
+      ? 'https://github.com/gatsbyjs/' + projectStarterInput
+      : projectStarterInput;
+
     createProject(
-      { projectName, projectType, projectIcon },
+      { projectName, projectType, projectIcon, projectStarter },
       this.props.projectHomePath,
       this.handleStatusUpdate,
       this.handleError,

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -36,6 +36,7 @@ type Props = {
   projectName: string,
   projectType: ?ProjectType,
   projectIcon: ?string,
+  projectStarter: string,
   status: Status,
   projectHomePath: string,
   handleCompleteBuild: (project: ProjectInternal) => void,
@@ -98,8 +99,8 @@ class BuildPane extends PureComponent<Props, State> {
     }
 
     // Add url to starter if not passed
-    // Todo: We need error handling to show a notification that it failed to use the starter
-    //       --> Just needed if we allow the user to enter an url to a starter.
+    // Todo: We need error handling to show a notification that it failed to use the starter (e.g. starter doesn't exists or wrong url/name)
+    //       --> Probably just needed if we allow the user to enter an url to a starter.
     const projectStarter = !projectStarterInput.includes('http')
       ? 'https://github.com/gatsbyjs/' + projectStarterInput
       : projectStarterInput;

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -38,6 +38,7 @@ type Props = {
   settings: AppSettings,
   projects: { [projectId: string]: ProjectInternal },
   projectHomePath: string,
+  projectStarter: string,
   isVisible: boolean,
   isOnboardingCompleted: boolean,
   addProject: Dispatch<typeof actions.addProject>,
@@ -49,7 +50,7 @@ type State = {
   projectName: string,
   projectType: ?ProjectType,
   projectIcon: ?string,
-  projectStarter: ?string,
+  projectStarter: string,
   activeField: ?Field,
   settings: ?AppSettings,
   status: Status,
@@ -164,11 +165,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
   };
 
   finishBuilding = (project: ProjectInternal) => {
-    const {
-      isOnboardingCompleted,
-      projectHomePath,
-      projectStarter,
-    } = this.props;
+    const { isOnboardingCompleted, projectHomePath } = this.props;
     const { projectType } = this.state;
 
     // Should be impossible
@@ -183,7 +180,6 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
         project,
         projectHomePath,
         projectType,
-        projectStarter, // todo: check project reducer, if it's available on state
         isOnboardingCompleted
       );
 

--- a/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
+++ b/src/components/CreateNewProjectWizard/CreateNewProjectWizard.js
@@ -26,7 +26,12 @@ import type { Field, Status, Step } from './types';
 import type { ProjectType, ProjectInternal, AppSettings } from '../../types';
 import type { Dispatch } from '../../actions/types';
 
-const FORM_STEPS: Array<Field> = ['projectName', 'projectType', 'projectIcon'];
+const FORM_STEPS: Array<Field> = [
+  'projectName',
+  'projectType',
+  'projectStarter',
+  'projectIcon',
+];
 const { dialog } = remote;
 
 type Props = {
@@ -44,6 +49,7 @@ type State = {
   projectName: string,
   projectType: ?ProjectType,
   projectIcon: ?string,
+  projectStarter: ?string,
   activeField: ?Field,
   settings: ?AppSettings,
   status: Status,
@@ -55,6 +61,7 @@ const initialState = {
   projectName: '',
   projectType: null,
   projectIcon: null,
+  projectStarter: '',
   activeField: 'projectName',
   status: 'filling-in-form',
   currentStep: 'projectName',
@@ -157,7 +164,11 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
   };
 
   finishBuilding = (project: ProjectInternal) => {
-    const { isOnboardingCompleted, projectHomePath } = this.props;
+    const {
+      isOnboardingCompleted,
+      projectHomePath,
+      projectStarter,
+    } = this.props;
     const { projectType } = this.state;
 
     // Should be impossible
@@ -172,6 +183,7 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
         project,
         projectHomePath,
         projectType,
+        projectStarter, // todo: check project reducer, if it's available on state
         isOnboardingCompleted
       );
 
@@ -194,13 +206,14 @@ class CreateNewProjectWizard extends PureComponent<Props, State> {
       projectName,
       projectType,
       projectIcon,
+      projectStarter,
       activeField,
       status,
       currentStep,
       isProjectNameTaken,
     } = this.state;
 
-    const project = { projectName, projectType, projectIcon };
+    const project = { projectName, projectType, projectIcon, projectStarter };
 
     const readyToBeBuilt = status !== 'filling-in-form';
 

--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterDialog.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterDialog.js
@@ -71,7 +71,7 @@ class SelectStarterDialog extends PureComponent<Props, State> {
       });
   }
 
-  prepareUrlForCodesandbox(repoUrl) {
+  prepareUrlForCodesandbox(repoUrl: string) {
     // Remove http protocol
     const sandboxUrl = `https://codesandbox.io/s/${repoUrl.replace(
       /(^\w+:|^)\/\//,

--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterDialog.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterDialog.js
@@ -4,6 +4,8 @@ import fetch from 'node-fetch'; // Note: This is using net.request from Node. Br
 import styled from 'styled-components';
 import yaml from 'js-yaml';
 import Scrollbars from 'react-custom-scrollbars';
+import ExternalLink from '../../ExternalLink';
+
 // import { SearchBox } from 'react-instantsearch/dom';
 // import {
 //   InstantSearch,
@@ -17,7 +19,7 @@ import Heading from '../../Heading';
 // import { ALGOLIA_KEYS } from '../../../constants';
 
 type Props = {
-  onSelect: string => string,
+  onSelect: string => ?string,
   selectedStarter: string,
 };
 
@@ -50,7 +52,7 @@ class SelectStarterDialog extends PureComponent<Props, State> {
     starters: [],
   };
 
-  static getDerivedStateFromProps(nextProps, prevState) {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     console.log('new props', nextProps, prevState);
     return prevState;
   }
@@ -67,6 +69,16 @@ class SelectStarterDialog extends PureComponent<Props, State> {
           starters,
         });
       });
+  }
+
+  prepareUrlForCodesandbox(repoUrl) {
+    // Remove http protocol
+    const sandboxUrl = `https://codesandbox.io/s/${repoUrl.replace(
+      /(^\w+:|^)\/\//,
+      ''
+    )}`;
+    // Remove .com from github.com --> to have /s/github/repo
+    return sandboxUrl.replace(/\.com/, '');
   }
 
   render() {
@@ -91,6 +103,11 @@ class SelectStarterDialog extends PureComponent<Props, State> {
                 {starter.description !== 'n/a' && (
                   <Paragraph>{starter.description}</Paragraph>
                 )}
+                <ExternalLink
+                  href={this.prepareUrlForCodesandbox(starter.repo)}
+                >
+                  Preview in Codesandbox
+                </ExternalLink>
               </StarterItem>
             ))}
           </StarterList>

--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterDialog.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterDialog.js
@@ -1,0 +1,139 @@
+// @flow
+import React, { PureComponent } from 'react';
+import fetch from 'node-fetch'; // Note: This is using net.request from Node. Browser fetch throws CORS error.
+import styled from 'styled-components';
+import yaml from 'js-yaml';
+import Scrollbars from 'react-custom-scrollbars';
+// import { SearchBox } from 'react-instantsearch/dom';
+// import {
+//   InstantSearch,
+//   InfiniteHits,
+//   Configure,
+// } from 'react-instantsearch/dom';
+
+import Paragraph from '../../Paragraph';
+import Heading from '../../Heading';
+
+// import { ALGOLIA_KEYS } from '../../../constants';
+
+type Props = {
+  onSelect: string => string,
+  selectedStarter: string,
+};
+
+type State = {
+  loading: boolean,
+  starters: Array<any>,
+};
+
+/*
+Gatsby starter selection dialog.
+A starter object from starter.yml contains the following data:
+[
+   {
+      "url": "https://wonism.github.io/",
+      "repo": "https://github.com/wonism/gatsby-advanced-blog",
+      "description": "n/a",
+      "tags": [
+        "Portfolio",
+        "Redux"
+      ],
+      "features": [
+        "feature items"
+      ]
+  }, ... 
+]
+*/
+class SelectStarterDialog extends PureComponent<Props, State> {
+  state = {
+    loading: true,
+    starters: [],
+  };
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    console.log('new props', nextProps, prevState);
+    return prevState;
+  }
+
+  componentDidMount() {
+    fetch(
+      'https://raw.githubusercontent.com/gatsbyjs/gatsby/master/docs/starters.yml'
+    )
+      .then(response => response.text())
+      .then(yamlText => {
+        const starters = yaml.safeLoad(yamlText);
+
+        this.setState({
+          starters,
+        });
+      });
+  }
+
+  render() {
+    const { onSelect, selectedStarter } = this.props;
+    const { starters } = this.state;
+    console.log('render dialog', selectedStarter);
+    return (
+      <Wrapper>
+        <Paragraph>
+          Please select a starter template for your new project.
+        </Paragraph>
+        <ScrollContainer>
+          <StarterList>
+            {selectedStarter}
+            {starters.slice(0, 10).map((starter, index) => (
+              <StarterItem
+                selected={selectedStarter === starter.repo}
+                key={index}
+                onClick={() => onSelect(starter.repo)}
+              >
+                <Heading size="small">{starter.repo}</Heading>
+                {starter.description !== 'n/a' && (
+                  <Paragraph>{starter.description}</Paragraph>
+                )}
+              </StarterItem>
+            ))}
+          </StarterList>
+
+          {/* We could add Algolia here --> Setup at Algolia required */}
+          {/* <InstantSearch {...ALGOLIA_KEYS}>
+          <Configure
+            attributesToRetrieve={[
+              'name',
+              'version',
+              'description',
+              'modified',
+              'humanDownloadsLast30Days',
+              'license',
+            ]}
+            hitsPerPage={10}
+          />
+          <SearchBox onChange={value => console.log(value)} />
+          <InfiniteHits
+            hitComponent={({ hit }) => (
+              <div onClick={() => onSelect(hit.name)}>
+                {hit.name}
+              </div>
+            )}
+          />
+        </InstantSearch> */}
+        </ScrollContainer>
+      </Wrapper>
+    );
+  }
+}
+
+const ScrollContainer = styled(Scrollbars)`
+  min-height: 60vh;
+`;
+
+const StarterList = styled.div``;
+const StarterItem = styled.div`
+  border: 2px solid ${props => (props.selected ? 'red' : 'transparent')};
+`;
+
+const Wrapper = styled.div`
+  padding: 10px;
+`;
+
+export default SelectStarterDialog;

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -56,7 +56,7 @@ class MainPane extends PureComponent<Props, State> {
   updateGatsbyStarter = (selectedStarter: string) =>
     this.props.updateFieldValue('projectStarter', selectedStarter);
 
-  static getDerivedStateFromProps(nextProps, prevState) {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     console.log('MainPane new props', nextProps, prevState);
     return prevState;
   }
@@ -74,8 +74,8 @@ class MainPane extends PureComponent<Props, State> {
     );
   };
 
-  projectSpecificSteps(projectType: ProjectType) {
-    const { activeField, projectStarter } = this.props;
+  projectSpecificSteps() {
+    const { activeField, projectType, projectStarter } = this.props;
     switch (projectType) {
       case 'gatsby':
         return (
@@ -123,7 +123,7 @@ class MainPane extends PureComponent<Props, State> {
 
   renderConditionalSteps(currentStepIndex: number) {
     const { activeField, projectType, projectIcon } = this.props;
-    const buildSteps: Array<?React$component> = [
+    const buildSteps: Array<?React$Node> = [
       // currentStepIndex > 0 -- > 1
       <FadeIn key="step-type">
         <FormField
@@ -138,7 +138,7 @@ class MainPane extends PureComponent<Props, State> {
           />
         </FormField>
       </FadeIn>,
-      this.projectSpecificSteps(projectType), // currentStepIndex > 1
+      this.projectSpecificSteps(), // currentStepIndex > 1
       <FadeIn key="step-icon">
         <FormField
           label="Project Icon"
@@ -155,7 +155,7 @@ class MainPane extends PureComponent<Props, State> {
       </FadeIn>,
     ];
 
-    const renderedSteps: Array<React$component> = buildSteps
+    const renderedSteps: Array<React$Node> = buildSteps
       .filter(step => !!step)
       .slice(0, currentStepIndex);
 

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -121,9 +121,9 @@ class MainPane extends PureComponent<Props, State> {
     }
   }
 
-  renderConditionalSteps(currentStepIndex) {
+  renderConditionalSteps(currentStepIndex: number) {
     const { activeField, projectType, projectIcon } = this.props;
-    const buildSteps = [
+    const buildSteps: Array<?React$component> = [
       // currentStepIndex > 0 -- > 1
       <FadeIn key="step-type">
         <FormField
@@ -155,7 +155,7 @@ class MainPane extends PureComponent<Props, State> {
       </FadeIn>,
     ];
 
-    const renderedSteps = buildSteps
+    const renderedSteps: Array<React$component> = buildSteps
       .filter(step => !!step)
       .slice(0, currentStepIndex);
 
@@ -165,7 +165,7 @@ class MainPane extends PureComponent<Props, State> {
       steps: renderedSteps,
     };
   }
-  validateField(currentStepIndex) {
+  validateField(currentStepIndex: number) {
     // todo: Refactor - Move buildsteps to component scope & use an array method to check current validation
     //       --> For now we're doing a different check for Gatsby flow
     const { projectIcon, projectStarter, projectType } = this.props;

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -2,15 +2,19 @@
 import React, { PureComponent, Fragment } from 'react';
 import { Motion, spring } from 'react-motion';
 import styled from 'styled-components';
+import { toastr } from 'react-redux-toastr';
 
 import FormField from '../FormField';
 import FadeIn from '../FadeIn';
+import TextInput from '../TextInput'; // todo: move to SelectStarter Component
+import FillButton from '../Button/FillButton'; // dito
 
 import ProjectName from './ProjectName';
 import ProjectPath from './ProjectPath';
 import SubmitButton from './SubmitButton';
 import ProjectIconSelection from '../ProjectIconSelection';
 import ProjectTypeSelection from '../ProjectTypeSelection';
+import SelectStarterDialog from './Gatsby/SelectStarterDialog';
 
 import type { Field, Status } from './types';
 import type { ProjectType } from '../../types';
@@ -19,6 +23,7 @@ type Props = {
   projectName: string,
   projectType: ?ProjectType,
   projectIcon: ?string,
+  projectStarter: ?string,
   activeField: ?Field,
   status: Status,
   currentStepIndex: number,
@@ -29,9 +34,18 @@ type Props = {
   handleSubmit: () => Promise<any> | void,
 };
 
-class MainPane extends PureComponent<Props> {
+type State = {
+  gatsbyStarter: string, // temporary value during selection in selection toast
+};
+
+class MainPane extends PureComponent<Props, State> {
+  state = {
+    gatsbyStarter: '',
+  };
+
   handleFocusProjectName = () => this.props.focusField('projectName');
   handleBlurProjectName = () => this.props.focusField(null);
+  handleFocusStarter = () => this.props.focusField('projectStarter');
 
   updateProjectName = (projectName: string) =>
     this.props.updateFieldValue('projectName', projectName);
@@ -39,12 +53,132 @@ class MainPane extends PureComponent<Props> {
     this.props.updateFieldValue('projectType', projectType);
   updateProjectIcon = (projectIcon: string) =>
     this.props.updateFieldValue('projectIcon', projectIcon);
+  updateGatsbyStarter = (selectedStarter: string) =>
+    this.props.updateFieldValue('projectStarter', selectedStarter);
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    console.log('MainPane new props', nextProps, prevState);
+    return prevState;
+  }
+
+  // Change method needed so we can dismiss the selection on close click of toastr
+  changeGatsbyStarter = (selectedStarter: string) => {
+    console.log('change starter', selectedStarter, this);
+    this.setState(
+      {
+        gatsbyStarter: selectedStarter,
+      },
+      () => {
+        console.log('updated', this.state);
+      }
+    );
+  };
+
+  projectSpecificSteps(projectType: ProjectType) {
+    const { activeField, projectStarter } = this.props;
+    switch (projectType) {
+      case 'gatsby':
+        return (
+          <FadeIn key="step-starter">
+            <FormField
+              label="Project Starter"
+              isFocused={activeField === 'projectStarter'}
+            >
+              {/* <ProjectTypeSelection
+                projectType={projectType}
+                onProjectTypeSelect={selectedProjectType =>
+                  this.updateProjectType(selectedProjectType)
+                }
+              /> */}
+              <TextInput
+                onChange={evt => this.updateGatsbyStarter(evt.target.value)}
+                value={projectStarter}
+                onFocus={this.handleFocusStarter}
+                placeholder="Enter a starter"
+              />
+              <FillButton
+                onClick={() =>
+                  toastr.confirm('Select starter', {
+                    component: () => (
+                      <SelectStarterDialog
+                        onSelect={this.changeGatsbyStarter}
+                        selectedStarter={this.state.gatsbyStarter}
+                      />
+                    ),
+                    okText: 'Use selected',
+                    onOk: () =>
+                      this.updateGatsbyStarter(this.state.gatsbyStarter),
+                  })
+                }
+              >
+                Select Starter
+              </FillButton>
+            </FormField>
+          </FadeIn>
+        );
+      default:
+        return null;
+    }
+  }
+
+  renderConditionalSteps(currentStepIndex) {
+    const { activeField, projectType, projectIcon } = this.props;
+    const buildSteps = [
+      // currentStepIndex > 0 -- > 1
+      <FadeIn key="step-type">
+        <FormField
+          label="Project Type"
+          isFocused={activeField === 'projectType'}
+        >
+          <ProjectTypeSelection
+            projectType={projectType}
+            onProjectTypeSelect={selectedProjectType =>
+              this.updateProjectType(selectedProjectType)
+            }
+          />
+        </FormField>
+      </FadeIn>,
+      this.projectSpecificSteps(projectType), // currentStepIndex > 1
+      <FadeIn key="step-icon">
+        <FormField
+          label="Project Icon"
+          focusOnClick={false}
+          isFocused={activeField === 'projectIcon'}
+        >
+          <ProjectIconSelection
+            selectedIcon={projectIcon}
+            randomize={true}
+            limitTo={8}
+            onSelectIcon={this.updateProjectIcon}
+          />
+        </FormField>
+      </FadeIn>,
+    ];
+
+    const renderedSteps = buildSteps
+      .filter(step => !!step)
+      .slice(0, currentStepIndex);
+
+    console.log('render steps', renderedSteps);
+    return {
+      lastIndex: projectType === 'gatsby' ? 3 : 2, //buildSteps.length, // Todo: Use buildSteps array to find last index
+      steps: renderedSteps,
+    };
+  }
+  validateField(currentStepIndex) {
+    // todo: Refactor - Move buildsteps to component scope & use an array method to check current validation
+    //       --> For now we're doing a different check for Gatsby flow
+    const { projectIcon, projectStarter, projectType } = this.props;
+    return projectType === 'gatsby'
+      ? (currentStepIndex > 0 && !projectType) ||
+          (currentStepIndex > 1 && projectStarter === '') ||
+          (currentStepIndex > 2 && !projectIcon)
+      : (currentStepIndex > 0 && !projectType) ||
+          (currentStepIndex > 1 && !projectIcon);
+  }
   render() {
     const {
       projectName,
-      projectType,
-      projectIcon,
       activeField,
       currentStepIndex,
       hasBeenSubmitted,
@@ -52,8 +186,10 @@ class MainPane extends PureComponent<Props> {
       handleSubmit,
     } = this.props;
 
+    const { lastIndex, steps } = this.renderConditionalSteps(currentStepIndex);
     return (
       <Fragment>
+        {/* <pre>{JSON.stringify(this.props, null, 2)}</pre> */}
         <Motion style={{ offset: spring(currentStepIndex === 0 ? 50 : 0) }}>
           {({ offset }) => (
             <Wrapper style={{ transform: `translateY(${offset}px)` }}>
@@ -68,38 +204,7 @@ class MainPane extends PureComponent<Props> {
               />
               <ProjectPath projectName={projectName} />
 
-              {currentStepIndex > 0 && (
-                <FadeIn>
-                  <FormField
-                    label="Project Type"
-                    isFocused={activeField === 'projectType'}
-                  >
-                    <ProjectTypeSelection
-                      projectType={projectType}
-                      onProjectTypeSelect={selectedProjectType =>
-                        this.updateProjectType(selectedProjectType)
-                      }
-                    />
-                  </FormField>
-                </FadeIn>
-              )}
-
-              {currentStepIndex > 1 && (
-                <FadeIn>
-                  <FormField
-                    label="Project Icon"
-                    focusOnClick={false}
-                    isFocused={activeField === 'projectIcon'}
-                  >
-                    <ProjectIconSelection
-                      selectedIcon={projectIcon}
-                      randomize={true}
-                      limitTo={8}
-                      onSelectIcon={this.updateProjectIcon}
-                    />
-                  </FormField>
-                </FadeIn>
-              )}
+              {steps}
             </Wrapper>
           )}
         </Motion>
@@ -108,10 +213,9 @@ class MainPane extends PureComponent<Props> {
             isDisabled={
               isProjectNameTaken ||
               !projectName ||
-              (currentStepIndex > 0 && !projectType) ||
-              (currentStepIndex > 1 && !projectIcon)
+              this.validateField(currentStepIndex)
             }
-            readyToBeSubmitted={currentStepIndex >= 2}
+            readyToBeSubmitted={currentStepIndex >= lastIndex}
             hasBeenSubmitted={hasBeenSubmitted}
             onSubmit={handleSubmit}
           />
@@ -122,7 +226,7 @@ class MainPane extends PureComponent<Props> {
 }
 
 const Wrapper = styled.div`
-  height: 500px;
+  height: 80vh;
   will-change: transform;
 `;
 

--- a/src/components/CreateNewProjectWizard/MainPane.js
+++ b/src/components/CreateNewProjectWizard/MainPane.js
@@ -155,7 +155,7 @@ class MainPane extends PureComponent<Props, State> {
       </FadeIn>,
     ];
 
-    const renderedSteps: Array<React$Node> = buildSteps
+    const renderedSteps: Array<?React$Node> = buildSteps
       .filter(step => !!step)
       .slice(0, currentStepIndex);
 

--- a/src/components/CreateNewProjectWizard/SummaryPane.js
+++ b/src/components/CreateNewProjectWizard/SummaryPane.js
@@ -185,6 +185,23 @@ class SummaryPane extends PureComponent<Props> {
           </Fragment>
         );
       }
+      case 'projectStarter': {
+        // todo: why is a key needed on FadeIn? Was s3t.
+        // todo: should we rename projectStarter to be mores specific as this is Gatbsy only.
+        return (
+          <Fragment>
+            <FadeIn>
+              <StepTitle>Gatsby Starter</StepTitle>
+
+              <Paragraph>
+                Please enter a starter for your project (e.g.
+                gatsby-starter-blog). Later we'll have a starter search modal
+                here.
+              </Paragraph>
+            </FadeIn>
+          </Fragment>
+        );
+      }
 
       default:
         throw new Error('Unrecognized `focusField`: ' + focusField);

--- a/src/components/CreateNewProjectWizard/types.js
+++ b/src/components/CreateNewProjectWizard/types.js
@@ -1,6 +1,10 @@
 // @flow
 
-export type Field = 'projectName' | 'projectType' | 'projectIcon';
+export type Field =
+  | 'projectName'
+  | 'projectType'
+  | 'projectIcon'
+  | 'projectStarter';
 export type BuildStep =
   | 'installingCliTool'
   | 'creatingProjectDirectory'

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -3,5 +3,5 @@
 module.exports = {
   PACKAGE_MANAGER: 'yarn',
   // Enable logging, if enabled all terminal responses are visible in the console (useful for debugging)
-  LOGGING: false,
+  LOGGING: true,
 };

--- a/src/config/project-types.js
+++ b/src/config/project-types.js
@@ -17,7 +17,7 @@ const config: {
       },
     },
     create: {
-      args: (projectPath: string) => Array<string>,
+      args: Array<string>,
     },
   },
 } = {
@@ -31,10 +31,10 @@ const config: {
     },
     create: {
       // not sure if we need that nesting but I think there could be more to configure
-      args: projectPath => [
+      args: [
         // used for project creation previous getBuildInstructions
         'create-react-app',
-        projectPath,
+        '$projectPath',
       ],
     },
   },
@@ -46,11 +46,12 @@ const config: {
     },
     create: {
       // not sure if we need that nesting but I think there could be more to configure
-      args: projectPath => [
+      args: [
         // used for project creation previous getBuildInstructions
         'gatsby',
         'new',
-        projectPath, // todo replace later with config variables like $projectPath - so we can remove the function. Also check if it's getting complicated.
+        '$projectPath',
+        '$projectStarter',
       ],
     },
   },
@@ -60,9 +61,9 @@ const config: {
       args: ['run', 'dev', '-p', '$port'],
     },
     create: {
-      args: projectPath => [
+      args: [
         'github:awolf81/create-next-app', // later will be 'create-next-app' --> added a comment to the following issue https://github.com/segmentio/create-next-app/issues/30
-        projectPath,
+        '$projectPath',
       ],
     },
   },

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -1,6 +1,7 @@
 // @flow
 import { injectGlobal } from 'styled-components';
 import 'react-tippy/dist/tippy.css';
+import 'react-redux-toastr/lib/css/react-redux-toastr.min.css';
 import { COLORS } from './constants';
 import './fonts.css';
 import './base.css';
@@ -18,5 +19,13 @@ injectGlobal`
 
   body {
     background: ${COLORS.gray[50]};
+  }
+
+  /* Modify top position of React-Redux-Toastr so it's closer to the upper edge - was top: 20% */
+  div .rrt-confirm-holder .rrt-confirm {
+    top: 5%;
+    width: 70vw;
+    margin-left: 15vw;
+    left: 0;
   }
 `;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,6 @@
 // @flow
 import { combineReducers } from 'redux';
+import { reducer as toastrReducer } from 'react-redux-toastr'; // todo: Would be better to separate library reducers and add them before creating store. Not sure how to do that and if it's really needed.
 
 import appSettings from './app-settings.reducer';
 import appLoaded from './app-loaded.reducer';
@@ -23,4 +24,5 @@ export default combineReducers({
   onboardingStatus,
   paths,
   queue,
+  toastr: toastrReducer,
 });

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -30,6 +30,7 @@ import {
   PACKAGE_MANAGER_CMD,
 } from '../services/platform.service';
 import { processLogger } from '../services/process-logger.service';
+import { substituteConfigVariables } from '../services/config-variables.service';
 
 import type { Saga } from 'redux-saga';
 import type { ChildProcess } from 'child_process';
@@ -402,42 +403,6 @@ const createStdioChannel = (
     // the exit channel completes, it should emit the return code of the process
     // and then immediately END.)
   });
-};
-
-// We're using "template" variables inside the project type configuration file (config/project-types.js)
-// so with the following function we can replace the string $port with the real port number e.g. 3000
-// (see type VariableMap for used mapping strings)
-export const substituteConfigVariables = (
-  configObject: any,
-  variableMap: VariableMap
-) => {
-  // e.g. $port inside args will be replaced with variable reference from variabeMap obj. {$port: port}
-  return Object.keys(configObject).reduce(
-    (config, key) => {
-      if (config[key] instanceof Array) {
-        // replace $port inside args array
-        config[key] = config[key].map(arg => variableMap[arg] || arg);
-      } else {
-        // check config[key] e.g. is {env: { PORT: '$port'} }
-        if (config[key] instanceof Object) {
-          // config[key] = {PORT: '$port'}, key = 'env'
-          config[key] = Object.keys(config[key]).reduce(
-            (newObj, nestedKey) => {
-              // use replacement value if available
-              newObj[nestedKey] =
-                variableMap[newObj[nestedKey]] || newObj[nestedKey];
-              return newObj;
-            },
-            { ...config[key] }
-          );
-        }
-      }
-      // todo: add top level substitution - not used yet but maybe needed later e.g. { env: $port } won't be replaced.
-      //       Bad example but just to have it as reminder.
-      return config;
-    },
-    { ...configObject }
-  );
 };
 
 export const getDevServerCommand = (

--- a/src/sagas/task.saga.js
+++ b/src/sagas/task.saga.js
@@ -36,13 +36,9 @@ import type { Saga } from 'redux-saga';
 import type { ChildProcess } from 'child_process';
 import type { Task, ProjectType } from '../types';
 import type { ReturnType } from '../actions/types';
+import type { VariableMap } from '../services/config-variables.service';
 
 const { dialog } = remote;
-
-// Mapping type for config template variables '$port'
-export type VariableMap = {
-  $port: string,
-};
 
 const chalk = new chalkRaw.constructor({ level: 3 });
 

--- a/src/services/config-variables.service.js
+++ b/src/services/config-variables.service.js
@@ -1,4 +1,12 @@
 // @flow
+
+// Mapping type for config template variables '$port'
+export type VariableMap = {
+  $port?: string,
+  $projectPath?: string,
+  $projectStarter?: ?string,
+};
+
 // We're using "template" variables inside the project type configuration file (config/project-types.js)
 // so with the following function we can replace the string $port with the real port number e.g. 3000
 // (see type VariableMap for used mapping strings)

--- a/src/services/config-variables.service.js
+++ b/src/services/config-variables.service.js
@@ -1,0 +1,36 @@
+// @flow
+// We're using "template" variables inside the project type configuration file (config/project-types.js)
+// so with the following function we can replace the string $port with the real port number e.g. 3000
+// (see type VariableMap for used mapping strings)
+export const substituteConfigVariables = (
+  configObject: any,
+  variableMap: VariableMap
+) => {
+  // e.g. $port inside args will be replaced with variable reference from variabeMap obj. {$port: port}
+  return Object.keys(configObject).reduce(
+    (config, key) => {
+      if (config[key] instanceof Array) {
+        // replace $port inside args array
+        config[key] = config[key].map(arg => variableMap[arg] || arg);
+      } else {
+        // check config[key] e.g. is {env: { PORT: '$port'} }
+        if (config[key] instanceof Object) {
+          // config[key] = {PORT: '$port'}, key = 'env'
+          config[key] = Object.keys(config[key]).reduce(
+            (newObj, nestedKey) => {
+              // use replacement value if available
+              newObj[nestedKey] =
+                variableMap[newObj[nestedKey]] || newObj[nestedKey];
+              return newObj;
+            },
+            { ...config[key] }
+          );
+        }
+      }
+      // todo: add top level substitution - not used yet but maybe needed later e.g. { env: $port } won't be replaced.
+      //       Bad example but just to have it as reminder.
+      return config;
+    },
+    { ...configObject }
+  );
+};

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -29,11 +29,11 @@ type ProjectInfo = {
   projectName: string,
   projectType: ProjectType,
   projectIcon: string,
-  projectStarter?: string,
+  projectStarter: ?string,
 };
 
 type BuildOptions = {
-  projectStarter?: string, // used for gatsby
+  projectStarter: ?string, // used for gatsby
 };
 
 export const checkIfProjectExists = (dir: string, projectName: string) =>

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -33,7 +33,7 @@ type ProjectInfo = {
 };
 
 type BuildOptions = {
-  projectStarter: ?string, // used for gatsby
+  projectStarter?: string, // used for gatsby
 };
 
 export const checkIfProjectExists = (dir: string, projectName: string) =>
@@ -82,9 +82,12 @@ export default (
   const projectPath = path.join(projectHomePath, projectDirectoryName);
 
   // Add starter for Gatsby. Check is optional as it can't be entered in the build steps for other project types.
-  const buildOptions = projectType === 'gatsby' && {
-    projectStarter,
-  };
+  const buildOptions =
+    projectType === 'gatsby'
+      ? {
+          projectStarter,
+        }
+      : null;
 
   const [instruction, ...args] = getBuildInstructions(
     projectType,
@@ -201,7 +204,7 @@ export const getColorForProject = (projectName: string) => {
 export const getBuildInstructions = (
   projectType: ProjectType,
   projectPath: string,
-  options: BuildOptions
+  options: ?BuildOptions
 ) => {
   // For Windows Support
   // Windows tries to run command as a script rather than on a cmd
@@ -215,13 +218,9 @@ export const getBuildInstructions = (
     projectConfigs[projectType].create,
     {
       $projectPath: projectPath,
-      $projectStarter: options.projectStarter,
+      $projectStarter: (options && options.projectStarter) || '',
     }
   );
-  console.log('creact command', createCommand, {
-    $projectPath: projectPath,
-    $projectStarter: options.projectStarter,
-  });
 
   return [command, ...createCommand.args];
 };

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as uuid from 'uuid/v1';
 import projectConfigs from '../config/project-types';
 import { processLogger } from './process-logger.service';
+import { substituteConfigVariables } from './config-variables.service';
 
 import { COLORS } from '../constants';
 
@@ -28,6 +29,11 @@ type ProjectInfo = {
   projectName: string,
   projectType: ProjectType,
   projectIcon: string,
+  projectStarter?: string,
+};
+
+type BuildOptions = {
+  projectStarter: ?string, // used for gatsby
 };
 
 export const checkIfProjectExists = (dir: string, projectName: string) =>
@@ -50,7 +56,7 @@ export const checkIfProjectExists = (dir: string, projectName: string) =>
  * fire multiple times, to handle updates mid-creation. Maybe an observable?
  */
 export default (
-  { projectName, projectType, projectIcon }: ProjectInfo,
+  { projectName, projectType, projectIcon, projectStarter }: ProjectInfo,
   projectHomePath: string,
   onStatusUpdate: (update: string) => void,
   onError: (err: string) => void,
@@ -75,7 +81,16 @@ export default (
   // To support cross platform with slashes and escapes
   const projectPath = path.join(projectHomePath, projectDirectoryName);
 
-  const [instruction, ...args] = getBuildInstructions(projectType, projectPath);
+  // Add starter for Gatsby. Check is optional as it can't be entered in the build steps for other project types.
+  const buildOptions = projectType === 'gatsby' && {
+    projectStarter,
+  };
+
+  const [instruction, ...args] = getBuildInstructions(
+    projectType,
+    projectPath,
+    buildOptions
+  );
 
   const process = childProcess.spawn(instruction, args, {
     env: getBaseProjectEnvironment(projectPath),
@@ -185,7 +200,8 @@ export const getColorForProject = (projectName: string) => {
 
 export const getBuildInstructions = (
   projectType: ProjectType,
-  projectPath: string
+  projectPath: string,
+  options: BuildOptions
 ) => {
   // For Windows Support
   // Windows tries to run command as a script rather than on a cmd
@@ -195,5 +211,17 @@ export const getBuildInstructions = (
     throw new Error('Unrecognized project type: ' + projectType);
   }
 
-  return [command, ...projectConfigs[projectType].create.args(projectPath)];
+  const createCommand = substituteConfigVariables(
+    projectConfigs[projectType].create,
+    {
+      $projectPath: projectPath,
+      $projectStarter: options.projectStarter,
+    }
+  );
+  console.log('creact command', createCommand, {
+    $projectPath: projectPath,
+    $projectStarter: options.projectStarter,
+  });
+
+  return [command, ...createCommand.args];
 };

--- a/src/services/create-project.service.test.js
+++ b/src/services/create-project.service.test.js
@@ -5,6 +5,8 @@ import {
   getBuildInstructions,
 } from './create-project.service';
 
+import { substituteConfigVariables } from './config-variables.service';
+
 jest.mock('os', () => ({
   homedir: jest.fn(),
   platform: () => process.platform,
@@ -35,8 +37,18 @@ describe('getBuildInstructions', () => {
   });
 
   it('should return the build instructions for a Gatsby project', () => {
-    const expectedOutput = ['npx', 'gatsby', 'new', path];
-    expect(getBuildInstructions('gatsby', path)).toEqual(expectedOutput);
+    const expectedOutput = [
+      'npx',
+      'gatsby',
+      'new',
+      path,
+      'gatsby-starter-blog',
+    ];
+    expect(
+      getBuildInstructions('gatsby', path, {
+        projectStarter: 'gatsby-starter-blog',
+      })
+    ).toEqual(expectedOutput);
   });
 
   it('should throw an exception when passed an unknown project type', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,7 +3597,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -5519,6 +5519,11 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
   integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
+
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=
 
 eventemitter3@^3.0.0:
   version "3.1.0"
@@ -8108,7 +8113,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.0:
+js-yaml@3.12.0, js-yaml@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
@@ -9322,6 +9327,11 @@ node-emoji@^1.0.4:
   integrity sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==
   dependencies:
     lodash.toarray "^4.4.0"
+
+node-fetch@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -11077,6 +11087,14 @@ react-pure-render@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-pure-render/-/react-pure-render-1.0.2.tgz#9d8a928c7f2c37513c2d064e57b3e3c356e9fabb"
   integrity sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs=
+
+react-redux-toastr@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/react-redux-toastr/-/react-redux-toastr-7.4.1.tgz#6351dc075c5b6f45df145d711bf40d6ed4065634"
+  integrity sha512-U7Z7A217yGgkjZE87MzHbLIlYV0OvZ3HiBRfUWoZF1Y4kvY6JAKn8EkAfPy40ZzoLiH2GpCq9Ac1U7v8on7PvQ==
+  dependencies:
+    classnames "^2.2.3"
+    eventemitter3 "^2.0.3"
 
 react-redux@5.0.7:
   version "5.0.7"


### PR DESCRIPTION
**Related Issue:**
#47 

**Summary:**
Add a Gatsby Starter selection to `CreateNewProjectWizard` & add the business logic to pass the starter url to the create command.
I've enlarged the TwoPanelModal height so the new component will fit into it.

There is still a lot todo. But I'd like to check if this is going into the right direction.

The thing with selecting more stuff is something we're handling with Guppy plugins. So we can add Flow, Storybook, Docz,... after project creation to keep the setup small.

**Screenshots/GIFs:**
**Gatsby with starter** (Styling of ProjectStarter input needs to be improved)
![grafik](https://user-images.githubusercontent.com/3046542/48741836-f10b5c00-ec5c-11e8-99ee-d65dc67baf89.png)

**Gatsby starter Summary pane**
![grafik](https://user-images.githubusercontent.com/3046542/48741987-6545ff80-ec5d-11e8-9d67-9398f7e4d913.png)

**Starter selection list (Styling needs to be improved)**
![grafik](https://user-images.githubusercontent.com/3046542/48741805-d0db9d00-ec5c-11e8-8d3a-1317a8612ac1.png)


**Todos:**
- [ ] Improve UI
  - [ ] Create a TextComponent with a button on the right to open the selection menu - similar to `DirectroyPicker`
  - [ ] Use Card component to render Starter selection list & add more details from the yaml.
  - [ ] Improve styling of the selected starter (just a red border at the moment)
  - [ ] Add basic navigation to starter list (just if we're not using Algolia)
- [ ] Refactor new step into `ProjectStarterSelector` component and use it in `projectSpecificSteps` method
- [ ] Selection list
  - [ ] Fix selection updates in `SelectStarterDialog` - Not working at the moment.
  - [ ] Sort by Github stars - requires an additional query. Maybe we need to use Graphql to get all the data. Like in this [code](https://github.com/gatsbyjs/gatsby/blob/f335f0c59e935770404a8844e37900308570ece4/www/src/pages/starters.js).
- [ ] Add test for `config-variables.service`
- [ ] Refactor build steps - I'd like to improve the conditons for button disable & submit button.
- [ ] Add a better copy to the Gatsby Starter summary pane. We'll need more details for the why and what it will do.
- [ ] Show a message if starter couldn't be used. Fails silently at the moment.
- [ ] Check if we need a loading spinner for the selection list.
- [ ] Should we display a preview screenshot? I think there is no image in the `starter.yml` not sure where to get the image - I'll check the Gatsby starter selection page.

**Discussion**
- What features are required in the starter selection dialog? I think we're not needing every feature from [Gatsby starter list](https://www.gatsbyjs.org/starters/?) - maybe we could add a link to it. But the Algolia search would be nice and maybe a sorting by the most popluar starters.
- Should we use Algolia for searching? I think it's OK to use a typeahead component as there are just arount 70 items in the list. We could change to Algolia later.
- Should we also add the `Deploy to Netlify` button? Or is this confusing for beginners? I think it's easy to add but I'm not sure if we should add it.  (Just opening a link like https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog will deploy to netlify).
- Should we allow the user to enter a URL manually into the starter input? Do we need some prefixes in the input field? For now I'm adding `https://github.com/gatsbyjs/` if no url is entered - so entering `gatsby-starter-blog` will use the starter `https://github.com/gatsbyjs/gatsby-starter-blog`
