### PR TITLE
CircleCi fails at reporting coverage (memory issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "publish": "yarn dist --publish always",
     "publish:all": "yarn dist:all --publish always",
     "test": "node scripts/test.js --env=node",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --maxWorkers=2 --coverage",
     "report-coverage": "yarn coverage && codecov",
     "flow": "flow",
     "lint": "eslint src/**/*.js config/**/*.js",


### PR DESCRIPTION
**Summary:**
As mentioned in this [post](https://vgpena.github.io/jest-circleci/) tried to increase works for coverage.
I've also configured CircleCi to 2 containers.

I'll add more details later today.

`--runInBands` not tested yet.  

Error about memory:
![grafik](https://user-images.githubusercontent.com/3046542/51629792-c5506f00-1f48-11e9-8656-78238d4ce8f9.png)

Not sure if the issue is fixed with `maxContainers` as I'm not seeing that there are two containers used. But the test passed.