### PR TITLE
[WIP] Improve Gatsby starter

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "publish": "yarn dist --publish always",
     "publish:all": "yarn dist:all --publish always",
     "test": "node scripts/test.js --env=node",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --maxWorkers=2 --coverage",
     "report-coverage": "yarn coverage && codecov",
     "flow": "flow",
     "lint": "eslint src/**/*.js config/**/*.js",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "uglifyjs-webpack-plugin": "1.1.6",
     "url-loader": "0.6.2",
     "uuid": "3.3.2",
+    "valid-url": "1.0.9",
     "webpack": "3.10.0",
     "webpack-dev-server": "2.11.0",
     "webpack-manifest-plugin": "1.3.2"

--- a/src/components/CreateNewProjectWizard/Gatsby/ProjectStarterSelection.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/ProjectStarterSelection.js
@@ -106,6 +106,7 @@ class ProjectStarter extends Component<Props, State> {
 
   updateSearchString = (filterString: string) => {
     const { projectStarter, onSelect } = this.props;
+
     this.setState({
       starterListVisible: filterString !== '' || !!projectStarter,
       filterString,

--- a/src/components/CreateNewProjectWizard/Gatsby/ProjectStarterSelection.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/ProjectStarterSelection.js
@@ -3,6 +3,7 @@ import React, { Fragment, Component } from 'react';
 import fetch from 'node-fetch'; // Note: This is using net.request from Node. Browser fetch throws CORS error.
 import yaml from 'js-yaml';
 import Fuse from 'fuse.js';
+import validUrl from 'valid-url';
 
 import TextInputWithButton from '../../TextInputWithButton';
 import SelectStarterList from './SelectStarterList';
@@ -89,12 +90,37 @@ class ProjectStarter extends Component<Props, State> {
     }));
   };
 
+  isExactMatch = (filterString: string) => {
+    const { starters } = this.state;
+
+    return starters.find(
+      starter =>
+        starter.repo === filterString ||
+        (starter.repo
+          .split('/')
+          .pop()
+          .toString() === filterString &&
+          !filterString.includes('http'))
+    );
+  };
+
   updateSearchString = (filterString: string) => {
-    const { projectStarter } = this.props;
+    const { projectStarter, onSelect } = this.props;
     this.setState({
       starterListVisible: filterString !== '' || !!projectStarter,
       filterString,
     });
+
+    // Check if filterString matches a url in starters array or a name (last part of url with-out http).
+    // Automatically selects starter on match
+    const matchedStarter = this.isExactMatch(filterString);
+    if (matchedStarter) {
+      onSelect(matchedStarter.repo);
+    } else if (validUrl.isUri(filterString)) {
+      // We're selecting the filterString as starter here as it's not matching a starter from the list but it's a url
+      // Before building we're doing an final check if it exists
+      onSelect(filterString);
+    }
   };
 
   render() {

--- a/src/components/CreateNewProjectWizard/Gatsby/ProjectStarterSelection.test.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/ProjectStarterSelection.test.js
@@ -107,6 +107,25 @@ describe('ProjectStarterSelection component', () => {
     expect(instance.state.starterListVisible).toBeFalsy();
   });
 
+  it('should select starter (with https) from list', () => {
+    const starter = 'https://github.com/wonism/gatsby-advanced-blog';
+    instance.updateSearchString(starter);
+    expect(mockedOnSelect).toBeCalledWith(starter);
+  });
+
+  it('should select starter (with repo name) in list', () => {
+    const starter = 'https://github.com/wonism/gatsby-advanced-blog';
+    instance.updateSearchString('gatsby-advanced-blog');
+    expect(mockedOnSelect).toBeCalledWith(starter);
+  });
+
+  it('should select starter (with https) not in list', () => {
+    const starter =
+      'https://github.com/2manyprojects2littletime/gatsby-starter-blog';
+    instance.updateSearchString(starter);
+    expect(mockedOnSelect).toBeCalledWith(starter);
+  });
+
   it('should move the selected starter to first entry of starter list', () => {
     const blogStarterUrl = 'https://github.com/dschau/gatsby-blog-starter-kit';
     wrapper.setProps({ projectStarter: blogStarterUrl });

--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
@@ -140,7 +140,7 @@ const SelectionInfo = styled.div`
   background: ${COLORS.gray[200]};
   border-radius: 5px;
   padding: 5px;
-  display: ${props => (props.visible ? 'auto' : 'none')};
+  ${({ visible }) => !visible && 'display: none;'};
 `;
 
 const ScrollContainer = styled(Scrollbars)`

--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
@@ -89,6 +89,9 @@ class SelectStarterList extends PureComponent<Props> {
                   >
                     {starter.repo.split('/').pop()}
                   </StarterItemHeading>
+                  <SelectionInfo visible={selectedStarter === starter.repo}>
+                    selected
+                  </SelectionInfo>
                   <ExternalLink
                     href={this.prepareUrlForCodesandbox(starter.repo)}
                   >
@@ -99,7 +102,9 @@ class SelectStarterList extends PureComponent<Props> {
                 </StarterItemTitle>
 
                 <Description>
-                  {starter.description !== 'n/a' && starter.description}
+                  {starter.description === 'n/a'
+                    ? 'No description'
+                    : starter.description}
                 </Description>
                 <Divider />
               </StarterItem>
@@ -129,6 +134,13 @@ const Description = styled.p`
   padding: 0 5px 2px;
   hyphens: auto;
   text-align: justify;
+`;
+
+const SelectionInfo = styled.div`
+  background: ${COLORS.gray[200]};
+  border-radius: 5px;
+  padding: 5px;
+  display: ${props => (props.visible ? 'auto' : 'none')};
 `;
 
 const ScrollContainer = styled(Scrollbars)`

--- a/yarn.lock
+++ b/yarn.lock
@@ -13930,6 +13930,11 @@ uuid@^3.0.1, uuid@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
   integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
 
+valid-url@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
+
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"


### PR DESCRIPTION
**Related Issue:**
#47
 
**Summary:**
After merging #335 I've noticed that entering an url or a starter name wasn't available. The `Summary` mentioned it but the functionality was removed because of the last UX improvement. Summary is correct again as the features are available once this PR is merged.

**Added the following to the input field:**
- Select starter by name e.g. enter `gatsby-starter-blog`
- Select stater by url e.g. `https://github.com/gatsbyjs/gatsby-starter-blog`
- Allow custom url with-out selecting a starter from the list e.g. `https://github.com/2manyprojects2littletime/gatsby-starter-blog`
- Test cases for the added functionality

**Discussion**
- Deleting the entered term in the input won't deselect the starter. I think that's OK - just wanted to mention it.
- Do we need an info that the url entered is valid? At the moment, there is no indication that it will be used. That's probably OK. We're only displaying a message if the starter wasn't found. I think that's a rare use-case we can improve later.
- Search improvement - @melanieseltzer mentioned it but I don't know it yet. But we can improve it with this PR.