### PR TITLE
Update languageCaptions in ApplicationMenu

### DIFF
--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -33,8 +33,8 @@ const { app, process, Menu } = remote;
 // todo: find a better place for this constant
 const languageCaptions = {
   en: 'English',
-  de: 'German',
-  zh: 'Chinese',
+  de: 'Deutsch', // German
+  zh: '中文', // Chinese
 };
 
 const languageCodes = ['en', 'de', 'zh'];

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -8,6 +8,7 @@ import { shell, remote } from 'electron';
 
 import * as actions from '../../actions';
 import { GUPPY_REPO_URL } from '../../constants';
+import { LANGUAGE_CODES, LANGUAGE_CAPTIONS } from '../../locale/constants';
 import { IN_APP_FEEDBACK_URL } from '../../config/app';
 import {
   isMac,
@@ -29,15 +30,6 @@ import type { Project, Task } from '../../types';
 import type { Dispatch } from '../../actions/types';
 
 const { app, process, Menu } = remote;
-
-// todo: find a better place for this constant
-const languageCaptions = {
-  en: 'English',
-  de: 'Deutsch', // German
-  zh: '中文', // Chinese
-};
-
-const languageCodes = ['en', 'de', 'zh'];
 
 type Props = {
   projects: Array<Project>,
@@ -201,8 +193,8 @@ class ApplicationMenu extends Component<Props> {
           {
             id: 'language',
             label: isMac ? 'Language' : '&Language',
-            submenu: languageCodes.map(langCode => ({
-              label: languageCaptions[langCode],
+            submenu: LANGUAGE_CODES.map(langCode => ({
+              label: LANGUAGE_CAPTIONS[langCode],
               click: () => changeLanguage(langCode),
               type: language.startsWith(langCode) ? 'checkbox' : 'normal',
               checked: language.startsWith(langCode),
@@ -234,8 +226,8 @@ class ApplicationMenu extends Component<Props> {
           {
             id: 'language',
             label: isMac ? 'Language' : '&Language',
-            submenu: languageCodes.map(langCode => ({
-              label: languageCaptions[langCode],
+            submenu: LANGUAGE_CODES.map(langCode => ({
+              label: LANGUAGE_CAPTIONS[langCode],
               click: () => changeLanguage(langCode),
               type: language.startsWith(langCode) ? 'checkbox' : 'normal',
               checked: language.startsWith(langCode),

--- a/src/components/ApplicationMenu/ApplicationMenu.js
+++ b/src/components/ApplicationMenu/ApplicationMenu.js
@@ -34,10 +34,10 @@ const { app, process, Menu } = remote;
 const languageCaptions = {
   en: 'English',
   de: 'German',
-  ch: 'Chinese',
+  zh: 'Chinese',
 };
 
-const languageCodes = ['en', 'de', 'ch'];
+const languageCodes = ['en', 'de', 'zh'];
 
 type Props = {
   projects: Array<Project>,

--- a/src/locale/constants.js
+++ b/src/locale/constants.js
@@ -1,0 +1,8 @@
+// @flow
+export const LANGUAGE_CODES = ['en', 'de', 'zh'];
+
+export const LANGUAGE_CAPTIONS = {
+  en: 'English',
+  de: 'Deutsch', // German
+  zh: '中文', // Chinese
+};


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->


**Related Issue:**
[66](https://github.com/joshwcomeau/guppy/issues/66)

**Summary:**
According to ISO 639-1, "ch" stands for Chamorro and "zh" stands for Chinese.
Besides, I find that most apps use the original language for each language caption, for example, "Deutsch" for "de" and "中文" for "zh", so I think we'd better do it here too. What do you think?

![image](https://user-images.githubusercontent.com/32248945/56087285-bbe2ee80-5e35-11e9-9b61-4bc793b54526.png)