### PR TITLE
Updated snapshot because of migration to React-Spring

### DIFF
--- a/src/components/ProgressBar/__snapshots__/ProgressBar.test.js.snap
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.test.js.snap
@@ -4,20 +4,28 @@ exports[`ProgressBar component should render with 0% 1`] = `
 <styled.div
   height={8}
 >
-  <Motion
-    style={
+  <Spring
+    config={
       Object {
-        "interpolatedProgress": Object {
-          "damping": 32,
-          "precision": 0.0001,
-          "stiffness": 32,
-          "val": 0,
-        },
+        "friction": 32,
+        "tension": 32,
+      }
+    }
+    from={Object {}}
+    hold={false}
+    immediate={false}
+    impl={[Function]}
+    inject={[Function]}
+    native={true}
+    reset={false}
+    to={
+      Object {
+        "progress": 0,
       }
     }
   >
     <Component />
-  </Motion>
+  </Spring>
 </styled.div>
 `;
 
@@ -25,20 +33,28 @@ exports[`ProgressBar component should render with 50% 1`] = `
 <styled.div
   height={8}
 >
-  <Motion
-    style={
+  <Spring
+    config={
       Object {
-        "interpolatedProgress": Object {
-          "damping": 32,
-          "precision": 0.0001,
-          "stiffness": 32,
-          "val": 0.5,
-        },
+        "friction": 32,
+        "tension": 32,
+      }
+    }
+    from={Object {}}
+    hold={false}
+    immediate={false}
+    impl={[Function]}
+    inject={[Function]}
+    native={true}
+    reset={false}
+    to={
+      Object {
+        "progress": 0.5,
       }
     }
   >
     <Component />
-  </Motion>
+  </Spring>
 </styled.div>
 `;
 
@@ -46,19 +62,27 @@ exports[`ProgressBar component should render with 100% 1`] = `
 <styled.div
   height={8}
 >
-  <Motion
-    style={
+  <Spring
+    config={
       Object {
-        "interpolatedProgress": Object {
-          "damping": 32,
-          "precision": 0.0001,
-          "stiffness": 32,
-          "val": 1,
-        },
+        "friction": 32,
+        "tension": 32,
+      }
+    }
+    from={Object {}}
+    hold={false}
+    immediate={false}
+    impl={[Function]}
+    inject={[Function]}
+    native={true}
+    reset={false}
+    to={
+      Object {
+        "progress": 1,
       }
     }
   >
     <Component />
-  </Motion>
+  </Spring>
 </styled.div>
 `;


### PR DESCRIPTION
Quick PR to update ProgressBar snapshot of unit test.

**Summary:**
I missed to update it after merging master into the component-test branch. It changed because we migrated from Motion to React-Spring.