### PR TITLE
Semantic colors

### DIFF
--- a/.storybook/components/Wrapper/Wrapper.js
+++ b/.storybook/components/Wrapper/Wrapper.js
@@ -13,7 +13,7 @@ class Wrapper extends Component<Props> {
     const { children } = this.props;
     return (
       <OuterWrapper>
-        <InnerWrapper>{children}</InnerWrapper>
+        <InnerWrapper> {children} </InnerWrapper>{' '}
       </OuterWrapper>
     );
   }
@@ -27,7 +27,7 @@ const OuterWrapper = styled.div`
   bottom: 0;
 `;
 const InnerWrapper = styled.div`
-  background: ${COLORS.white};
+  background: ${COLORS.lightBackground};
   box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
   margin: 2rem;
   padding: 1.5rem;

--- a/.storybook/components/Wrapper/Wrapper.js
+++ b/.storybook/components/Wrapper/Wrapper.js
@@ -13,7 +13,7 @@ class Wrapper extends Component<Props> {
     const { children } = this.props;
     return (
       <OuterWrapper>
-        <InnerWrapper> {children} </InnerWrapper>{' '}
+        <InnerWrapper>{children}</InnerWrapper>
       </OuterWrapper>
     );
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -65,7 +65,7 @@ const Wrapper = styled.div`
   display: flex;
   position: relative;
   z-index: 1;
-  background: ${COLORS.gray[50]};
+  background: ${COLORS.background};
 
   animation: ${fadeIn} 500ms ease-in;
 `;

--- a/src/components/AppSettingsModal/AppSettingsModal.js
+++ b/src/components/AppSettingsModal/AppSettingsModal.js
@@ -8,7 +8,7 @@ import { remote } from 'electron';
 
 import * as actions from '../../actions';
 import { getDefaultProjectPath } from '../../reducers/app-settings.reducer';
-import { COLORS } from '../../constants';
+import { GRADIENTS } from '../../constants';
 import { setNested } from '../../utils';
 
 import Modal from '../Modal';
@@ -94,7 +94,7 @@ export class AppSettingsModal extends PureComponent<Props, State> {
             {/* // todo: Refactor to map over settings so this renders dynamically -
                          needs additional info on state e.g. component for rendering + props
                          -> For now it's OK to hard code as we're only having three
-                            settings 
+                            settings
             */}
             <SectionTitle>General</SectionTitle>
             <PixelShifter x={5} reason="Slightly intend in section">
@@ -144,10 +144,7 @@ export class AppSettingsModal extends PureComponent<Props, State> {
             </PixelShifter>
             <Spacer size={10} />
             <Actions>
-              <FillButton
-                size="large"
-                colors={[COLORS.green[700], COLORS.lightGreen[500]]}
-              >
+              <FillButton size="large" colors={GRADIENTS.success}>
                 Save
               </FillButton>
             </Actions>

--- a/src/components/BigClickableButton/BigClickableButton.js
+++ b/src/components/BigClickableButton/BigClickableButton.js
@@ -4,7 +4,7 @@ import { Spring, animated } from 'react-spring';
 import styled from 'styled-components';
 import Color from 'color';
 
-import { COLORS } from '../../constants';
+import { COLORS, GRADIENTS } from '../../constants';
 
 type Props = {
   width: number,
@@ -25,7 +25,7 @@ class BigClickableButton extends Component<Props, State> {
     width: 64,
     height: 64,
     thickness: 6,
-    colors: ['#2142ff', COLORS.blue[500]],
+    colors: GRADIENTS.darkPrimary,
   };
 
   state = {
@@ -148,7 +148,7 @@ export const Button = styled.button`
   display: flex;
   align-items: center;
   justify-content: space-around;
-  color: ${COLORS.white};
+  color: ${COLORS.textOnBackground};
   font-size: 18px;
 
   border: none;

--- a/src/components/BigClickableButton/__snapshots__/BigClickableButton.test.js.snap
+++ b/src/components/BigClickableButton/__snapshots__/BigClickableButton.test.js.snap
@@ -19,12 +19,12 @@ exports[`BigClickableButton component should render pressed 1`] = `
   color: #FFF;
   font-size: 18px;
   border: none;
-  background: linear-gradient(45deg,#2142ff,#3f6cff);
+  background: linear-gradient(45deg,#651fff,#304FFE);
   outline: none;
 }
 
 <styled.button
-  background="linear-gradient(45deg, #2142ff, #3f6cff)"
+  background="linear-gradient(45deg, #651fff, #304FFE)"
   height={64}
   onMouseDown={[Function]}
   onMouseLeave={[Function]}
@@ -80,7 +80,7 @@ exports[`BigClickableButton component should render pressed 2`] = `
                       L 72,72
                       L 6,72
                     "
-          fill="rgb(0, 30, 202)"
+          fill="rgb(63, 0, 200)"
         />
         <path
           d="
@@ -89,7 +89,7 @@ exports[`BigClickableButton component should render pressed 2`] = `
                       L 72,72
                       L 64, 64
                     "
-          fill="rgb(0, 52, 223)"
+          fill="rgb(1, 33, 210)"
         />
       </svg>
     </styled.svg>
@@ -116,12 +116,12 @@ exports[`BigClickableButton component should render released 1`] = `
   color: #FFF;
   font-size: 18px;
   border: none;
