### PR TITLE
Fix spaces and update lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,13 @@
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "lint-staged": {
-    "*.{js,jsx,mjs}": [
-      "npm run prettier",
-      "eslint",
-      "git add"
-    ]
+    "linters": {
+      "*.{js,jsx,mjs}": [
+        "npm run prettier",
+        "eslint",
+        "git add"
+      ]
+    }
   },
   "dependencies": {
     "create-react-app": "1.5.2",
@@ -119,7 +121,7 @@
     "jest-styled-components": "6.2.2",
     "jsdom": "13.0.0",
     "jsdom-global": "3.0.2",
-    "lint-staged": "7.2.0",
+    "lint-staged": "7.3.0",
     "loader-utils": "1.1.0",
     "lolex": "3.0.0",
     "mixpanel-browser": "2.22.4",

--- a/src/components/DependencyManagementPane/DependencyDetailsTable.js
+++ b/src/components/DependencyManagementPane/DependencyDetailsTable.js
@@ -60,7 +60,7 @@ class DependencyDetailsTable extends Component<Props> {
           </tr>
           <tr>
             <Cell>
-              <Label> Last Published </Label>
+              <Label>Last Published</Label>
             </Cell>
             <Cell>
               {lastUpdatedAt ? (
@@ -74,7 +74,7 @@ class DependencyDetailsTable extends Component<Props> {
           </tr>
           <tr>
             <Cell>
-              <Label> License </Label>
+              <Label>License</Label>
             </Cell>
             <Cell>
               <License license={dependency.license} />
@@ -82,13 +82,13 @@ class DependencyDetailsTable extends Component<Props> {
           </tr>
           <tr>
             <Cell>
-              <Label> Resources </Label>
+              <Label>Resources</Label>
             </Cell>
             <Cell>
-              <ExternalLink href={packageHref}> NPM </ExternalLink>
+              <ExternalLink href={packageHref}>NPM</ExternalLink>
               {githubHref && <Middot />}
               {githubHref && (
-                <ExternalLink href={githubHref}> GitHub </ExternalLink>
+                <ExternalLink href={githubHref}>GitHub</ExternalLink>
               )}
               {dependency.homepage && <Middot />}
               {dependency.homepage && (

--- a/src/components/DependencyManagementPane/DependencyManagementPane.js
+++ b/src/components/DependencyManagementPane/DependencyManagementPane.js
@@ -203,7 +203,8 @@ export class DependencyManagementPane extends PureComponent<Props, State> {
                 isOnline={this.props.isOnline}
                 onClick={this.openAddNewDependencyModal}
               >
-                <IconBase icon={plus} size={20} /> <Spacer size={6} />
+                <IconBase icon={plus} size={20} />
+                <Spacer size={6} />
                 Add New
                 <OnlyOn
                   size="mdMin"

--- a/src/components/DependencyManagementPane/DependencyUpdateRow.js
+++ b/src/components/DependencyManagementPane/DependencyUpdateRow.js
@@ -63,7 +63,7 @@ class DependencyUpdateRow extends Component<Props> {
           }}
         />
         <Spacer size={6} />
-        Up - to - date
+        Up-to-date
       </UpToDate>
     ) : (
       <FillButton
@@ -87,12 +87,12 @@ class DependencyUpdateRow extends Component<Props> {
     return (
       <Wrapper>
         <Col>
-          <VersionLabel> Latest Version </VersionLabel>
-          <VersionNum> {latestVersion || '--'} </VersionNum>
+          <VersionLabel>Latest Version</VersionLabel>
+          <VersionNum>{latestVersion || '--'}</VersionNum>
         </Col>
         <Col>
-          <VersionLabel> Installed Version </VersionLabel>
-          <VersionNum> {dependency.version} </VersionNum>
+          <VersionLabel>Installed Version</VersionLabel>
+          <VersionNum>{dependency.version}</VersionNum>
         </Col>
         <UpdateCol isOnline={isOnline}> {this.renderActionColumn()} </UpdateCol>
       </Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,10 +1790,6 @@ app-builder-lib@20.28.4, app-builder-lib@~20.28.3:
     semver "^5.5.1"
     temp-file "^3.1.3"
 
-app-root-path@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
-
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -7617,7 +7613,7 @@ jest-util@^23.4.0:
     slash "^1.0.0"
     source-map "^0.6.0"
 
-jest-validate@^23.0.0, jest-validate@^23.6.0:
+jest-validate@^23.5.0, jest-validate@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
   dependencies:
@@ -7953,11 +7949,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.2.0.tgz#bdf4bb7f2f37fe689acfaec9999db288a5b26888"
+lint-staged@7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.3.0.tgz#90ff33e5ca61ed3dbac35b6f6502dbefdc0db58d"
+  integrity sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==
   dependencies:
-    app-root-path "^2.0.1"
     chalk "^2.3.1"
     commander "^2.14.1"
     cosmiconfig "^5.0.2"
@@ -7967,7 +7963,7 @@ lint-staged@7.2.0:
     find-parent-dir "^0.3.0"
     is-glob "^4.0.0"
     is-windows "^1.0.2"
-    jest-validate "^23.0.0"
+    jest-validate "^23.5.0"
     listr "^0.14.1"
     lodash "^4.17.5"
     log-symbols "^2.2.0"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
N/A

**Summary:**
Quick PR to fix some spacing issues I noticed (one of which caused a visual regression with Up-to-date verbiage). I think Prettier screwed up somehow? 

Also updated `lint-staged` config and pinned to 7.3.0 to get rid of this validation message I was seeing (see https://github.com/okonet/lint-staged/issues/482 for info):

<img width="400" alt="Screen Shot 2019-03-26 at 2 32 16 PM" src="https://user-images.githubusercontent.com/17421347/55043036-8cd51c00-4ff1-11e9-8bc3-7cb84b9bae18.png">
