### PR TITLE
In-app feedback with Nolt.io

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -16,6 +16,7 @@ import ProjectConfigurationModal from '../ProjectConfigurationModal';
 import AppSettingsModal from '../AppSettingsModal';
 import Initialization from '../Initialization';
 import LoadingScreen from '../LoadingScreen';
+import FeedbackButton from '../FeedbackButton';
 
 import type { Project } from '../../types';
 
@@ -43,6 +44,7 @@ class App extends PureComponent<Props> {
               <CreateNewProjectWizard />
               <ProjectConfigurationModal />
               <AppSettingsModal />
+              <FeedbackButton />
             </Fragment>
           )
         }

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -16,6 +16,7 @@ import {
 import {
   openProjectInFolder,
   openProjectInEditor,
+  openWindow,
 } from '../../services/shell.service';
 import {
   getSelectedProject,
@@ -26,7 +27,7 @@ import { getDevServerTaskForProjectId } from '../../reducers/tasks.reducer';
 import type { Project, Task } from '../../types';
 import type { Dispatch } from '../../actions/types';
 
-const { app, process, Menu, BrowserWindow } = remote;
+const { app, process, Menu } = remote;
 
 type Props = {
   projects: Array<Project>,
@@ -62,17 +63,7 @@ class ApplicationMenu extends Component<Props> {
   };
 
   openLink = url => {
-    const win = new BrowserWindow({
-      width: 800,
-      height: 600,
-      webPreferences: {
-        devTools: false,
-      },
-    });
-    // Remove the menu
-    win.setMenu(null);
-    win.loadURL(url);
-    win.show();
+    openWindow(url);
   };
 
   buildMenu = (props: Props) => {

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -8,6 +8,7 @@ import { shell, remote } from 'electron';
 
 import * as actions from '../../actions';
 import { GUPPY_REPO_URL } from '../../constants';
+import { IN_APP_FEEDBACK_URL } from '../../config/app';
 import {
   isMac,
   getCopyForOpeningFolder,
@@ -25,7 +26,7 @@ import { getDevServerTaskForProjectId } from '../../reducers/tasks.reducer';
 import type { Project, Task } from '../../types';
 import type { Dispatch } from '../../actions/types';
 
-const { app, process, Menu } = remote;
+const { app, process, Menu, BrowserWindow } = remote;
 
 type Props = {
   projects: Array<Project>,
@@ -58,6 +59,20 @@ class ApplicationMenu extends Component<Props> {
 
   openGithubLink = pathname => {
     shell.openExternal(`${GUPPY_REPO_URL}/${pathname}`);
+  };
+
+  openLink = url => {
+    const win = new BrowserWindow({
+      width: 800,
+      height: 600,
+      webPreferences: {
+        devTools: false,
+      },
+    });
+    // Remove the menu
+    win.setMenu(null);
+    win.loadURL(url);
+    win.show();
   };
 
   buildMenu = (props: Props) => {
@@ -158,6 +173,10 @@ class ApplicationMenu extends Component<Props> {
           {
             label: isMac ? 'Privacy Policy' : 'Privacy policy',
             click: () => this.openGithubLink('blob/master/PRIVACY.md'),
+          },
+          {
+            label: 'Feedback',
+            click: () => this.openLink(IN_APP_FEEDBACK_URL),
           },
         ],
       },

--- a/src/components/DetectActive/DetectActive.js
+++ b/src/components/DetectActive/DetectActive.js
@@ -2,16 +2,18 @@
 import React, { Component } from 'react';
 
 type Props = {
-  children: (isActive: boolean) => React$Node,
+  children: (isActive: boolean, isHovered: boolean) => React$Node,
 };
 
 type State = {
   isActive: boolean,
+  isHovered: boolean,
 };
 
 class DetectActive extends Component<Props, State> {
   state = {
     isActive: false,
+    isHovered: false,
   };
 
   handleMouseDown = (ev: SyntheticEvent<*>) => {
@@ -22,8 +24,12 @@ class DetectActive extends Component<Props, State> {
     this.setState({ isActive: false });
   };
 
+  handleMouseOver = (ev: SyntheticEvent<*>) => {
+    this.setState({ isHovered: true });
+  };
+
   handleMouseLeave = (ev: SyntheticEvent<*>) => {
-    this.setState({ isActive: false });
+    this.setState({ isActive: false, isHovered: false });
   };
 
   render() {
@@ -31,9 +37,10 @@ class DetectActive extends Component<Props, State> {
       <span
         onMouseDown={this.handleMouseDown}
         onMouseUp={this.handleMouseUp}
+        onMouseOver={this.handleMouseOver}
         onMouseLeave={this.handleMouseLeave}
       >
-        {this.props.children(this.state.isActive)}
+        {this.props.children(this.state.isActive, this.state.isHovered)}
       </span>
     );
   }

--- a/src/components/FeedbackButton/FeedbackButton.js
+++ b/src/components/FeedbackButton/FeedbackButton.js
@@ -1,0 +1,54 @@
+// @flow
+import React, { PureComponent } from 'react';
+import styled from 'styled-components';
+import IconBase from 'react-icons-kit';
+import { messageSquare } from 'react-icons-kit/feather/messageSquare';
+
+import DetectActive from '../DetectActive';
+
+import { openWindow } from '../../services/shell.service';
+import { IN_APP_FEEDBACK_URL } from '../../config/app';
+import { COLORS } from '../../constants';
+
+type Props = {
+  size: number,
+  color: string,
+  hoverColor: string,
+};
+
+class FeedbackButton extends PureComponent<Props> {
+  static defaultProps = {
+    size: 36,
+    color: COLORS.gray[400],
+    hoverColor: COLORS.purple[500],
+  };
+
+  render() {
+    const { color, hoverColor, size } = this.props;
+    return (
+      <DetectActive>
+        {(_, isHovered) => (
+          <Wrapper color={isHovered ? hoverColor : color}>
+            <IconBase
+              size={size}
+              icon={messageSquare}
+              onClick={() => openWindow(IN_APP_FEEDBACK_URL)}
+            />
+          </Wrapper>
+        )}
+      </DetectActive>
+    );
+  }
+}
+
+const Wrapper = styled.div`
+  position: fixed;
+  width: 40px;
+  height: 40px;
+  right: 20px;
+  bottom: 20px;
+  color: ${props => props.color};
+  z-index: 1;
+`;
+
+export default FeedbackButton;

--- a/src/components/FeedbackButton/FeedbackButton.js
+++ b/src/components/FeedbackButton/FeedbackButton.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { messageSquare } from 'react-icons-kit/feather/messageSquare';
+import { Spring, animated, interpolate } from 'react-spring';
 
 import DetectActive from '../DetectActive';
 
@@ -28,20 +29,33 @@ class FeedbackButton extends PureComponent<Props> {
     return (
       <DetectActive>
         {(_, isHovered) => (
-          <Wrapper color={isHovered ? hoverColor : color}>
-            <IconBase
-              size={size}
-              icon={messageSquare}
-              onClick={() => openWindow(IN_APP_FEEDBACK_URL)}
-            />
-          </Wrapper>
+          <Spring
+            native
+            to={{
+              scale: isHovered ? 1.15 : 1,
+            }}
+          >
+            {({ scale }) => (
+              <IconWrapper scale={scale} color={isHovered ? hoverColor : color}>
+                <IconBase
+                  size={size}
+                  icon={messageSquare}
+                  onClick={() => openWindow(IN_APP_FEEDBACK_URL)}
+                />
+              </IconWrapper>
+            )}
+          </Spring>
         )}
       </DetectActive>
     );
   }
 }
 
-const Wrapper = styled.div`
+const IconWrapper = animated(styled.div.attrs({
+  style: ({ scale }) => ({
+    transform: `scale(${scale}, ${scale})`,
+  }),
+})`
   position: fixed;
   width: 40px;
   height: 40px;
@@ -49,6 +63,6 @@ const Wrapper = styled.div`
   bottom: 20px;
   color: ${props => props.color};
   z-index: 1;
-`;
+`);
 
 export default FeedbackButton;

--- a/src/components/FeedbackButton/index.js
+++ b/src/components/FeedbackButton/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './FeedbackButton';

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -1,6 +1,7 @@
 // @flow
 // app-wide settings (no user changable settings here)
 module.exports = {
+  IN_APP_FEEDBACK_URL: 'https://d0419603.nolt.io/',
   PACKAGE_MANAGER: 'yarn',
   // Enable logging, if enabled all terminal responses are visible in the console (useful for debugging)
   LOGGING: false,

--- a/src/services/shell.service.js
+++ b/src/services/shell.service.js
@@ -2,17 +2,48 @@
 /**
  * Thin wrapper around electron `shell`, and other shell-like functions
  */
-import { shell } from 'electron';
+import { shell, remote } from 'electron';
 import launchEditor from 'react-dev-utils/launchEditor';
 import { exec } from 'child_process';
 
 import type { Project } from '../types';
+
+const { BrowserWindow } = remote;
+
+const openedWindows = {};
 
 export const openProjectInFolder = (project: Project) =>
   shell.openItem(project.path);
 
 export const openProjectInEditor = (project: Project) =>
   launchEditor(project.path, 1, 1);
+
+export const openWindow = (url: string) => {
+  const urlKey = url.replace(/(\/|:|\.)/g, '');
+
+  if (openedWindows[urlKey]) {
+    try {
+      return openedWindows[urlKey].show();
+    } catch (err) {
+      // swallow error - Window could be closed
+    }
+  }
+
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      devTools: false,
+    },
+  });
+  // Remove the menu
+  win.setMenu(null);
+  win.loadURL(url);
+  win.show();
+
+  // Save Window so we can open it later
+  openedWindows[urlKey] = win;
+};
 
 export const getNodeJsVersion = () =>
   new Promise<string | void>(resolve =>


### PR DESCRIPTION

**Related Issue:**
#243

**Summary:**
Added [Nolt.io](https://nolt.io). It opens a new Electron window from help/Feedback or from the UI.
If the user minimizes the second screen and clicks the the feedback button again. It won't open a new feedback screen. It displays the same window.

**Todos:**
- [ ] Change Nolt board to a board from @joshwcomeau (if it's OK to use Nolt)

**Things to discuss:**
- Feedback button position in lower right corner OK? Or should we place it at a different location
- Feedback button styling OK? Coloring like the settings button.
- Is it OK to use Nolt? I haven't used it before. I've googled a lot and that's the only service I've found that is free. But there are probably other good services. I like Nolt as styling is a bit customizable and also integrates Github (not sure how good the Github integration is but it would be great if we could create new issues from a feedback post).
- It would be nice to display the most recent posts/comments on hover of the feedback button. Not sure if this is possible - I have to check the API of Nolt.
- Display a number on the feedback button if there are new posts/comments (if possible)
- Do we have to update privacy policy? I think we should add a note that Nolt is a data processor with a link to their privacy policy.

**Screenshots/GIFs:**
*Application menu*
![grafik](https://user-images.githubusercontent.com/3046542/48968829-798b5300-eff5-11e8-8f9c-b2adc2503d59.png)

*New window*
![grafik](https://user-images.githubusercontent.com/3046542/48968794-08e43680-eff5-11e8-9a93-c9594ab45f5a.png)

*Feedback button*
![screenrecording_feedback_button](https://user-images.githubusercontent.com/3046542/48968802-21ece780-eff5-11e8-9f4e-c9ca9dfa8362.gif)
