### PR TITLE
Test for button components

### DIFF
--- a/src/components/Button/ButtonBase.js
+++ b/src/components/Button/ButtonBase.js
@@ -92,28 +92,28 @@ const ButtonBaseStyles = styled.button`
   }
 `;
 
-const XSmallButton = styled(ButtonBaseStyles)`
+export const XSmallButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0px 12px')};
   height: ${props => (props.noPadding ? 'auto' : '22px')};
   border-radius: 15px;
   font-size: 12px;
 `;
 
-const SmallButton = styled(ButtonBaseStyles)`
+export const SmallButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0px 14px')};
   height: ${props => (props.noPadding ? 'auto' : '30px')};
   border-radius: 17px;
   font-size: 14px;
 `;
 
-const MediumButton = styled(ButtonBaseStyles)`
+export const MediumButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0px 20px')};
   height: ${props => (props.noPadding ? 'auto' : '38px')};
   border-radius: 19px;
   font-size: 16px;
 `;
 
-const LargeButton = styled(ButtonBaseStyles)`
+export const LargeButton = styled(ButtonBaseStyles)`
   padding: ${props => (props.noPadding ? '0px' : '0 32px')};
   height: ${props => (props.noPadding ? 'auto' : '48px')};
   border-radius: 24px;

--- a/src/components/Button/ButtonBase.test.js
+++ b/src/components/Button/ButtonBase.test.js
@@ -2,18 +2,17 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import ButtonBase, {
-  XSmallButton,
-  SmallButton,
-  MediumButton,
-  LargeButton,
+  XSmallButton as xsmall,
+  SmallButton as small,
+  MediumButton as medium,
+  LargeButton as large,
 } from './ButtonBase';
 
