### PR TITLE
Fix project type selection

### DIFF
--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -31,7 +31,7 @@ class StrokeButton extends Component<Props> {
     } = this.props;
 
     return (
-      <DetectActive>
+      <DetectActiveStyled>
         {isActive => (
           <Wrapper>
             <Foreground>
@@ -47,10 +47,14 @@ class StrokeButton extends Component<Props> {
             />
           </Wrapper>
         )}
-      </DetectActive>
+      </DetectActiveStyled>
     );
   }
 }
+
+const DetectActiveStyled = styled(DetectActive)`
+  display: inline-block;
+`;
 
 const Wrapper = styled.div`
   position: relative;

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -31,7 +31,7 @@ class StrokeButton extends Component<Props> {
     } = this.props;
 
     return (
-      <DetectActiveStyled>
+      <DetectActive>
         {isActive => (
           <Wrapper>
             <Foreground>
@@ -47,14 +47,10 @@ class StrokeButton extends Component<Props> {
             />
           </Wrapper>
         )}
-      </DetectActiveStyled>
+      </DetectActive>
     );
   }
 }
-
-const DetectActiveStyled = styled(DetectActive)`
-  display: inline-block;
-`;
 
 const Wrapper = styled.div`
   position: relative;

--- a/src/components/DetectActive/DetectActive.js
+++ b/src/components/DetectActive/DetectActive.js
@@ -40,7 +40,7 @@ class DetectActive extends Component<Props, State> {
   render() {
     const { className } = this.props;
     return (
-      <div
+      <span
         className={className}
         onMouseDown={this.handleMouseDown}
         onMouseUp={this.handleMouseUp}
@@ -48,7 +48,7 @@ class DetectActive extends Component<Props, State> {
         onMouseLeave={this.handleMouseLeave}
       >
         {this.props.children(this.state.isActive, this.state.isHovered)}
-      </div>
+      </span>
     );
   }
 }


### PR DESCRIPTION
PR  #336 introduced a small visual issue in the project creation wizard.

**Summary:**
Changed wrapping `div` of `DetectActive` component back to `span`. 

**Screenshots/GIFs:**
Current master:
![screenshot_fix_projecttypeselection_before](https://user-images.githubusercontent.com/3046542/50667581-4952af00-0fba-11e9-84f9-9b8f5be751a0.PNG)

With fix:
![screenshot_fix_projecttypeselection_after](https://user-images.githubusercontent.com/3046542/50667586-5079bd00-0fba-11e9-8d5b-e0e4138f92fe.PNG)