-  background: linear-gradient(45deg,#2142ff,#3f6cff);
+  background: linear-gradient(45deg,#651fff,#304FFE);
   outline: none;
 }
 
 <styled.button
-  background="linear-gradient(45deg, #2142ff, #3f6cff)"
+  background="linear-gradient(45deg, #651fff, #304FFE)"
   height={64}
   onMouseDown={[Function]}
   onMouseLeave={[Function]}
@@ -177,7 +177,7 @@ exports[`BigClickableButton component should render released 2`] = `
                       L 72,72
                       L 6,72
                     "
-          fill="rgb(0, 30, 202)"
+          fill="rgb(63, 0, 200)"
         />
         <path
           d="
@@ -186,7 +186,7 @@ exports[`BigClickableButton component should render released 2`] = `
                       L 72,72
                       L 64, 64
                     "
-          fill="rgb(0, 52, 223)"
+          fill="rgb(1, 33, 210)"
         />
       </svg>
     </styled.svg>

--- a/src/components/Button/ButtonBase.js
+++ b/src/components/Button/ButtonBase.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 type Size = 'xsmall' | 'small' | 'medium' | 'large';
 
@@ -20,8 +20,8 @@ type Props = {
 class ButtonBase extends Component<Props> {
   static defaultProps = {
     size: 'medium',
-    background: COLORS.gray[200],
-    textColor: COLORS.gray[900],
+    background: RAW_COLORS.gray[200],
+    textColor: COLORS.text,
   };
 
   getButtonElem = (size: Size) => {

--- a/src/components/Button/ButtonBase.stories.js
+++ b/src/components/Button/ButtonBase.stories.js
@@ -5,7 +5,7 @@ import { decorateAction } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 
 import Showcase from '../../../.storybook/components/Showcase';
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 import ButtonBase from './ButtonBase';
 
 const targetAction = decorateAction([args => [args[0].target]]);
@@ -37,9 +37,9 @@ storiesOf('Button / Base', module)
       <Fragment>
         <Showcase label="Solid Colours">
           <ButtonBase
-            background={COLORS.blue[700]}
-            hoverBackground={COLORS.violet[700]}
-            textColor={COLORS.yellow[500]}
+            background={RAW_COLORS.blue[700]}
+            hoverBackground={RAW_COLORS.violet[700]}
+            textColor={RAW_COLORS.yellow[500]}
             onClick={targetAction('button-clicked')}
           >
             Colourful!
@@ -47,13 +47,13 @@ storiesOf('Button / Base', module)
         </Showcase>
         <Showcase label="Gradients">
           <ButtonBase
-            background={`linear-gradient(0deg, ${COLORS.blue[700]}, ${
-              COLORS.violet[500]
+            background={`linear-gradient(0deg, ${RAW_COLORS.blue[700]}, ${
+              RAW_COLORS.violet[500]
             })`}
-            hoverBackground={`linear-gradient(0deg, ${COLORS.red[700]}, ${
-              COLORS.orange[500]
+            hoverBackground={`linear-gradient(0deg, ${RAW_COLORS.red[700]}, ${
+              RAW_COLORS.orange[500]
             })`}
-            textColor={COLORS.yellow[500]}
+            textColor={RAW_COLORS.yellow[500]}
             onClick={targetAction('button-clicked')}
           >
             Colourful!

--- a/src/components/Button/FillButton.js
+++ b/src/components/Button/FillButton.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 
-import { COLORS } from '../../constants';
+import { COLORS, GRADIENTS } from '../../constants';
 
 import ButtonBase from './ButtonBase';
 
@@ -30,8 +30,8 @@ export const wrapColorsInGradient = (colors?: Array<string> | string) => {
 
 class FillButton extends Component<Props> {
   static defaultProps = {
-    colors: [COLORS.purple[500], COLORS.violet[500]],
-    textColor: COLORS.white,
+    colors: GRADIENTS.primary,
+    textColor: COLORS.textOnBackground,
   };
 
   render() {

--- a/src/components/Button/StrokeButton.js
+++ b/src/components/Button/StrokeButton.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { COLORS, GRADIENTS } from '../../constants';
 
 import DetectActive from '../DetectActive';
 import ButtonBase from './ButtonBase';
@@ -16,8 +16,8 @@ export type Props = {
 
 class StrokeButton extends Component<Props> {
   static defaultProps = {
-    fillColor: COLORS.white,
-    strokeColors: [COLORS.purple[500], COLORS.violet[500]],
+    fillColor: COLORS.lightBackground,
+    strokeColors: GRADIENTS.primary,
     showStroke: true,
   };
 

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -5,7 +5,7 @@ import { COLORS } from '../../constants';
 
 export default styled.div`
   padding: 15px;
-  background: ${COLORS.white};
+  background: ${COLORS.lightBackground};
   border-radius: 8px;
   box-shadow: 0px 6px 60px rgba(0, 0, 0, 0.1), 0px 2px 8px rgba(0, 0, 0, 0.05);
 `;

--- a/src/components/CircularOutline/CircularOutline.js
+++ b/src/components/CircularOutline/CircularOutline.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 import { Spring, animated } from 'react-spring';
 
-import { COLORS } from '../../constants';
+import { GRADIENTS } from '../../constants';
 
 type Props = {
   size: number,
@@ -27,7 +27,7 @@ const springSettings = {
 
 class CircularOutline extends Component<Props> {
   static defaultProps = {
-    colors: [COLORS.purple[500], COLORS.violet[500]],
+    colors: GRADIENTS.primary,
     strokeWidth: 2,
   };
 

--- a/src/components/CreateNewProjectWizard/BuildPane.js
+++ b/src/components/CreateNewProjectWizard/BuildPane.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { check } from 'react-icons-kit/feather/check';
 
-import { COLORS } from '../../constants';
+import { COLORS, RAW_COLORS } from '../../constants';
 import createProject from '../../services/create-project.service';
 import { replaceProjectStarterStringWithUrl } from './helpers';
 
@@ -220,11 +220,11 @@ const Wrapper = styled.div`
   height: 100%;
   background-image: linear-gradient(
     45deg,
-    ${COLORS.blue[900]},
-    ${COLORS.blue[800]}
+    ${RAW_COLORS.blue[900]},
+    ${RAW_COLORS.blue[800]}
   );
-  border: 4px solid ${COLORS.white};
-  color: ${COLORS.white};
+  border: 4px solid ${COLORS.textOnBackground};
+  color: ${COLORS.textOnBackground};
   box-shadow: 0px 6px 60px rgba(0, 0, 0, 0.1), 0px 2px 8px rgba(0, 0, 0, 0.05);
   border-radius: 0;
   user-select: none;
@@ -260,11 +260,11 @@ const Finished = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  border: 4px solid ${COLORS.white};
+  border: 4px solid ${COLORS.textOnBackground};
   background-image: linear-gradient(
     45deg,
-    ${COLORS.teal[500]},
-    ${COLORS.lightGreen[700]}
+    ${RAW_COLORS.teal[500]},
+    ${RAW_COLORS.lightGreen[700]}
   );
   font-size: 32px;
   font-weight: 600;

--- a/src/components/CreateNewProjectWizard/BuildStepProgress.js
+++ b/src/components/CreateNewProjectWizard/BuildStepProgress.js
@@ -97,7 +97,7 @@ const ChildWrapper = styled.div`
 `;
 
 const Checkmark = styled(IconBase)`
-  color: ${COLORS.green[500]};
+  color: ${COLORS.lightSuccess};
 `;
 
 const MainCopy = styled.div`

--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
@@ -9,7 +9,7 @@ import ExternalLink from '../../ExternalLink';
 import CodesandboxLogo from '../../CodesandboxLogo';
 import StrokeButton from '../../Button/StrokeButton';
 
-import { COLORS } from '../../../constants';
+import { RAW_COLORS, COLORS } from '../../../constants';
 
 type Props = {
   updateStarter: (string, boolean) => void,
@@ -115,7 +115,7 @@ class SelectStarterList extends PureComponent<Props> {
               <ShowMoreWrapper>
                 <StrokeButton
                   size="small"
-                  strokeColors={[COLORS.gray[200], COLORS.gray[500]]}
+                  strokeColors={[RAW_COLORS.gray[200], RAW_COLORS.gray[500]]}
                   onClick={handleShowMore}
                 >
                   Show more...
@@ -137,7 +137,7 @@ const Description = styled.p`
 `;
 
 const SelectionInfo = styled.div`
-  background: ${COLORS.gray[200]};
+  background: ${RAW_COLORS.gray[200]};
   border-radius: 5px;
   padding: 5px;
   ${({ visible }) => !visible && 'display: none;'};
@@ -145,7 +145,7 @@ const SelectionInfo = styled.div`
 
 const ScrollContainer = styled(Scrollbars)`
   min-height: 120px;
-  border: 1px solid ${COLORS.gray[400]};
+  border: 1px solid ${RAW_COLORS.gray[400]};
   border-radius: 4px;
 `;
 
@@ -167,7 +167,8 @@ export const StarterItemHeading = styled.div`
   cursor: pointer;
   border-radius: 6px;
   border: 2px solid
-    ${props => (props.selected ? COLORS.purple[500] : COLORS.gray[200])};
+    ${props =>
+      props.selected ? RAW_COLORS.purple[500] : RAW_COLORS.gray[200]};
   padding: 2px 5px;
   font-size 15px;
   font-weight: bold;

--- a/src/components/CreateNewProjectWizard/ImportExisting.js
+++ b/src/components/CreateNewProjectWizard/ImportExisting.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { folderPlus } from 'react-icons-kit/feather/folderPlus';
 
-import { COLORS } from '../../constants';
+import { COLORS, RAW_COLORS } from '../../constants';
 
 import ImportProjectButton from '../ImportProjectButton';
 
@@ -29,7 +29,7 @@ export const ImportExisting = ({ isOnboarding }: Props) => {
       </ImportProjectButton>
       <MainText>
         Already have a project you'd like to manage with Guppy?{' '}
-        <ImportProjectButton color={COLORS.white}>
+        <ImportProjectButton color={COLORS.textOnBackground}>
           Import it instead
         </ImportProjectButton>.
       </MainText>
@@ -51,14 +51,14 @@ const IconWrapper = styled.div`
   align-items: center;
   border: 2px solid rgba(255, 255, 255, 0.75);
   border-radius: 50%;
-  color: ${COLORS.transparentWhite[300]};
+  color: ${RAW_COLORS.transparentWhite[300]};
 `;
 
 const MainText = styled.div`
   flex: 1;
   text-align: left;
   margin-left: 10px;
-  color: ${COLORS.transparentWhite[300]};
+  color: ${RAW_COLORS.transparentWhite[300]};
 `;
 
 const mapStateToProps = state => ({

--- a/src/components/CreateNewProjectWizard/ProjectName.js
+++ b/src/components/CreateNewProjectWizard/ProjectName.js
@@ -223,7 +223,7 @@ class ProjectName extends PureComponent<Props, State> {
 
 export const ErrorMessage = styled.div`
   margin-top: 6px;
-  color: ${COLORS.pink[700]};
+  color: ${COLORS.error};
 `;
 
 const ButtonPositionAdjuster = styled.div`

--- a/src/components/CreateNewProjectWizard/ProjectPath.js
+++ b/src/components/CreateNewProjectWizard/ProjectPath.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { changeDefaultProjectPath } from '../../actions';
 import { getDefaultProjectPath } from '../../reducers/app-settings.reducer';
 import { getProjectNameSlug } from '../../services/create-project.service';
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import TextButton from '../TextButton';
 
@@ -80,13 +80,13 @@ const MainText = styled.div`
   text-align: left;
   margin: -20px 0 30px 5px;
   font-size: 15px;
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
 `;
 
 export const DirectoryButton = styled(TextButton)`
   font-family: 'Fira Mono';
   font-size: 12px;
-  color: ${COLORS.gray[600]};
+  color: ${RAW_COLORS.gray[600]};
   text-decoration: none;
 `;
 

--- a/src/components/CreateNewProjectWizard/SubmitButton.js
+++ b/src/components/CreateNewProjectWizard/SubmitButton.js
@@ -5,7 +5,7 @@ import IconBase from 'react-icons-kit';
 import { check } from 'react-icons-kit/feather/check';
 import { chevronRight } from 'react-icons-kit/feather/chevronRight';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, GRADIENTS } from '../../constants';
 
 import { FillButton } from '../Button';
 import Spinner from '../Spinner';
@@ -39,10 +39,11 @@ const SubmitButton = ({
         (!isOnline && buttonText === "Let's do this")
       }
       size="large"
-      colors={[
-        readyToBeSubmitted ? COLORS.green[700] : COLORS.blue[700],
-        readyToBeSubmitted ? COLORS.lightGreen[500] : COLORS.blue[500],
-      ]}
+      colors={
+        readyToBeSubmitted
+          ? GRADIENTS.success
+          : [RAW_COLORS.blue[700], RAW_COLORS.blue[500]]
+      }
       style={{ width: 200 }}
       onClick={onSubmit}
     >

--- a/src/components/CreateNewProjectWizard/SummaryPane.js
+++ b/src/components/CreateNewProjectWizard/SummaryPane.js
@@ -2,7 +2,7 @@
 import React, { PureComponent, Fragment } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 import Paragraph from '../Paragraph';
 import FadeIn from '../FadeIn';
@@ -207,8 +207,8 @@ class SummaryPane extends PureComponent<Props> {
               <Paragraph>
                 For a better overview you can also have a look at the{' '}
                 <ExternalLink
-                  color={COLORS.white}
-                  hoverColor={COLORS.white}
+                  color={RAW_COLORS.white}
+                  hoverColor={RAW_COLORS.white}
                   href="https://www.gatsbyjs.org/starters/"
                 >
                   Gatsby starters library

--- a/src/components/CreateNewProjectWizard/SummaryPane.js
+++ b/src/components/CreateNewProjectWizard/SummaryPane.js
@@ -95,8 +95,8 @@ class SummaryPane extends PureComponent<Props> {
                 </Paragraph>
                 <Paragraph>
                   <ExternalLink
-                    color={COLORS.white}
-                    hoverColor={COLORS.white}
+                    color={COLORS.textOnBackground}
+                    hoverColor={COLORS.textOnBackground}
                     href="https://github.com/facebook/create-react-app"
                   >
                     <strong>Learn more about create-react-app.</strong>
@@ -122,8 +122,8 @@ class SummaryPane extends PureComponent<Props> {
                 </Paragraph>
                 <Paragraph>
                   <ExternalLink
-                    color={COLORS.white}
-                    hoverColor={COLORS.white}
+                    color={COLORS.textOnBackground}
+                    hoverColor={COLORS.textOnBackground}
                     href="https://www.gatsbyjs.org/"
                   >
                     <strong>Learn more about Gatsby.</strong>
@@ -150,8 +150,8 @@ class SummaryPane extends PureComponent<Props> {
                 </Paragraph>
                 <Paragraph>
                   <ExternalLink
-                    color={COLORS.white}
-                    hoverColor={COLORS.white}
+                    color={COLORS.textOnBackground}
+                    hoverColor={COLORS.textOnBackground}
                     href="https://nextjs.org/learn/"
                   >
                     <strong>Learn more about Next.js.</strong>

--- a/src/components/DependencyManagementPane/AddDependencyInitialScreen.js
+++ b/src/components/DependencyManagementPane/AddDependencyInitialScreen.js
@@ -35,7 +35,7 @@ class AddDependencyInitialScreen extends Component<Props> {
 
 export const InstructionsParagraph = Paragraph.extend`
   font-size: 1.4rem;
-  color: ${COLORS.gray[600]};
+  color: ${COLORS.lightText};
 `;
 
 const EmptyState = styled.div`
@@ -60,7 +60,7 @@ const LinkText = styled.div`
   justify-content: center;
   align-items: center;
   text-align: center;
-  color: ${COLORS.gray[600]};
+  color: ${COLORS.lightText};
 `;
 
 export default AddDependencyInitialScreen;

--- a/src/components/DependencyManagementPane/AddDependencySearchBox.js
+++ b/src/components/DependencyManagementPane/AddDependencySearchBox.js
@@ -46,7 +46,7 @@ injectGlobal`
     background: transparent;
     border: none;
     border-bottom: 2px solid rgba(255, 255, 255, 0.75);
-    color: ${COLORS.white};
+    color: ${COLORS.lightBackground};
     border-radius: 0px;
     outline: none;
     font-size: 21px;
@@ -56,7 +56,7 @@ injectGlobal`
     }
 
     &:focus {
-      border-bottom: 2px solid ${COLORS.white};
+      border-bottom: 2px solid ${COLORS.lightBackground};
 
     }
   }

--- a/src/components/DependencyManagementPane/AddDependencySearchResult.js
+++ b/src/components/DependencyManagementPane/AddDependencySearchResult.js
@@ -81,7 +81,7 @@ export const getColorForDownloadNumber = (num: number) => {
   if (num < 5000) {
     return COLORS.error;
   } else if (num < 50000) {
-    return COLORS.lightSuccess;
+    return COLORS.lightWarning;
   } else {
     return COLORS.success;
   }

--- a/src/components/DependencyManagementPane/AddDependencySearchResult.js
+++ b/src/components/DependencyManagementPane/AddDependencySearchResult.js
@@ -13,7 +13,7 @@ import {
   getSelectedProjectId,
   getDependencyMapForSelectedProject,
 } from '../../reducers/projects.reducer';
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS, GRADIENTS } from '../../constants';
 
 import Divider from '../Divider';
 import Spacer from '../Spacer';
@@ -79,11 +79,11 @@ export const StatsItem = ({
 
 export const getColorForDownloadNumber = (num: number) => {
   if (num < 5000) {
-    return COLORS.pink[700];
+    return COLORS.error;
   } else if (num < 50000) {
-    return COLORS.orange[500];
+    return COLORS.lightSuccess;
   } else {
-    return COLORS.green[700];
+    return COLORS.success;
   }
 };
 
@@ -98,7 +98,7 @@ export class AddDependencySearchResult extends PureComponent<Props> {
           <IconBase
             icon={check}
             size={24}
-            style={{ color: COLORS.green[500] }}
+            style={{ color: COLORS.lightSuccess }}
           />
           <Spacer size={6} />
           Installed
@@ -119,8 +119,8 @@ export class AddDependencySearchResult extends PureComponent<Props> {
     return (
       <StrokeButton
         size="small"
-        strokeColors={[COLORS.green[700], COLORS.lightGreen[500]]}
-        textColor={COLORS.green[700]}
+        strokeColors={GRADIENTS.success}
+        textColor={COLORS.success}
         onClick={() => addDependency(projectId, hit.name, hit.version)}
       >
         Add To Project
@@ -192,11 +192,11 @@ const Name = styled.span`
   font-weight: 600;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  color: ${COLORS.blue[700]};
+  color: ${COLORS.link};
 `;
 
 const Version = styled.span`
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
   font-weight: 400;
   font-size: 20px;
 `;
@@ -205,7 +205,7 @@ export const StatsRow = styled.div`
   display: flex;
   align-items: center;
   font-size: 14px;
-  color: ${COLORS.gray[500]};
+  color: ${RAW_COLORS.gray[500]};
 `;
 
 const StatsItemElem = styled.span`
@@ -230,7 +230,7 @@ const NoActionAvailable = styled.div`
   align-items: center;
   width: 135px;
   font-size: 15px;
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
 `;
 
 // TODO: I should be able to reuse the existing button component with
@@ -241,7 +241,7 @@ injectGlobal`
     margin-top: 45px;
     margin-left: 50%;
     background: transparent;
-    border: 2px solid ${COLORS.blue[700]};
+    border: 2px solid ${COLORS.link};
     border-radius: 60px;
     font-size: 18px;
     transform: translateX(-50%);

--- a/src/components/DependencyManagementPane/DeleteDependencyButton.js
+++ b/src/components/DependencyManagementPane/DeleteDependencyButton.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { remote } from 'electron';
 
 import * as actions from '../../actions';
-import { COLORS } from '../../constants';
+import { COLORS, GRADIENTS } from '../../constants';
 
 import { FillButton } from '../Button';
 import Spinner from '../Spinner';
@@ -70,7 +70,7 @@ class DeleteDependencyButton extends PureComponent<Props> {
     return (
       <FillButton
         size="small"
-        colors={[COLORS.pink[300], COLORS.red[500]]}
+        colors={GRADIENTS.error}
         onClick={this.handleClick}
       >
         {dependencyStatus === 'deleting' ? (
@@ -78,7 +78,7 @@ class DeleteDependencyButton extends PureComponent<Props> {
             y={2}
             reason="visually center the spinner within the button"
           >
-            <Spinner size={18} color={COLORS.white} />
+            <Spinner size={18} color={COLORS.textOnBackground} />
           </PixelShifter>
         ) : (
           DEPENDENCY_DELETE_COPY[dependencyStatus]

--- a/src/components/DependencyManagementPane/DependencyDetails.js
+++ b/src/components/DependencyManagementPane/DependencyDetails.js
@@ -2,7 +2,7 @@
 import React, { PureComponent, Fragment } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { COLORS, RAW_COLORS } from '../../constants';
 
 import Heading from '../Heading';
 import PixelShifter from '../PixelShifter';
@@ -65,11 +65,11 @@ const Header = styled.header`
   position: relative;
   background-image: linear-gradient(
     45deg,
-    ${COLORS.blue[700]},
-    ${COLORS.violet[700]}
+    ${RAW_COLORS.blue[700]},
+    ${RAW_COLORS.violet[700]}
   );
   border-radius: 8px 8px 0 0;
-  color: ${COLORS.white};
+  color: ${COLORS.textOnBackground};
 `;
 
 const HeaderText = styled.div`
@@ -77,20 +77,20 @@ const HeaderText = styled.div`
 `;
 
 const Name = styled(Heading)`
-  color: ${COLORS.white};
+  color: ${COLORS.textOnBackground};
 `;
 
 const Description = styled.div`
   font-size: 20px;
   font-weight: 400;
-  color: ${COLORS.transparentWhite[300]};
+  color: ${RAW_COLORS.transparentWhite[300]};
   -webkit-font-smoothing: antialiased;
 `;
 
 const VersionsWrapper = styled.div`
   padding: 15px;
   height: 72px;
-  background: ${COLORS.gray[100]};
+  background: ${RAW_COLORS.gray[100]};
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 `;
 

--- a/src/components/DependencyManagementPane/DependencyDetailsTable.js
+++ b/src/components/DependencyManagementPane/DependencyDetailsTable.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 import moment from 'moment';
 
-import { COLORS, GUPPY_REPO_URL } from '../../constants';
+import { RAW_COLORS, COLORS, GUPPY_REPO_URL } from '../../constants';
 
 import ExternalLink from '../ExternalLink';
 import Label from '../Label';
@@ -100,13 +100,7 @@ class DependencyDetailsTable extends Component<Props> {
           </tr>
           <tr>
             <LastCell>
-              <Label
-                style={{
-                  color: COLORS.pink[500],
-                }}
-              >
-                Danger Zone
-              </Label>
+              <Label style={{ color: COLORS.lightError }}>Danger Zone</Label>
             </LastCell>
             <LastCell>
               <DeleteDependencyButton
@@ -133,15 +127,15 @@ const Cell = styled.td`
 
   &:first-of-type {
     width: 150px;
-    color: ${COLORS.gray[600]};
+    color: ${RAW_COLORS.gray[600]};
   }
 `;
 
 const DependencyLocationLabel = styled.span`
   background-color: ${props =>
-    props.isDevDependency ? COLORS.orange[700] : COLORS.blue[700]};
+    props.isDevDependency ? COLORS.warning : RAW_COLORS.blue[700]};
   border-radius: 4px;
-  color: ${COLORS.white};
+  color: ${COLORS.textOnBackground};
   font-size: 14px;
   padding: 5px 10px;
 `;

--- a/src/components/DependencyManagementPane/DependencyInstalling.js
+++ b/src/components/DependencyManagementPane/DependencyInstalling.js
@@ -3,7 +3,7 @@ import React, { Component, Fragment } from 'react';
 import styled from 'styled-components';
 
 import guppyLoaderSrc from '../../assets/images/guppy-loader.gif';
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import Heading from '../Heading';
 import Spacer from '../Spacer';
@@ -17,7 +17,7 @@ class DependencyInstalling extends Component<Props> {
   render() {
     const { name, queued } = this.props;
     const stylizedName = (
-      <span style={{ color: COLORS.purple[500] }}>{name}</span>
+      <span style={{ color: RAW_COLORS.purple[500] }}>{name}</span>
     );
 
     return (

--- a/src/components/DependencyManagementPane/DependencyManagementPane.js
+++ b/src/components/DependencyManagementPane/DependencyManagementPane.js
@@ -7,7 +7,7 @@ import { plus } from 'react-icons-kit/feather/plus';
 
 import { getSelectedProject } from '../../reducers/projects.reducer';
 import { getOnlineState } from '../../reducers/app-status.reducer';
-import { COLORS, GUPPY_REPO_URL } from '../../constants';
+import { RAW_COLORS, COLORS, GUPPY_REPO_URL } from '../../constants';
 
 import Module from '../Module';
 import AddDependencyModal from './AddDependencyModal';
@@ -117,7 +117,10 @@ export class DependencyManagementPane extends PureComponent<Props, State> {
       dependency.status.match(/^queued-/)
     ) {
       return (
-        <Spinner size={20} color={isSelected ? COLORS.white : undefined} />
+        <Spinner
+          size={20}
+          color={isSelected ? COLORS.textOnBackground : undefined}
+        />
       );
     }
 
@@ -262,9 +265,11 @@ export const DependencyButton = styled.button`
   border: none;
   background: ${props =>
     props.isSelected
-      ? `linear-gradient(10deg, ${COLORS.blue[700]}, ${COLORS.blue[500]})`
-      : COLORS.gray[100]};
-  color: ${props => (props.isSelected ? COLORS.white : COLORS.gray[900])};
+      ? `linear-gradient(10deg, ${RAW_COLORS.blue[700]}, ${
+          RAW_COLORS.blue[500]
+        })`
+      : RAW_COLORS.gray[100]};
+  color: ${props => (props.isSelected ? COLORS.textOnBackground : COLORS.text)};
   border-radius: 4px;
   border-bottom: ${props =>
     props.isSelected
@@ -276,8 +281,10 @@ export const DependencyButton = styled.button`
     outline: none;
     background: ${props =>
       props.isSelected
-        ? `linear-gradient(10deg, ${COLORS.blue[700]}, ${COLORS.blue[500]})`
-        : COLORS.gray[200]};
+        ? `linear-gradient(10deg, ${RAW_COLORS.blue[700]}, ${
+            RAW_COLORS.blue[500]
+          })`
+        : RAW_COLORS.gray[200]};
   }
 
   &:active,
@@ -285,8 +292,10 @@ export const DependencyButton = styled.button`
     outline: none;
     background: ${props =>
       props.isSelected
-        ? `linear-gradient(10deg, ${COLORS.blue[700]}, ${COLORS.blue[500]})`
-        : COLORS.gray[300]};
+        ? `linear-gradient(10deg, ${RAW_COLORS.blue[700]}, ${
+            RAW_COLORS.blue[500]
+          })`
+        : RAW_COLORS.gray[300]};
   }
 
   &:first-of-type {
@@ -303,9 +312,9 @@ export const AddDependencyButton = styled.button`
   height: 42px;
   padding: 8px 10px;
   margin-top: 10px;
-  border: 2px dashed ${COLORS.gray[300]};
+  border: 2px dashed ${RAW_COLORS.gray[300]};
   border-radius: 6px;
-  color: ${COLORS.gray[500]};
+  color: ${RAW_COLORS.gray[500]};
   background: none;
   display: flex;
   justify-content: center;
@@ -317,8 +326,8 @@ export const AddDependencyButton = styled.button`
   opacity: ${props => (props.isOnline ? 1 : 0.5)};
   pointer-events: ${props => (props.isOnline ? 'auto' : 'none')};
   &:hover {
-    border: 2px dashed ${COLORS.gray[400]};
-    color: ${COLORS.gray[600]};
+    border: 2px dashed ${RAW_COLORS.gray[400]};
+    color: ${COLORS.text};
   }
 `;
 
@@ -336,8 +345,8 @@ const DependencyVersion = styled.span`
   font-size: 16px;
   color: ${props =>
     props.isSelected
-      ? COLORS.transparentWhite[400]
-      : COLORS.transparentBlack[400]}};
+      ? RAW_COLORS.transparentWhite[400]
+      : RAW_COLORS.transparentBlack[400]}};
 `;
 
 export const MainContent = Card.extend`

--- a/src/components/DependencyManagementPane/DependencyUpdateRow.js
+++ b/src/components/DependencyManagementPane/DependencyUpdateRow.js
@@ -6,7 +6,7 @@ import IconBase from 'react-icons-kit';
 import { check } from 'react-icons-kit/feather/check';
 
 import * as actions from '../../actions';
-import { COLORS } from '../../constants';
+import { COLORS, GRADIENTS } from '../../constants';
 
 import { getOnlineState } from '../../reducers/app-status.reducer';
 
@@ -58,9 +58,7 @@ class DependencyUpdateRow extends Component<Props> {
         <IconBase
           icon={check}
           size={24}
-          style={{
-            color: COLORS.green[500],
-          }}
+          style={{ color: COLORS.lightSuccess }}
         />
         <Spacer size={6} />
         Up-to-date
@@ -68,15 +66,17 @@ class DependencyUpdateRow extends Component<Props> {
     ) : (
       <FillButton
         size="small"
-        colors={[COLORS.green[700], COLORS.lightGreen[500]]}
-        style={{
-          width: 80,
-        }}
+        colors={GRADIENTS.success}
+        style={{ width: 80 }}
         onClick={() =>
           updateDependency(projectId, dependency.name, latestVersion)
         }
       >
-        {isUpdating ? <Spinner size={16} color={COLORS.white} /> : 'Update'}
+        {isUpdating ? (
+          <Spinner size={16} color={COLORS.textOnBackground} />
+        ) : (
+          'Update'
+        )}
       </FillButton>
     );
   }
@@ -120,7 +120,7 @@ const UpdateCol = styled.div`
 
 // eslint-disable-next-line no-unexpected-multiline
 const VersionLabel = styled(Label)`
-  color: ${COLORS.gray[600]};
+  color: ${COLORS.lightText};
 `;
 
 const VersionNum = styled.div`
@@ -136,7 +136,7 @@ const UpToDate = styled.div`
   justify-content: center;
   align-items: center;
   font-size: 15px;
-  color: ${COLORS.green[700]};
+  color: ${COLORS.success};
   font-weight: 500;
 `;
 

--- a/src/components/DevelopmentServerStatus/DevelopmentServerStatus.js
+++ b/src/components/DevelopmentServerStatus/DevelopmentServerStatus.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { externalLink } from 'react-icons-kit/feather/externalLink';
 
-import { COLORS, BREAKPOINTS } from '../../constants';
+import { RAW_COLORS, COLORS, BREAKPOINTS } from '../../constants';
 import { capitalize } from '../../utils';
 
 import ExternalLink from '../ExternalLink';
@@ -34,8 +34,8 @@ const DevelopmentServerStatus = ({ status, port }: Props) => {
         <StatusCaption>
           {isRunning && (
             <ExternalLink
-              color={COLORS.gray[700]}
-              hoverColor={COLORS.gray[900]}
+              color={RAW_COLORS.gray[700]}
+              hoverColor={COLORS.text}
               href={serverUrl}
             >
               <IconLinkContents>
@@ -63,7 +63,7 @@ const getLabel = (status: TaskStatus) => {
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
-  border: 2px solid ${COLORS.gray[200]};
+  border: 2px solid ${RAW_COLORS.gray[200]};
   padding: 10px;
   margin-bottom: 20px;
   border-radius: 24px;
@@ -107,7 +107,7 @@ const Status = styled.div`
   font-weight: 600;
   letter-spacing: -1px;
   -webkit-font-smoothing: antialiased;
-  color: ${COLORS.gray[900]};
+  color: ${COLORS.text};
   line-height: 28px;
 `;
 

--- a/src/components/DirectoryPicker/DirectoryPicker.js
+++ b/src/components/DirectoryPicker/DirectoryPicker.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { folderPlus } from 'react-icons-kit/feather/folderPlus';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 import TextButton from '../TextButton';
 import TextInput from '../TextInput';
@@ -74,7 +74,7 @@ class DirectoryPicker extends PureComponent<Props> {
 }
 
 const Wrapper = styled.div`
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
 `;
 
 const ButtonPositionAdjuster = styled.div`
@@ -82,20 +82,20 @@ const ButtonPositionAdjuster = styled.div`
 `;
 
 const DirectoryButton = styled(TextButton)`
-  color: ${COLORS.gray[600]};
+  color: ${COLORS.lightText};
   text-decoration: none;
 
   &:after {
     content: '';
     display: block;
     padding-top: 6px;
-    border-bottom: 2px solid ${COLORS.gray[600]};
+    border-bottom: 2px solid ${COLORS.lightText};
   }
 
   &:hover:after {
     content: '';
     display: block;
-    border-bottom: 2px solid ${COLORS.purple[700]};
+    border-bottom: 2px solid ${RAW_COLORS.purple[700]};
   }
 `;
 
@@ -105,14 +105,14 @@ const IconWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 2px solid ${COLORS.gray[400]};
+  border: 2px solid ${RAW_COLORS.gray[400]};
   border-radius: 50%;
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
   cursor: pointer;
 
   &:hover {
-    color: ${COLORS.purple[500]};
-    border-color: ${COLORS.purple[500]};
+    color: ${RAW_COLORS.purple[500]};
+    border-color: ${RAW_COLORS.purple[500]};
   }
 `;
 

--- a/src/components/Divider/Divider.js
+++ b/src/components/Divider/Divider.js
@@ -2,12 +2,12 @@
 // Used in AddDependencySearchResult & StarterSelection
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 const Divider = styled.div`
   width: 100%;
   height: 1px;
-  background: ${COLORS.gray[100]};
+  background: ${RAW_COLORS.gray[100]};
 `;
 
 export default Divider;

--- a/src/components/EjectButton/EjectButton.js
+++ b/src/components/EjectButton/EjectButton.js
@@ -4,8 +4,6 @@ import IconBase from 'react-icons-kit';
 import { ic_eject as ejectIcon } from 'react-icons-kit/md/ic_eject';
 import { remote } from 'electron';
 
-import { COLORS } from '../../constants';
-
 import BigClickableButton from '../BigClickableButton';
 
 const { dialog } = remote;
@@ -47,7 +45,6 @@ class EjectButton extends PureComponent<Props> {
       <BigClickableButton
         width={40}
         height={34}
-        colors={[COLORS.purple[500], COLORS.blue[700]]}
         isOn={isRunning}
         onClick={() =>
           dialog.showMessageBox(dialogOptions, dialogCallback.bind(this))

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -16,8 +16,8 @@ type Props = {
 
 class ExternalLink extends Component<Props> {
   static defaultProps = {
-    color: COLORS.blue[700],
-    hoverColor: COLORS.blue[500],
+    color: COLORS.link,
+    hoverColor: COLORS.lightLink,
     display: 'inline-block',
   };
 

--- a/src/components/FeedbackButton/FeedbackButton.js
+++ b/src/components/FeedbackButton/FeedbackButton.js
@@ -7,7 +7,7 @@ import { Spring, animated, interpolate } from 'react-spring';
 import { shell } from 'electron';
 
 import { IN_APP_FEEDBACK_URL } from '../../config/app';
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 type Props = {
   size: number,
@@ -22,8 +22,8 @@ type State = {
 class FeedbackButton extends PureComponent<Props, State> {
   static defaultProps = {
     size: 28,
-    color: COLORS.gray[600],
-    hoverColor: COLORS.purple[500],
+    color: COLORS.lightText,
+    hoverColor: RAW_COLORS.purple[500],
   };
 
   state = {
@@ -128,7 +128,7 @@ const SliderBox = animated(styled.div`
   right: -25px;
   width: 1px; /* small width so it hides behind wrapper - not 0 because we need something to scale*/
   height: 50px;
-  background: ${COLORS.gray[200]};
+  background: ${RAW_COLORS.gray[200]};
   z-index: -1;
   transform-origin: center right;
 `);
@@ -154,10 +154,10 @@ const Text = animated(styled.div`
 const Icon = animated(styled(IconBase)`
   width: 50px;
   height: 50px;
-  background: ${COLORS.white};
+  background: ${RAW_COLORS.white};
   color: ${props => props.color};
   border-radius: 50% 50%;
-  border: 2px solid ${COLORS.gray[200]};
+  border: 2px solid ${RAW_COLORS.gray[200]};
   cursor: pointer;
 `);
 

--- a/src/components/FormField/FormField.js
+++ b/src/components/FormField/FormField.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 import Label from '../Label';
 
@@ -45,11 +45,11 @@ class FormField extends PureComponent<Props> {
 
 const getTextColor = (props: Props) => {
   if (props.hasError) {
-    return COLORS.pink[500];
+    return COLORS.lightError;
   } else if (props.isFocused) {
-    return COLORS.purple[700];
+    return RAW_COLORS.purple[700];
   } else {
-    return COLORS.gray[500];
+    return RAW_COLORS.gray[500];
   }
 };
 

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 type Props = {
   size: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge',
@@ -37,7 +37,7 @@ const HeadingXSmall = styled.h6`
   font-weight: 600;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  color: ${COLORS.gray[800]};
+  color: ${RAW_COLORS.gray[800]};
 `;
 
 const HeadingSmall = HeadingXSmall.withComponent('h3').extend`

--- a/src/components/HelpButton/HelpButton.js
+++ b/src/components/HelpButton/HelpButton.js
@@ -5,7 +5,7 @@ import IconBase from 'react-icons-kit';
 import { u2753 as questionMarkIcon } from 'react-icons-kit/noto_emoji_regular/u2753';
 import { shell } from 'electron';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 type Props = {
   size?: number,
@@ -32,13 +32,13 @@ const Help = styled.button`
   align-items: center;
   border: none;
   border-radius: 50%;
-  color: ${COLORS.white};
-  background: ${COLORS.gray[500]};
+  color: ${COLORS.textOnBackground};
+  background: ${RAW_COLORS.gray[500]};
   padding: 0;
   cursor: pointer;
 
   &:hover {
-    background: ${COLORS.blue[700]};
+    background: ${COLORS.link};
   }
 `;
 

--- a/src/components/IntroScreen/IntroScreen.js
+++ b/src/components/IntroScreen/IntroScreen.js
@@ -39,7 +39,7 @@ class IntroScreen extends Component<Props> {
             <Spacer size={40} />
             <div>
               Or,{' '}
-              <ImportProjectButton color={COLORS.blue[700]}>
+              <ImportProjectButton color={COLORS.link}>
                 import an existing project
               </ImportProjectButton>
             </div>

--- a/src/components/LargeLED/LargeLED.helpers.js
+++ b/src/components/LargeLED/LargeLED.helpers.js
@@ -1,7 +1,7 @@
 // @flow
 import Color from 'color';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 import type { TaskStatus } from '../../types';
 
@@ -18,15 +18,15 @@ export const getColorsForStatus = (status: TaskStatus): ColorData => {
   switch (status) {
     case 'success': {
       return {
-        base: COLORS.green[500],
-        highlight: COLORS.lime[500],
-        pulseBase: COLORS.green[700],
-        pulseHighlight: COLORS.lime[500],
-        shadowLight: Color(COLORS.green[900])
+        base: COLORS.lightSuccess,
+        highlight: RAW_COLORS.lime[500],
+        pulseBase: COLORS.success,
+        pulseHighlight: RAW_COLORS.lime[500],
+        shadowLight: Color(RAW_COLORS.green[900])
           .alpha(0.25)
           .rgb()
           .string(),
-        shadowDark: Color(COLORS.green[900])
+        shadowDark: Color(RAW_COLORS.green[900])
           .alpha(0.5)
           .rgb()
           .string(),
@@ -35,15 +35,15 @@ export const getColorsForStatus = (status: TaskStatus): ColorData => {
 
     case 'failed': {
       return {
-        base: COLORS.red[500],
-        highlight: COLORS.pink[300],
-        pulseBase: COLORS.red[700],
-        pulseHighlight: COLORS.pink[500],
-        shadowLight: Color(COLORS.red[900])
+        base: RAW_COLORS.red[500],
+        highlight: RAW_COLORS.pink[300],
+        pulseBase: RAW_COLORS.red[700],
+        pulseHighlight: COLORS.lightError,
+        shadowLight: Color(RAW_COLORS.red[900])
           .alpha(0.25)
           .rgb()
           .string(),
-        shadowDark: Color(COLORS.red[900])
+        shadowDark: Color(RAW_COLORS.red[900])
           .alpha(0.5)
           .rgb()
           .string(),
@@ -53,15 +53,15 @@ export const getColorsForStatus = (status: TaskStatus): ColorData => {
     default:
     case 'idle': {
       return {
-        base: COLORS.gray[700],
-        highlight: COLORS.gray[500],
-        pulseBase: COLORS.gray[700],
-        pulseHighlight: COLORS.gray[500],
-        shadowLight: Color(COLORS.gray[900])
+        base: RAW_COLORS.gray[700],
+        highlight: RAW_COLORS.gray[500],
+        pulseBase: RAW_COLORS.gray[700],
+        pulseHighlight: RAW_COLORS.gray[500],
+        shadowLight: Color(RAW_COLORS.gray[900])
           .alpha(0.25)
           .rgb()
           .string(),
-        shadowDark: Color(COLORS.gray[900])
+        shadowDark: Color(RAW_COLORS.gray[900])
           .alpha(0.5)
           .rgb()
           .string(),

--- a/src/components/License/License.js
+++ b/src/components/License/License.js
@@ -5,7 +5,7 @@ import IconBase from 'react-icons-kit';
 import { u1F4C3 as billIcon } from 'react-icons-kit/noto_emoji_regular/u1F4C3';
 import { x as xIcon } from 'react-icons-kit/feather/x';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import ExternalLink from '../ExternalLink';
 import Spacer from '../Spacer';
@@ -23,7 +23,7 @@ class License extends Component<Props> {
       <Wrapper>
         {withIcon && (
           <Fragment>
-            <IconWrapper color={license ? 'inherit' : COLORS.red[500]}>
+            <IconWrapper color={license ? 'inherit' : RAW_COLORS.red[500]}>
               <IconBase icon={license ? billIcon : xIcon} size={24} />
             </IconWrapper>
             <Spacer size={6} />

--- a/src/components/LoadingScreen/LoadingScreen.js
+++ b/src/components/LoadingScreen/LoadingScreen.js
@@ -11,7 +11,7 @@ import {
 } from '../../reducers/app-status.reducer';
 
 import guppyLoaderSrc from '../../assets/images/guppy-loader.gif';
-import { COLORS, Z_INDICES } from '../../constants';
+import { RAW_COLORS, COLORS, Z_INDICES } from '../../constants';
 import { ellipsify } from '../../utils';
 
 type Props = {
@@ -89,7 +89,7 @@ class LoadingScreen extends PureComponent<Props, State> {
 
 const Backdrop = styled.div`
   align-items: center;
-  background: ${COLORS.transparentWhite[300]};
+  background: ${RAW_COLORS.transparentWhite[300]};
   display: ${props => (props.isVisible ? 'flex' : 'none')};
   height: 100vh;
   justify-content: center;

--- a/src/components/LoadingScreen/LoadingScreen.js
+++ b/src/components/LoadingScreen/LoadingScreen.js
@@ -115,7 +115,7 @@ const InfoWrapper = styled.div`
 `;
 
 const InfoText = styled.div`
-  color: ${COLORS.black};
+  color: ${RAW_COLORS.black};
   padding: 0;
 `;
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -175,7 +175,7 @@ const PaneWrapper = animated(styled.div.attrs({
   max-height: 95%;
   box-shadow: 0px 6px 60px rgba(0, 0, 0, 0.2), 0px 2px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  background: ${COLORS.white};
+  background: ${COLORS.lightBackground};
   will-change: transform;
 `);
 

--- a/src/components/ModalHeader/ModalHeader.js
+++ b/src/components/ModalHeader/ModalHeader.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 import PixelShifter from '../PixelShifter';
 import Heading from '../Heading';
@@ -24,8 +24,8 @@ class ModalHeader extends Component<Props> {
 
     const colors =
       theme === 'standard'
-        ? [COLORS.gray[100], COLORS.gray[100]]
-        : [COLORS.blue[700], COLORS.teal[500]];
+        ? [RAW_COLORS.gray[100], RAW_COLORS.gray[100]]
+        : [RAW_COLORS.blue[700], RAW_COLORS.teal[500]];
 
     return (
       <Wrapper colors={colors}>
@@ -37,7 +37,10 @@ class ModalHeader extends Component<Props> {
             >
               <Heading
                 style={{
-                  color: theme === 'standard' ? COLORS.gray[900] : COLORS.white,
+                  color:
+                    theme === 'standard'
+                      ? COLORS.text
+                      : COLORS.textOnBackground,
                 }}
               >
                 {title}

--- a/src/components/OnlineChecker/OnlineChecker.js
+++ b/src/components/OnlineChecker/OnlineChecker.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
-import { Z_INDICES, COLORS } from '../../constants';
+import { RAW_COLORS, Z_INDICES, COLORS } from '../../constants';
 
 import * as actions from '../../actions';
 import { getOnlineState } from '../../reducers/app-status.reducer';
@@ -61,16 +61,16 @@ const InfoBar = styled.div`
   left: 0;
   top: 0;
   z-index: ${Z_INDICES.infoBanner};
-  background-color: ${COLORS.transparentWhite[100]};
+  background-color: ${RAW_COLORS.transparentWhite[100]};
   padding: 16px;
   align-content: center;
-  box-shadow: 0px 2px 2px 0px ${COLORS.transparentBlack[900]};
+  box-shadow: 0px 2px 2px 0px ${RAW_COLORS.transparentBlack[900]};
 `;
 
 const SVG = styled.svg`
   width: 16px;
   height: 16px;
-  fill: ${COLORS.red[500]};
+  fill: ${RAW_COLORS.red[500]};
   margin: 2px 8px;
 `;
 

--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 import { Spring, animated } from 'react-spring';
 
-import { COLORS } from '../../constants';
+import { GRADIENTS } from '../../constants';
 
 // TODO: consider renaming stiffness and damping to tension and friction
 type Props = {
@@ -20,7 +20,7 @@ class ProgressBar extends Component<Props> {
     height: 8,
     stiffness: 32,
     damping: 32,
-    colors: [COLORS.blue[700], COLORS.teal[500], COLORS.lightGreen[500]],
+    colors: GRADIENTS.progress,
     reset: false,
   };
 

--- a/src/components/ProgressBar/ProgressBar.stories.js
+++ b/src/components/ProgressBar/ProgressBar.stories.js
@@ -3,7 +3,7 @@ import React, { Fragment, Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import Showcase from '../../../.storybook/components/Showcase';
 import { StrokeButton } from '../Button';
@@ -81,12 +81,12 @@ storiesOf('ProgressBar', module).add(
               height={16}
               progress={progress}
               colors={[
-                COLORS.red[500],
-                COLORS.orange[500],
-                COLORS.lime[500],
-                COLORS.teal[500],
-                COLORS.blue[700],
-                COLORS.purple[500],
+                RAW_COLORS.red[500],
+                RAW_COLORS.orange[500],
+                RAW_COLORS.lime[500],
+                RAW_COLORS.teal[500],
+                RAW_COLORS.blue[700],
+                RAW_COLORS.purple[500],
               ]}
             />
           )}

--- a/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
+++ b/src/components/ProjectConfigurationModal/ProjectConfigurationModal.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import * as actions from '../../actions';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, GRADIENTS } from '../../constants';
 import { getSelectedProject } from '../../reducers/projects.reducer';
 import { getIsQueueEmpty } from '../../reducers/queue.reducer';
 
@@ -134,7 +134,7 @@ export class ProjectConfigurationModal extends PureComponent<Props, State> {
             <Actions>
               <FillButton
                 size="large"
-                colors={[COLORS.green[700], COLORS.lightGreen[500]]}
+                colors={GRADIENTS.success}
                 disabled={dependenciesChangingForProject}
               >
                 Save Project
@@ -164,7 +164,7 @@ const Actions = styled.div`
 
 const DisabledText = styled.div`
   padding-top: 16px;
-  color: ${COLORS.gray[500]};
+  color: ${RAW_COLORS.gray[500]};
 `;
 
 const mapStateToProps = state => {

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -8,7 +8,7 @@ import { packageIcon } from 'react-icons-kit/feather/packageIcon';
 
 import { getSelectedProject } from '../../reducers/projects.reducer';
 import { getDependenciesLoadingStatus } from '../../reducers/dependencies.reducer';
-import { RAW_COLORS, COLORS } from '../../constants';
+import { RAW_COLORS, COLORS, GRADIENTS } from '../../constants';
 import * as actions from '../../actions';
 
 import MainContentWrapper from '../MainContentWrapper';
@@ -123,7 +123,7 @@ export class ProjectPage extends PureComponent<Props> {
           <InstallWrapper>
             <FillButton
               size="large"
-              colors={[COLORS.green[700], COLORS.lightGreen[500]]}
+              colors={GRADIENTS.success}
               onClick={() => reinstallDependencies(project.id)}
             >
               Install Dependencies
@@ -211,7 +211,7 @@ const DependencyMissingIcon = styled(IconBase).attrs({
   icon: packageIcon,
   size: 100,
 })`
-  color: ${COLORS.gray[300]};
+  color: ${RAW_COLORS.gray[300]};
   padding: 30px;
 `;
 

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -8,7 +8,7 @@ import { packageIcon } from 'react-icons-kit/feather/packageIcon';
 
 import { getSelectedProject } from '../../reducers/projects.reducer';
 import { getDependenciesLoadingStatus } from '../../reducers/dependencies.reducer';
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 import * as actions from '../../actions';
 
 import MainContentWrapper from '../MainContentWrapper';
@@ -147,7 +147,10 @@ export class ProjectPage extends PureComponent<Props> {
               reason="Align left edge of title with the modules on page"
             >
               <Tooltip title={path} position="bottom">
-                <Heading size="xlarge" style={{ color: COLORS.purple[500] }}>
+                <Heading
+                  size="xlarge"
+                  style={{ color: RAW_COLORS.purple[500] }}
+                >
                   {project.name}
                 </Heading>
               </Tooltip>
@@ -157,9 +160,9 @@ export class ProjectPage extends PureComponent<Props> {
 
           <ProjectActionBar>
             <FillButton
-              colors={COLORS.gray[200]}
-              hoverColors={COLORS.gray[300]}
-              textColor={COLORS.gray[900]}
+              colors={RAW_COLORS.gray[200]}
+              hoverColors={RAW_COLORS.gray[300]}
+              textColor={COLORS.text}
               size="small"
               onClick={this.openFolder}
             >
@@ -167,9 +170,9 @@ export class ProjectPage extends PureComponent<Props> {
             </FillButton>
             <Spacer size={15} />
             <FillButton
-              colors={COLORS.gray[200]}
-              hoverColors={COLORS.gray[300]}
-              textColor={COLORS.gray[900]}
+              colors={RAW_COLORS.gray[200]}
+              hoverColors={RAW_COLORS.gray[300]}
+              textColor={COLORS.text}
               size="small"
               onClick={this.openIDE}
             >

--- a/src/components/SettingsButton/SettingsButton.js
+++ b/src/components/SettingsButton/SettingsButton.js
@@ -5,7 +5,7 @@ import { Spring, animated, interpolate } from 'react-spring';
 import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { settings } from 'react-icons-kit/feather/settings';
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import * as actions from '../../actions';
 
@@ -29,8 +29,8 @@ type State = {
 class SettingsButton extends Component<Props, State> {
   static defaultProps = {
     size: 36,
-    color: COLORS.gray[400],
-    hoverColor: COLORS.purple[500],
+    color: RAW_COLORS.gray[400],
+    hoverColor: RAW_COLORS.purple[500],
     settingsFor: 'project',
   };
 

--- a/src/components/Sidebar/AddProjectButton.js
+++ b/src/components/Sidebar/AddProjectButton.js
@@ -21,7 +21,11 @@ const AddProjectButton = ({ size, isVisible, onClick, isOnline }: Props) => (
     onClick={onClick}
   >
     <IconWrapper>
-      <IconBase size={30} icon={plus} style={{ color: COLORS.white }} />
+      <IconBase
+        size={30}
+        icon={plus}
+        style={{ color: COLORS.textOnBackground }}
+      />
     </IconWrapper>
     <Background />
   </Button>
@@ -46,7 +50,7 @@ const Background = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: ${COLORS.white};
+  background: ${COLORS.lightBackground};
   opacity: 0.1;
   transition: opacity 300ms;
   border-radius: 100%;

--- a/src/components/Sidebar/IntroductionBlurb.js
+++ b/src/components/Sidebar/IntroductionBlurb.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { cornerUpLeft } from 'react-icons-kit/feather/cornerUpLeft';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import Paragraph from '../Paragraph';
 import Spacer from '../Spacer';
@@ -54,7 +54,7 @@ const Wrapper = styled.div.attrs({
   right: 0;
   width: 450px;
   padding-left: 56px;
-  color: ${COLORS.gray[800]};
+  color: ${RAW_COLORS.gray[800]};
   will-change: transform;
 `;
 
@@ -69,7 +69,7 @@ const Heading = styled.h2`
 
 const Em = styled.em`
   font-style: italic;
-  color: ${COLORS.purple[500]};
+  color: ${RAW_COLORS.purple[500]};
 `;
 
 export default IntroductionBlurb;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import { Tooltip } from 'react-tippy';
 import { Scrollbars } from 'react-custom-scrollbars';
 
-import { COLORS, Z_INDICES } from '../../constants';
+import { RAW_COLORS, Z_INDICES } from '../../constants';
 import * as actions from '../../actions';
 import {
   getProjectsArray,
@@ -150,7 +150,7 @@ export class Sidebar extends PureComponent<Props, State> {
                     {...props}
                     style={{
                       ...style,
-                      background: COLORS.transparentWhite[700],
+                      background: RAW_COLORS.transparentWhite[700],
                       borderRadius: '6px',
                     }}
                     className="thumb-vertical"
@@ -225,8 +225,8 @@ const Wrapper = animated(styled.nav.attrs({
   padding-left: ${SIDEBAR_OVERFLOW}px;
   background-image: linear-gradient(
     85deg,
-    ${COLORS.blue[900]},
-    ${COLORS.blue[700]}
+    ${RAW_COLORS.blue[900]},
+    ${RAW_COLORS.blue[700]}
   );
   will-change: transform;
   height: 100vh;

--- a/src/components/Sidebar/Sidebar.test.js
+++ b/src/components/Sidebar/Sidebar.test.js
@@ -7,7 +7,7 @@ import AddProjectButton from './AddProjectButton';
 import SidebarProjectIcon from './SidebarProjectIcon';
 import IntroductionBlurb from './IntroductionBlurb';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 const createProps = props => ({
   selectedProjectId: null,
@@ -25,7 +25,7 @@ const testProject = {
   name: 'Test Project',
   type: 'nextjs',
   icon: 'nextjs-project-icon',
-  color: COLORS.red['500'],
+  color: RAW_COLORS.red[500],
   createdAt: 0,
   dependencies: [],
   tasks: [],

--- a/src/components/Sidebar/SidebarProjectIcon.js
+++ b/src/components/Sidebar/SidebarProjectIcon.js
@@ -28,7 +28,7 @@ const SidebarProjectIcon = ({
 }: Props) => {
   const sharedProps = {
     size,
-    colors: [COLORS.white],
+    colors: [COLORS.lightBackground],
     status: isSelected ? 'highlighted' : 'faded',
     onClick: handleSelect,
   };
@@ -57,7 +57,7 @@ const ProjectNameIcon = styled.div`
   justify-content: center;
   align-items: center;
   font-size: 24px;
-  color: ${COLORS.white};
+  color: ${COLORS.textOnBackground};
   border-radius: 50%;
 `;
 

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -4,14 +4,14 @@ import styled, { keyframes } from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { loader } from 'react-icons-kit/feather/loader';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 type Props = {
   size: number,
   color?: string,
 };
 
-const Spinner = ({ size, color = COLORS.gray[500] }: Props) => (
+const Spinner = ({ size, color = RAW_COLORS.gray[500] }: Props) => (
   <Icon size={size} color={color} icon={loader} />
 );
 

--- a/src/components/TaskDetailsModal/TaskDetailsModal.js
+++ b/src/components/TaskDetailsModal/TaskDetailsModal.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import moment from 'moment';
 
 import * as actions from '../../actions';
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 import { capitalize } from '../../utils';
 import {
   getTaskByProjectIdAndTaskName,
@@ -66,7 +66,7 @@ class TaskDetailsModal extends PureComponent<Props> {
         return (
           <PrimaryStatusText>
             Task is{' '}
-            <strong style={{ color: COLORS.orange[500] }}>running</strong>...
+            <strong style={{ color: COLORS.lightWarning }}>running</strong>...
           </PrimaryStatusText>
         );
 
@@ -74,7 +74,7 @@ class TaskDetailsModal extends PureComponent<Props> {
         return (
           <PrimaryStatusText>
             Task{' '}
-            <strong style={{ color: COLORS.green[700] }}>
+            <strong style={{ color: COLORS.success }}>
               completed successfully
             </strong>.
           </PrimaryStatusText>
@@ -210,7 +210,7 @@ const MainContent = styled.section`
 
 const Description = styled.div`
   font-size: 21px;
-  color: ${COLORS.gray[500]};
+  color: ${RAW_COLORS.gray[500]};
 `;
 
 const Status = styled.div`
@@ -227,14 +227,14 @@ const PrimaryStatusText = styled.div`
 `;
 
 const LastRunText = styled.div`
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
   font-size: 16px;
 `;
 
 const HorizontalRule = styled.div`
   height: 0px;
   margin-top: 25px;
-  border-bottom: 1px solid ${COLORS.gray[200]};
+  border-bottom: 1px solid ${RAW_COLORS.gray[200]};
 `;
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
+++ b/src/components/TaskRunnerPaneRow/TaskRunnerPaneRow.js
@@ -6,7 +6,7 @@ import { u1F44C as successIcon } from 'react-icons-kit/noto_emoji_regular/u1F44C
 import { u1F31B as idleIcon } from 'react-icons-kit/noto_emoji_regular/u1F31B';
 import { u274C as failIcon } from 'react-icons-kit/noto_emoji_regular/u274C';
 
-import { COLORS, BREAKPOINTS } from '../../constants';
+import { RAW_COLORS, COLORS, BREAKPOINTS } from '../../constants';
 import { capitalize } from '../../utils';
 
 import Card from '../Card';
@@ -91,7 +91,7 @@ const getIconForStatus = (status: TaskStatus) => {
         <IconBase
           size={21}
           icon={successIcon}
-          style={{ color: COLORS.green[700] }}
+          style={{ color: COLORS.success }}
         />
       );
     case 'failed':
@@ -99,7 +99,7 @@ const getIconForStatus = (status: TaskStatus) => {
         <IconBase
           size={18}
           icon={failIcon}
-          style={{ color: COLORS.red[500] }}
+          style={{ color: RAW_COLORS.red[500] }}
         />
       );
     default:
@@ -107,7 +107,7 @@ const getIconForStatus = (status: TaskStatus) => {
         <IconBase
           size={21}
           icon={idleIcon}
-          style={{ color: COLORS.gray[400], transform: 'translateY(-2px)' }}
+          style={{ color: RAW_COLORS.gray[400], transform: 'translateY(-2px)' }}
         />
       );
   }
@@ -139,13 +139,13 @@ const NameColumn = Column.extend`
 
 const TaskName = styled.span`
   font-weight: 500;
-  color: ${COLORS.gray[900]};
+  color: ${COLORS.text};
 `;
 
 const TaskDescription = styled.span`
   font-weight: 400;
   margin-left: 15px;
-  color: ${COLORS.gray[500]};
+  color: ${RAW_COLORS.gray[500]};
 
   @media ${BREAKPOINTS.sm} {
     display: none;

--- a/src/components/TerminalOutput/TerminalOutput.js
+++ b/src/components/TerminalOutput/TerminalOutput.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import styled from 'styled-components';
 
 import * as actions from '../../actions';
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 import { FillButton } from '../Button';
 import Heading from '../Heading';
@@ -80,7 +80,7 @@ class TerminalOutput extends PureComponent<Props> {
           >
             <FillButton
               size="xsmall"
-              colors={[COLORS.pink[300], COLORS.red[500]]}
+              colors={[RAW_COLORS.pink[300], RAW_COLORS.red[500]]}
               onClick={this.handleClear}
             >
               Clear
@@ -123,8 +123,8 @@ const Wrapper = styled.div`
   height: ${props => props.height}px;
   overflow: auto;
   padding: 15px;
-  color: ${COLORS.white};
-  background-color: ${COLORS.blue[900]};
+  color: ${COLORS.textOnBackground};
+  background-color: ${RAW_COLORS.blue[900]};
   border-radius: 4px;
   font-family: 'Fira Mono', monospace;
   font-size: 13px;

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 type Props = {
   isFocused?: boolean,
@@ -19,11 +19,11 @@ const TextInput = ({ isFocused, hasError, children, ...delegated }: Props) => (
 
 const getBorderColor = (props: Props) => {
   if (props.hasError) {
-    return COLORS.pink[500];
+    return COLORS.error;
   } else if (props.isFocused) {
-    return COLORS.purple[700];
+    return RAW_COLORS.purple[700];
   } else {
-    return COLORS.gray[700];
+    return RAW_COLORS.gray[700];
   }
 };
 
@@ -43,7 +43,7 @@ const InputElem = styled.input`
   font-size: 21px;
 
   &::placeholder {
-    color: ${COLORS.gray[300]};
+    color: ${RAW_COLORS.gray[300]};
   }
 `;
 

--- a/src/components/TextInputWithButton/TextInputWithButton.js
+++ b/src/components/TextInputWithButton/TextInputWithButton.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import IconBase from 'react-icons-kit';
 import { moreHorizontal } from 'react-icons-kit/feather/moreHorizontal';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import TextInput from '../TextInput';
 import HoverableOutlineButton from '../HoverableOutlineButton';
@@ -51,7 +51,7 @@ class TextInputWithButton extends PureComponent<Props> {
 }
 
 const Wrapper = styled.div`
-  color: ${COLORS.gray[400]};
+  color: ${RAW_COLORS.gray[400]};
 `;
 
 const ButtonPositionAdjuster = styled.div`

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { Spring, animated, interpolate } from 'react-spring';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS, COLORS } from '../../constants';
 
 type Props = {
   isToggled: boolean,
@@ -75,8 +75,8 @@ const Wrapper = styled.button`
   border-radius: ${props => props.height / 2}px;
   background-image: linear-gradient(
     45deg,
-    ${COLORS.gray[400]},
-    ${COLORS.gray[200]}
+    ${RAW_COLORS.gray[400]},
+    ${RAW_COLORS.gray[200]}
   );
   overflow: hidden; /* Hide 'OnBackground' corners */
   outline: none; /* TODO: better a11y story */
@@ -94,8 +94,8 @@ const OnBackground = styled.div`
   bottom: 0;
   background-image: linear-gradient(
     15deg,
-    ${COLORS.blue[700]},
-    ${COLORS.teal[500]}
+    ${RAW_COLORS.blue[700]},
+    ${RAW_COLORS.teal[500]}
   );
   opacity: ${props => (props.isVisible ? 1 : 0)};
   transition: opacity 300ms;
@@ -109,7 +109,7 @@ const Pulsing = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: ${COLORS.blue[800]};
+  background: ${RAW_COLORS.blue[800]};
   animation: ${pulse} 2000ms infinite;
   box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2);
 `;
@@ -126,7 +126,7 @@ const Ball = animated(styled.div.attrs({
   z-index: 2;
   width: ${props => props.size}px;
   height: ${props => props.size}px;
-  background: ${COLORS.white};
+  background: ${COLORS.lightBackground};
   border-radius: 50%;
 
   transform-origin: center center;

--- a/src/components/TwoPaneModal/TwoPaneModal.js
+++ b/src/components/TwoPaneModal/TwoPaneModal.js
@@ -10,7 +10,7 @@ import React, { PureComponent } from 'react';
 import { Spring, animated, config } from 'react-spring';
 import styled from 'styled-components';
 
-import { COLORS, Z_INDICES } from '../../constants';
+import { RAW_COLORS, COLORS, Z_INDICES } from '../../constants';
 
 type Props = {
   leftPane: React$Node,
@@ -210,13 +210,13 @@ const LeftHalf = styled.div.attrs({
 
 const LeftPaneWrapper = styled.div`
   height: 100%;
-  color: ${COLORS.white};
+  color: ${COLORS.textOnBackground};
   background-image: linear-gradient(
     70deg,
-    ${COLORS.blue[700]},
-    ${COLORS.teal[500]}
+    ${RAW_COLORS.blue[700]},
+    ${RAW_COLORS.teal[500]}
   ); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
-  border: 4px solid ${COLORS.white};
+  border: 4px solid ${COLORS.textOnBackground};
   box-shadow: 0px 6px 60px rgba(0, 0, 0, 0.1), 0px 2px 8px rgba(0, 0, 0, 0.05);
   border-radius: 8px 0 0 8px;
 `;
@@ -225,7 +225,7 @@ const RightPaneWrapper = styled.div`
   position: relative;
   z-index: 1;
   flex: 1;
-  background: ${COLORS.white};
+  background: ${COLORS.lightBackground};
   box-shadow: 0px 6px 60px rgba(0, 0, 0, 0.1), 0px 2px 8px rgba(0, 0, 0, 0.05);
   border-radius: 0 8px 8px 0;
 `;

--- a/src/components/WhimsicalInstaller/File.js
+++ b/src/components/WhimsicalInstaller/File.js
@@ -91,12 +91,12 @@ class File extends PureComponent<Props> {
                 L0,28
               `}
             stroke="none"
-            fill={COLORS.white}
+            fill={COLORS.lightBackground}
           />
           <polygon
             points="15,0 15,5 20,5"
             stroke="none"
-            fill={COLORS.white}
+            fill={COLORS.lightBackground}
             filter="url(#file-corner)"
           />
         </svg>

--- a/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
+++ b/src/components/WhimsicalInstaller/WhimsicalInstaller.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
 
-import { COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 import WhimsicalInstaller from './WhimsicalInstaller';
 
@@ -32,5 +32,5 @@ storiesOf('WhimsicalInstaller', module)
 const Wrapper = styled.div`
   width: ${props => props.width}px;
   height: ${props => props.height}px;
-  background: ${COLORS.blue[700]};
+  background: ${RAW_COLORS.blue[700]};
 `;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 // @flow
 import packageJson from '../package.json';
 
-export const COLORS = {
+export const RAW_COLORS = {
   hotPink: {
     '500': '#F50057',
     '700': '#C51162',
@@ -107,6 +107,39 @@ export const COLORS = {
   },
   white: '#FFF',
   black: '#000',
+};
+
+export const COLORS = {
+  background: RAW_COLORS.gray[50],
+  lightBackground: RAW_COLORS.white,
+
+  text: RAW_COLORS.gray[900],
+  textOnBackground: RAW_COLORS.white,
+  lightText: RAW_COLORS.gray[600],
+
+  link: RAW_COLORS.blue[700],
+  lightLink: RAW_COLORS.blue[500],
+
+  success: RAW_COLORS.green[700],
+  lightSuccess: RAW_COLORS.green[500],
+
+  error: RAW_COLORS.pink[700],
+  lightError: RAW_COLORS.pink[500],
+
+  warning: RAW_COLORS.orange[700],
+  lightWarning: RAW_COLORS.orange[500],
+};
+
+export const GRADIENTS = {
+  success: [COLORS.success, RAW_COLORS.lightGreen[500]],
+  error: [RAW_COLORS.pink[300], RAW_COLORS.red[500]],
+  primary: [RAW_COLORS.purple[500], RAW_COLORS.violet[500]],
+  darkPrimary: [RAW_COLORS.purple[500], RAW_COLORS.blue[700]],
+  progress: [
+    RAW_COLORS.blue[700],
+    RAW_COLORS.teal[500],
+    RAW_COLORS.lightGreen[500],
+  ],
 };
 
 export const BREAKPOINT_SIZES = {

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -13,10 +13,10 @@ injectGlobal`
   select,
   option {
     /* This is important for MacOS Mojave's dark mode */
-    color: ${COLORS.gray[900]};
+    color: ${COLORS.text};
   }
 
   body {
-    background: ${COLORS.gray[50]};
+    background: ${COLORS.background};
   }
 `;

--- a/src/services/create-project.service.js
+++ b/src/services/create-project.service.js
@@ -9,7 +9,7 @@ import projectConfigs from '../config/project-types';
 import { processLogger } from './process-logger.service';
 import { substituteConfigVariables } from './config-variables.service';
 
-import { COLORS } from '../constants';
+import { RAW_COLORS } from '../constants';
 
 import {
   formatCommandForPlatform,
@@ -185,14 +185,14 @@ export const getProjectNameSlug = (projectName: string) =>
 
 // Exported so that getColorForProject can be tested
 export const possibleProjectColors = [
-  COLORS.hotPink[700],
-  COLORS.pink[700],
-  COLORS.red[700],
-  COLORS.orange[700],
-  COLORS.green[700],
-  COLORS.teal[700],
-  COLORS.violet[700],
-  COLORS.purple[700],
+  RAW_COLORS.hotPink[700],
+  RAW_COLORS.pink[700],
+  RAW_COLORS.red[700],
+  RAW_COLORS.orange[700],
+  RAW_COLORS.green[700],
+  RAW_COLORS.teal[700],
+  RAW_COLORS.violet[700],
+  RAW_COLORS.purple[700],
 ];
 
 export const getColorForProject = (projectName: string) => {

--- a/src/stories/colors.stories.js
+++ b/src/stories/colors.stories.js
@@ -5,91 +5,56 @@ import styled from 'styled-components';
 
 import Heading from '../components/Heading';
 import { contrastingColor } from '../utils';
-import { COLORS } from '../constants';
-
-const COMMON_COLORS = {
-  pink: {
-    '300': COLORS.pink[300],
-    '500': COLORS.pink[500],
-    '700': COLORS.pink[700],
-  },
-  red: {
-    '500': COLORS.red[500],
-    '700': COLORS.red[700],
-  },
-  orange: {
-    '500': COLORS.orange[500],
-    '700': COLORS.orange[700],
-  },
-  lime: {
-    '500': COLORS.lime[500],
-  },
-  lightGreen: {
-    '500': COLORS.lightGreen[500],
-  },
-  green: {
-    '500': COLORS.green[500],
-    '700': COLORS.green[700],
-  },
-  teal: {
-    '500': COLORS.teal[500],
-    '700': COLORS.teal[700],
-  },
-  blue: {
-    '700': COLORS.blue[700],
-    '900': COLORS.blue[900],
-  },
-  violet: {
-    '500': COLORS.violet[500],
-    '700': COLORS.violet[700],
-  },
-  purple: {
-    '500': COLORS.purple[500],
-    '700': COLORS.purple[700],
-  },
-  gray: {
-    '50': COLORS.gray[50],
-    '100': COLORS.gray[100],
-    '200': COLORS.gray[200],
-    '300': COLORS.gray[300],
-    '400': COLORS.gray[400],
-    '500': COLORS.gray[500],
-    '600': COLORS.gray[600],
-    '700': COLORS.gray[700],
-    '800': COLORS.gray[800],
-    '900': COLORS.gray[900],
-  },
-};
+import { RAW_COLORS, COLORS, GRADIENTS } from '../constants';
 
 const ColorList = ({ colors }) => (
   <Fragment>
-    {Object.entries(colors)
-      .filter(([_, gradient]) => typeof gradient === 'object')
-      .map(([name, gradient], i) => (
-        <Fragment key={i}>
-          <Heading
-            style={{ marginTop: i === 0 ? 0 : '20px', marginBottom: '10px' }}
-          >
+    {Object.entries(colors).map(
+      ([name, gradient], i) =>
+        typeof gradient === 'string' ? (
+          <ColorBlock key={i} color={gradient}>
             {name}
-          </Heading>
-          {Object.entries(gradient).map(([interval, color], j) => (
-            <ColorBlock key={j} color={color}>
-              {interval}
-            </ColorBlock>
-          ))}
-        </Fragment>
-      ))}
+          </ColorBlock>
+        ) : Array.isArray(gradient) ? (
+          <GradientBlock key={i} colors={gradient}>
+            {name}
+          </GradientBlock>
+        ) : (
+          <Fragment key={i}>
+            <Heading
+              style={{ marginTop: i === 0 ? 0 : '20px', marginBottom: '10px' }}
+            >
+              {name}
+            </Heading>
+            {Object.entries(gradient).map(([interval, color], j) => (
+              <ColorBlock key={j} color={color}>
+                {interval}
+              </ColorBlock>
+            ))}
+          </Fragment>
+        )
+    )}
   </Fragment>
 );
 
 storiesOf('Colors', module)
-  .add('Commonly-used', () => <ColorList colors={COMMON_COLORS} />)
-  .add('All', () => <ColorList colors={COLORS} />);
+  .add('Semantics', () => <ColorList colors={COLORS} />)
+  .add('Gradients', () => <ColorList colors={GRADIENTS} />)
+  .add('All', () => <ColorList colors={RAW_COLORS} />);
 
 const ColorBlock = styled.div`
   background: ${props => props.color};
   border-radius: 4px;
   color: ${props => contrastingColor(props.color)};
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 10px;
+`;
+
+const GradientBlock = styled.div`
+  background-image: linear-gradient(15deg, ${props => props.colors.join(', ')});
+  border-radius: 4px;
+  color: ${props => contrastingColor(props.colors[0])};
   width: 100%;
   padding: 10px;
   margin-bottom: 10px;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->

Based on branch from @mathieudutour (see PR #326). Taking over to bring it up to date with master and get it ready.

**To Do:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->

From #326:

- [ ] Look at the shades of blue and purple used, decide on `primary` and `secondary` colors
- [ ] Go through the remaining RAW_COLORS and decide whether we want to add a new semantic color, make an exception, or better, change it to use an existing semantic color.


Anything else?