-const sizes = ['xsmall', 'small', 'medium', 'large'];
 const sizeComponents = {
-  xsmall: XSmallButton,
-  small: SmallButton,
-  medium: MediumButton,
-  large: LargeButton,
+  xsmall,
+  small,
+  medium,
+  large,
 };
 
 describe('ButtonBase component', () => {
@@ -21,7 +20,7 @@ describe('ButtonBase component', () => {
     const wrapper = shallow(<ButtonBase />);
     const instance = wrapper.instance();
 
-    for (const size of sizes) {
+    for (const size in sizeComponents) {
       it(`should return sized button component for size = ${size}`, () => {
         const component = instance.getButtonElem(size);
         expect(component).toBe(sizeComponents[size]);
@@ -40,7 +39,7 @@ describe('ButtonBase component', () => {
 
     it('should return default size medium', () => {
       const componentDefault = instance.getButtonElem();
-      expect(componentDefault).toBe(sizeComponents['medium']);
+      expect(componentDefault).toBe(medium);
     });
   });
 });

--- a/src/components/Button/ButtonBase.test.js
+++ b/src/components/Button/ButtonBase.test.js
@@ -1,0 +1,46 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import ButtonBase, {
+  XSmallButton,
+  SmallButton,
+  MediumButton,
+  LargeButton,
+} from './ButtonBase';
+
+const sizes = ['xsmall', 'small', 'medium', 'large'];
+const sizeComponents = {
+  xsmall: XSmallButton,
+  small: SmallButton,
+  medium: MediumButton,
+  large: LargeButton,
+};
+
+describe('ButtonBase component', () => {
+  describe('Button with size prop', () => {
+    const wrapper = shallow(<ButtonBase />);
+    const instance = wrapper.instance();
+
+    for (const size of sizes) {
+      it(`should return sized button component for size = ${size}`, () => {
+        const component = instance.getButtonElem(size);
+        expect(component).toBe(sizeComponents[size]);
+      });
+      it(`should render button for ${size} size`, () => {
+        // Using mount so the styles are available in the snapshot
+        const wrapperSizedButton = mount(<ButtonBase size={size} />);
+        expect(wrapperSizedButton).toMatchSnapshot();
+      });
+      it(`should render button for ${size} size with-out padding`, () => {
+        // Using mount so the styles are available in the snapshot
+        const wrapperSizedButton = mount(<ButtonBase size={size} noPadding />);
+        expect(wrapperSizedButton).toMatchSnapshot();
+      });
+    }
+
+    it('should return default size medium', () => {
+      const componentDefault = instance.getButtonElem();
+      expect(componentDefault).toBe(sizeComponents['medium']);
+    });
+  });
+});

--- a/src/components/Button/FillButton.js
+++ b/src/components/Button/FillButton.js
@@ -12,7 +12,7 @@ type Props = {
   children: React$Node,
 };
 
-export const wrapColorsInGradient = colors => {
+export const wrapColorsInGradient = (colors?: Array<string> | string) => {
   if (!Array.isArray(colors)) {
     return colors;
   }

--- a/src/components/Button/FillButton.js
+++ b/src/components/Button/FillButton.js
@@ -12,7 +12,7 @@ type Props = {
   children: React$Node,
 };
 
-const wrapColorsInGradient = colors => {
+export const wrapColorsInGradient = colors => {
   if (!Array.isArray(colors)) {
     return colors;
   }

--- a/src/components/Button/FillButton.test.js
+++ b/src/components/Button/FillButton.test.js
@@ -1,0 +1,29 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import { mount } from 'enzyme';
+import FillButton, { wrapColorsInGradient } from './FillButton';
+
+describe('FillButton component', () => {
+  it('should render button filled', () => {
+    const wrapper = mount(<FillButton />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('Wrap colors in gradient', () => {
+    const testColor = '#fff';
+    it('should return single color (string)', () => {
+      expect(wrapColorsInGradient(testColor)).toEqual(testColor);
+    });
+    it('should return single color (array)', () => {
+      expect(wrapColorsInGradient([testColor])).toEqual(testColor);
+    });
+
+    it('should return a gradient', () => {
+      const colors = [testColor, '#000'];
+      expect(wrapColorsInGradient(colors)).toEqual(`linear-gradient(
+    45deg,
+    ${colors.join(',')}
+  )`);
+    });
+  });
+});

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -64,7 +64,7 @@ const Foreground = styled.span`
   z-index: 1;
 `;
 
-const Background = styled.div`
+export const Background = styled.div`
   position: absolute;
   z-index: 0;
   top: ${props => (props.isActive ? -2 : 0)}px;

--- a/src/components/Button/StrokeButton.test.js
+++ b/src/components/Button/StrokeButton.test.js
@@ -1,0 +1,17 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import { mount } from 'enzyme';
+import StrokeButton, { Background } from './StrokeButton';
+
+describe('StrokeButton component', () => {
+  it('should render button with stroke outline', () => {
+    const wrapper = mount(<StrokeButton />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render background with active style', () => {
+    const colors = StrokeButton.defaultProps.strokeColors;
+    const background = mount(<Background isActive colors={colors} />);
+    expect(background).toMatchSnapshot();
+  });
+});

--- a/src/components/Button/__snapshots__/ButtonBase.test.js.snap
+++ b/src/components/Button/__snapshots__/ButtonBase.test.js.snap
@@ -1,0 +1,525 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonBase component Button with size prop should render button for large size 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0 32px;
+  height: 48px;
+  border-radius: 24px;
+  font-size: 24px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  size="large"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for large size with-out padding 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px;
+  height: auto;
+  border-radius: 24px;
+  font-size: 24px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  noPadding={true}
+  size="large"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    noPadding={true}
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      noPadding={true}
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for medium size 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px 20px;
+  height: 38px;
+  border-radius: 19px;
+  font-size: 16px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  size="medium"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for medium size with-out padding 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px;
+  height: auto;
+  border-radius: 19px;
+  font-size: 16px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  noPadding={true}
+  size="medium"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    noPadding={true}
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      noPadding={true}
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for small size 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px 14px;
+  height: 30px;
+  border-radius: 17px;
+  font-size: 14px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  size="small"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for small size with-out padding 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px;
+  height: auto;
+  border-radius: 17px;
+  font-size: 14px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  noPadding={true}
+  size="small"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    noPadding={true}
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      noPadding={true}
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for xsmall size 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px 12px;
+  height: 22px;
+  border-radius: 15px;
+  font-size: 12px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  size="xsmall"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;
+
+exports[`ButtonBase component Button with size prop should render button for xsmall size with-out padding 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eaeaea;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c0 {
+  padding: 0px;
+  height: auto;
+  border-radius: 15px;
+  font-size: 12px;
+}
+
+<ButtonBase
+  background="#eaeaea"
+  noPadding={true}
+  size="xsmall"
+  textColor="#111111"
+>
+  <Styled(styled.button)
+    background="#eaeaea"
+    noPadding={true}
+    textColor="#111111"
+  >
+    <styled.button
+      background="#eaeaea"
+      className="c0"
+      noPadding={true}
+      textColor="#111111"
+    >
+      <button
+        className="c0 c1"
+      />
+    </styled.button>
+  </Styled(styled.button)>
+</ButtonBase>
+`;

--- a/src/components/Button/__snapshots__/FillButton.test.js.snap
+++ b/src/components/Button/__snapshots__/FillButton.test.js.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FillButton component should render button filled 1`] = `
+.c1 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: linear-gradient( 45deg, #651fff,#D500F9 );
+  color: #FFF;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c1:hover {
+  background: linear-gradient( 45deg, #651fff,#D500F9 );
+}
+
+.c1:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c1:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+  -webkit-transform: scale(1.1);
+  -ms-transform: scale(1.1);
+  transform: scale(1.1);
+}
+
+.c0 {
+  padding: 0px 20px;
+  height: 38px;
+  border-radius: 19px;
+  font-size: 16px;
+}
+
+<FillButton
+  colors={
+    Array [
+      "#651fff",
+      "#D500F9",
+    ]
+  }
+  textColor="#FFF"
+>
+  <ButtonBase
+    activeSplat={true}
+    background="linear-gradient(
+    45deg,
+    #651fff,#D500F9
+  )"
+    hoverBackground="linear-gradient(
+    45deg,
+    #651fff,#D500F9
+  )"
+    size="medium"
+    textColor="#FFF"
+  >
+    <Styled(styled.button)
+      activeSplat={true}
+      background="linear-gradient(
+    45deg,
+    #651fff,#D500F9
+  )"
+      hoverBackground="linear-gradient(
+    45deg,
+    #651fff,#D500F9
+  )"
+      textColor="#FFF"
+    >
+      <styled.button
+        activeSplat={true}
+        background="linear-gradient(
+    45deg,
+    #651fff,#D500F9
+  )"
+        className="c0"
+        hoverBackground="linear-gradient(
+    45deg,
+    #651fff,#D500F9
+  )"
+        textColor="#FFF"
+      >
+        <button
+          className="c0 c1"
+        />
+      </styled.button>
+    </Styled(styled.button)>
+  </ButtonBase>
+</FillButton>
+`;

--- a/src/components/Button/__snapshots__/StrokeButton.test.js.snap
+++ b/src/components/Button/__snapshots__/StrokeButton.test.js.snap
@@ -1,0 +1,178 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StrokeButton component should render background with active style 1`] = `
+.c0 {
+  position: absolute;
+  z-index: 0;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border-radius: 100px;
+  background: linear-gradient(25deg,#651fff,#D500F9);
+  opacity: 0;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+}
+
+<styled.div
+  colors={
+    Array [
+      "#651fff",
+      "#D500F9",
+    ]
+  }
+  isActive={true}
+>
+  <div
+    className="c0"
+  />
+</styled.div>
+`;
+
+exports[`StrokeButton component should render button with stroke outline 1`] = `
+.c3 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFF;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c3:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c3:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c2 {
+  padding: 0px 20px;
+  height: 38px;
+  border-radius: 19px;
+  font-size: 16px;
+}
+
+.c0 {
+  position: relative;
+  display: inline-block;
+  padding: 2px;
+}
+
+.c1 {
+  display: block;
+  position: relative;
+  z-index: 1;
+}
+
+.c4 {
+  position: absolute;
+  z-index: 0;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  border-radius: 100px;
+  background: linear-gradient(25deg,#651fff,#D500F9);
+  opacity: 1;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+}
+
+<StrokeButton
+  fillColor="#FFF"
+  showStroke={true}
+  strokeColors={
+    Array [
+      "#651fff",
+      "#D500F9",
+    ]
+  }
+>
+  <DetectActive
+    className=""
+  >
+    <span
+      className=""
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      onMouseUp={[Function]}
+    >
+      <styled.div>
+        <div
+          className="c0"
+        >
+          <styled.span>
+            <span
+              className="c1"
+            >
+              <ButtonBase
+                background="#FFF"
+                size="medium"
+                textColor="#111111"
+              >
+                <Styled(styled.button)
+                  background="#FFF"
+                  textColor="#111111"
+                >
+                  <styled.button
+                    background="#FFF"
+                    className="c2"
+                    textColor="#111111"
+                  >
+                    <button
+                      className="c2 c3"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "display": "block",
+                          }
+                        }
+                      />
+                    </button>
+                  </styled.button>
+                </Styled(styled.button)>
+              </ButtonBase>
+            </span>
+          </styled.span>
+          <styled.div
+            colors={
+              Array [
+                "#651fff",
+                "#D500F9",
+              ]
+            }
+            isActive={false}
+            isVisible={true}
+          >
+            <div
+              className="c4"
+            />
+          </styled.div>
+        </div>
+      </styled.div>
+    </span>
+  </DetectActive>
+</StrokeButton>
+`;

--- a/src/components/ButtonWithIcon/ButtonWithIcon.test.js
+++ b/src/components/ButtonWithIcon/ButtonWithIcon.test.js
@@ -1,0 +1,14 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import { mount } from 'enzyme';
+import Icon from 'react-icons-kit';
+import { settings } from 'react-icons-kit/feather';
+import ButtonWithIcon from './ButtonWithIcon';
+
+describe('ButtonWithIcon component', () => {
+  it('should render button with icon', () => {
+    const icon = <Icon icon={settings} />;
+    const wrapper = mount(<ButtonWithIcon icon={icon} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/ButtonWithIcon/__snapshots__/ButtonWithIcon.test.js.snap
+++ b/src/components/ButtonWithIcon/__snapshots__/ButtonWithIcon.test.js.snap
@@ -1,0 +1,347 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonWithIcon component should render button with icon 1`] = `
+.c3 {
+  position: relative;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFF;
+  color: #111111;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.c3:disabled {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  opacity: 0.75;
+}
+
+.c3:not(:disabled):active {
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+}
+
+.c2 {
+  padding: 0px;
+  height: auto;
+  border-radius: 19px;
+  font-size: 16px;
+}
+
+.c0 {
+  position: relative;
+  display: inline-block;
+  padding: 2px;
+}
+
+.c1 {
+  display: block;
+  position: relative;
+  z-index: 1;
+}
+
+.c6 {
+  position: absolute;
+  z-index: 0;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  border-radius: 100px;
+  background: linear-gradient(25deg,#651fff,#D500F9);
+  opacity: 1;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+}
+
+.c4 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 34px;
+  padding: 0 10px 0 32px;
+}
+
+.c5 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 34px;
+  height: 34px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+<ButtonWithIcon
+  icon={
+    <Icon
+      fill="currentColor"
+      icon={
+        Object {
+          "attribs": Object {
+            "fill": "none",
+            "stroke": "currentColor",
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round",
+            "stroke-width": "2",
+          },
+          "children": Array [
+            Object {
+              "attribs": Object {
+                "cx": "12",
+                "cy": "12",
+                "r": "3",
+              },
+              "children": Array [],
+              "name": "circle",
+            },
+            Object {
+              "attribs": Object {
+                "d": "M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z",
+              },
+              "children": Array [],
+              "name": "path",
+            },
+          ],
+          "viewBox": "0 0 24 24",
+        }
+      }
+      size={16}
+    />
+  }
+>
+  <StrokeButton
+    fillColor="#FFF"
+    noPadding={true}
+    showStroke={true}
+    strokeColors={
+      Array [
+        "#651fff",
+        "#D500F9",
+      ]
+    }
+  >
+    <DetectActive
+      className=""
+    >
+      <span
+        className=""
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+        onMouseUp={[Function]}
+      >
+        <styled.div>
+          <div
+            className="c0"
+          >
+            <styled.span>
+              <span
+                className="c1"
+              >
+                <ButtonBase
+                  background="#FFF"
+                  noPadding={true}
+                  size="medium"
+                  textColor="#111111"
+                >
+                  <Styled(styled.button)
+                    background="#FFF"
+                    noPadding={true}
+                    textColor="#111111"
+                  >
+                    <styled.button
+                      background="#FFF"
+                      className="c2"
+                      noPadding={true}
+                      textColor="#111111"
+                    >
+                      <button
+                        className="c2 c3"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "display": "block",
+                            }
+                          }
+                        >
+                          <styled.div>
+                            <div
+                              className="c4"
+                            >
+                              <styled.div>
+                                <div
+                                  className="c5"
+                                >
+                                  <Icon
+                                    fill="currentColor"
+                                    icon={
+                                      Object {
+                                        "attribs": Object {
+                                          "fill": "none",
+                                          "stroke": "currentColor",
+                                          "stroke-linecap": "round",
+                                          "stroke-linejoin": "round",
+                                          "stroke-width": "2",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {
+                                              "cx": "12",
+                                              "cy": "12",
+                                              "r": "3",
+                                            },
+                                            "children": Array [],
+                                            "name": "circle",
+                                          },
+                                          Object {
+                                            "attribs": Object {
+                                              "d": "M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z",
+                                            },
+                                            "children": Array [],
+                                            "name": "path",
+                                          },
+                                        ],
+                                        "viewBox": "0 0 24 24",
+                                      }
+                                    }
+                                    size={16}
+                                  >
+                                    <div
+                                      fill="currentColor"
+                                      size={16}
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "display": "inline-flex",
+                                          "justifyContent": "center",
+                                        }
+                                      }
+                                    >
+                                      <SvgIcon
+                                        icon={
+                                          Object {
+                                            "attribs": Object {
+                                              "fill": "none",
+                                              "stroke": "currentColor",
+                                              "stroke-linecap": "round",
+                                              "stroke-linejoin": "round",
+                                              "stroke-width": "2",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "cx": "12",
+                                                  "cy": "12",
+                                                  "r": "3",
+                                                },
+                                                "children": Array [],
+                                                "name": "circle",
+                                              },
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                              },
+                                            ],
+                                            "viewBox": "0 0 24 24",
+                                          }
+                                        }
+                                        size={16}
+                                      >
+                                        <svg
+                                          fill="none"
+                                          height={16}
+                                          stroke="currentColor"
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth="2"
+                                          style={
+                                            Object {
+                                              "display": "inline-block",
+                                              "verticalAlign": "middle",
+                                            }
+                                          }
+                                          viewBox="0 0 24 24"
+                                          width={16}
+                                        >
+                                          <circle
+                                            cx="12"
+                                            cy="12"
+                                            key="0"
+                                            r="3"
+                                          />
+                                          <path
+                                            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
+                                            key="1"
+                                          />
+                                        </svg>
+                                      </SvgIcon>
+                                    </div>
+                                  </Icon>
+                                </div>
+                              </styled.div>
+                            </div>
+                          </styled.div>
+                        </span>
+                      </button>
+                    </styled.button>
+                  </Styled(styled.button)>
+                </ButtonBase>
+              </span>
+            </styled.span>
+            <styled.div
+              colors={
+                Array [
+                  "#651fff",
+                  "#D500F9",
+                ]
+              }
+              isActive={false}
+              isVisible={true}
+            >
+              <div
+                className="c6"
+              />
+            </styled.div>
+          </div>
+        </styled.div>
+      </span>
+    </DetectActive>
+  </StrokeButton>
+</ButtonWithIcon>
+`;


### PR DESCRIPTION
**Related Issue:**
#309 

**Summary:**
Most test cases are snapshot tests. For testing styled-components I've used `mount` so the styles are available in the snapshot. Not sure if there is a better way to test them but I think that's OK.

Added unit tests for:
- ButtonBase
- FillButton
- StrokeButton
- ButtonWithIcon

@idoberko2 would be awesome if you could also review these tests and let me know if there is something to improve.

I think next I'll add tests for `EjectButton` & `BigClickableButton` & for `ProjectConfigurationModal`. Probably in two PRs to separate them a bit as the `ProjectConfigurationModal` has more to test.