### PR TITLE
Project title icons

### DIFF
--- a/src/components/Icons/index.js
+++ b/src/components/Icons/index.js
@@ -1,0 +1,24 @@
+// @flow
+import React from 'react';
+import styled from 'styled-components';
+import reactIconSrc from '../../assets/images/react-icon.svg';
+import gatsbyIconSrc from '../../assets/images/gatsby_small.png';
+import nextjsIconSrc from '../../assets/images/nextjs_small.png';
+
+const Icon = styled.img`
+  width: 22px;
+  height: 22px;
+`;
+
+const SizedReactIcon = styled.img`
+  width: 32px;
+  height: 32px;
+`;
+
+const ReactIcon = <SizedReactIcon src={reactIconSrc} />;
+
+const GatsbyIcon = <Icon src={gatsbyIconSrc} />;
+
+const NextjsIcon = <Icon src={nextjsIconSrc} />;
+
+export { GatsbyIcon, NextjsIcon, ReactIcon };

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -24,6 +24,7 @@ import Paragraph from '../Paragraph';
 import MountAfter from '../MountAfter';
 import Spinner from '../Spinner';
 import Card from '../Card';
+import ProjectTitle from '../ProjectTitle';
 
 import {
   openProjectInEditor,
@@ -32,7 +33,6 @@ import {
 import { getCopyForOpeningFolder } from '../../services/platform.service';
 
 import type { Project } from '../../types';
-import type { Dispatch } from '../../actions/types';
 
 type Props = {
   project: Project,
@@ -146,14 +146,11 @@ export class ProjectPage extends PureComponent<Props> {
               x={-2}
               reason="Align left edge of title with the modules on page"
             >
-              <Tooltip title={path} position="bottom">
-                <Heading
-                  size="xlarge"
-                  style={{ color: RAW_COLORS.purple[500] }}
-                >
-                  {project.name}
-                </Heading>
-              </Tooltip>
+              <ProjectTitle
+                tooltip={path}
+                title={project.name}
+                projectType={project.type}
+              />
             </PixelShifter>
             <SettingsButton />
           </FlexRow>

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
+import type { Dispatch } from 'react-redux';
 import styled, { keyframes } from 'styled-components';
 import { Tooltip } from 'react-tippy';
 import IconBase from 'react-icons-kit';

--- a/src/components/ProjectTitle/ProjectTitle.js
+++ b/src/components/ProjectTitle/ProjectTitle.js
@@ -54,7 +54,7 @@ const ProjectTitle = ({
 }: {
   tooltip: string,
   title: string,
-  projectType: ProjectType,
+  projectType?: ProjectType,
 }) => {
   return (
     <TitleWrapper>
@@ -64,9 +64,11 @@ const ProjectTitle = ({
         </Heading>
       </Tooltip>
 
-      <Tooltip title={`A ${projectType} project`} position="bottom">
-        {projectType && <TypeIcon type={projectType} />}
-      </Tooltip>
+      {projectType && (
+        <Tooltip title={`A ${projectType} project`} position="bottom">
+          {projectType && <TypeIcon type={projectType} />}
+        </Tooltip>
+      )}
     </TitleWrapper>
   );
 };

--- a/src/components/ProjectTitle/ProjectTitle.js
+++ b/src/components/ProjectTitle/ProjectTitle.js
@@ -1,0 +1,66 @@
+// @flow
+import React from 'react';
+import { Tooltip } from 'react-tippy';
+import styled from 'styled-components';
+import { RAW_COLORS } from '../../constants';
+import Heading from '../Heading';
+import reactIconSrc from '../../assets/images/react-icon.svg';
+import gatsbyIconSrc from '../../assets/images/gatsby_small.png';
+import nextjsIconSrc from '../../assets/images/nextjs_small.png';
+import { ProjectType } from '../../types';
+
+const TitleIcon = styled.img`
+  display: inline-block;
+  vertical-align: text-top;
+  filter: grayscale(100%);
+  :hover {
+    filter: grayscale(0%);
+  }
+`;
+
+const ProjectTitleIcon = styled(TitleIcon)`
+  width: 3rem;
+  height: 3rem;
+  margin-left: 1rem;
+  margin-top: 1rem;
+`;
+
+const ProjectTitleIconReact = styled(TitleIcon)`
+  width: 5rem;
+  height: 5rem;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+`;
+
+const TypeIcon = ({ type }: { type: ProjectType }) => {
+  switch (type) {
+    case 'create-react-app':
+      return <ProjectTitleIconReact src={reactIconSrc} />;
+    case 'gatsby':
+      return <ProjectTitleIcon src={gatsbyIconSrc} />;
+    case 'nextjs':
+      return <ProjectTitleIcon src={nextjsIconSrc} />;
+    default:
+      return null;
+  }
+};
+
+const ProjectTitle = ({ tooltip, title, projectType }) => {
+  return (
+    <TitleWrapper>
+      <Tooltip title={tooltip} position="bottom">
+        <Heading size="xlarge" style={{ color: RAW_COLORS.purple[500] }}>
+          {title}
+        </Heading>
+      </Tooltip>
+
+      <Tooltip title={`A ${projectType} project`} position="bottom">
+        {projectType && <TypeIcon type={projectType} />}
+      </Tooltip>
+    </TitleWrapper>
+  );
+};
+
+export default ProjectTitle;

--- a/src/components/ProjectTitle/ProjectTitle.js
+++ b/src/components/ProjectTitle/ProjectTitle.js
@@ -7,7 +7,7 @@ import Heading from '../Heading';
 import reactIconSrc from '../../assets/images/react-icon.svg';
 import gatsbyIconSrc from '../../assets/images/gatsby_small.png';
 import nextjsIconSrc from '../../assets/images/nextjs_small.png';
-import { ProjectType } from '../../types';
+import type { ProjectType } from '../../types';
 
 const TitleIcon = styled.img`
   display: inline-block;
@@ -47,7 +47,15 @@ const TypeIcon = ({ type }: { type: ProjectType }) => {
   }
 };
 
-const ProjectTitle = ({ tooltip, title, projectType }) => {
+const ProjectTitle = ({
+  tooltip,
+  title,
+  projectType,
+}: {
+  tooltip: string,
+  title: string,
+  projectType: ProjectType,
+}) => {
   return (
     <TitleWrapper>
       <Tooltip title={tooltip} position="bottom">

--- a/src/components/ProjectTitle/ProjectTitle.stories.js
+++ b/src/components/ProjectTitle/ProjectTitle.stories.js
@@ -1,0 +1,45 @@
+// @flow
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import ProjectTitle from './ProjectTitle';
+import Showcase from '../../../.storybook/components/Showcase';
+
+storiesOf('ProjectTitle', module).add(
+  'default',
+  withInfo()(() => (
+    <Fragment>
+      <Showcase label="With react icon">
+        <ProjectTitle
+          projectType="create-react-app"
+          title="Test Title"
+          tooltip="z:/some/path"
+        />
+      </Showcase>
+
+      <Showcase label="With Gatsby icon">
+        <ProjectTitle
+          projectType="gatsby"
+          title="Test Title"
+          tooltip="z:/some/path"
+        />
+      </Showcase>
+
+      <Showcase label="With Nextjs icon">
+        <ProjectTitle
+          projectType="nextjs"
+          title="Test Title"
+          tooltip="z:/some/path"
+        />
+      </Showcase>
+      <Showcase label="Without icon">
+        <ProjectTitle
+          projectType=""
+          title="Test Title"
+          tooltip="z:/some/path"
+        />
+      </Showcase>
+    </Fragment>
+  ))
+);

--- a/src/components/ProjectTitle/ProjectTitle.stories.js
+++ b/src/components/ProjectTitle/ProjectTitle.stories.js
@@ -34,11 +34,7 @@ storiesOf('ProjectTitle', module).add(
         />
       </Showcase>
       <Showcase label="Without icon">
-        <ProjectTitle
-          projectType=""
-          title="Test Title"
-          tooltip="z:/some/path"
-        />
+        <ProjectTitle title="Test Title" tooltip="z:/some/path" />
       </Showcase>
     </Fragment>
   ))

--- a/src/components/ProjectTitle/index.js
+++ b/src/components/ProjectTitle/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './ProjectTitle';

--- a/src/components/ProjectTypeSelection/ProjectTypeSelection.js
+++ b/src/components/ProjectTypeSelection/ProjectTypeSelection.js
@@ -2,10 +2,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import styled from 'styled-components';
 
-import reactIconSrc from '../../assets/images/react-icon.svg';
-import gatsbyIconSrc from '../../assets/images/gatsby_small.png';
-import nextjsIconSrc from '../../assets/images/nextjs_small.png';
-
+import { GatsbyIcon, NextjsIcon, ReactIcon } from '../Icons';
 import ButtonWithIcon from '../ButtonWithIcon';
 import Spacer from '../Spacer';
 
@@ -44,21 +41,6 @@ class ProjectTypeSelection extends PureComponent<Props> {
   }
 }
 
-const ReactIcon = styled.img`
-  width: 32px;
-  height: 32px;
-`;
-
-const GatsbyIcon = styled.img`
-  width: 22px;
-  height: 22px;
-`;
-
-const NextjsIcon = styled.img`
-  width: 22px;
-  height: 22px;
-`;
-
 const ProjectTypeTogglesWrapper = styled.div`
   margin-top: 8px;
   margin-left: -8px;
@@ -67,17 +49,17 @@ const ProjectTypeTogglesWrapper = styled.div`
 const mapProjectTypeToComponent = [
   {
     type: 'create-react-app',
-    Component: <ReactIcon src={reactIconSrc} />,
+    Component: ReactIcon,
     caption: 'Vanilla React',
   },
   {
     type: 'gatsby',
-    Component: <GatsbyIcon src={gatsbyIconSrc} />,
+    Component: GatsbyIcon,
     caption: 'Gatsby',
   },
   {
     type: 'nextjs',
-    Component: <NextjsIcon src={nextjsIconSrc} />,
+    Component: NextjsIcon,
     caption: 'Next.js',
   },
 ];


### PR DESCRIPTION
**Related Issue:** #319 

**Summary:**
- Added an icon that displays the icon for a project's type in the project title display
- Added project title to storybook
- Made the icon grayscale initially, then back to color on hover
- Added a tooltip that says what the project is.
- Refactored the icons in ProjectTypeSelection to be reused.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/56098867/66265281-24050280-e7d1-11e9-9d3a-33c951ac1490.png)
![image](https://user-images.githubusercontent.com/56098867/66265293-4ac33900-e7d1-11e9-859d-a2960548be68.png)

