### PR TITLE
Added pointerEvents on BackfaceWrapper - fix hover issue

### DIFF
--- a/src/components/TwoPaneModal/TwoPaneModal.js
+++ b/src/components/TwoPaneModal/TwoPaneModal.js
@@ -131,7 +131,9 @@ class TwoPaneModal extends PureComponent<Props, State> {
                   <PaneChildren>{leftPane}</PaneChildren>
                 </LeftPaneWrapper>
 
-                <BackfaceWrapper>{backface}</BackfaceWrapper>
+                <BackfaceWrapper isFolded={isFolded}>
+                  {backface}
+                </BackfaceWrapper>
               </LeftHalf>
 
               <RightPaneWrapper
@@ -229,7 +231,11 @@ const RightPaneWrapper = styled.div`
   border-radius: 0 8px 8px 0;
 `;
 
-const BackfaceWrapper = styled.div`
+const BackfaceWrapper = styled.div.attrs({
+  style: props => ({
+    pointerEvents: props.isFolded ? 'auto' : 'none',
+  }),
+})`
   position: absolute;
   z-index: 3;
   top: 0;


### PR DESCRIPTION
As mentioned in PR #335 there is a small issue with the `ExternalLink` on the `LeftPane` of the TwoPaneModal.

**Summary:**
Added `pointerEvents` to `BackfaceWrapper`. If folded disable `pointerEvents`.
Styling of ExternalLink is unchanged - I've just used the recording from GatsbyStarter branch.

One point that could be improved is that the Earth animaion is running even if it's not visible (see recording below). I think the impact is not that big but I haven't tested. We can tackle this after this PR by adding a prop to `Earth` component so it's only animating if it's visible.

**Screenshots/GIFs:**
*With-out pointerEvents on BackfaceWrapper*
![recording](https://user-images.githubusercontent.com/3046542/48999812-077f4f00-f158-11e8-85d8-06b30b0d9073.gif)

*With pointerEvents on BackfaceWrapper (different ExternalLink)*
![screenrecording_externallink_hover_fixed](https://user-images.githubusercontent.com/3046542/49044588-8fa03b80-f1ce-11e8-82ae-f68f0c1d17fb.gif)

*Removed class from div to show the Earth animation*
![screenrecording_removed_style_leftpane](https://user-images.githubusercontent.com/3046542/49044932-9c715f00-f1cf-11e8-8e8d-971fc8cb2107.gif)
