### PR TITLE
Fix project page snapshot

### DIFF
--- a/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
+++ b/src/components/CreateNewProjectWizard/Gatsby/SelectStarterList.js
@@ -9,7 +9,7 @@ import ExternalLink from '../../ExternalLink';
 import CodesandboxLogo from '../../CodesandboxLogo';
 import StrokeButton from '../../Button/StrokeButton';
 
-import { RAW_COLORS, COLORS } from '../../../constants';
+import { RAW_COLORS } from '../../../constants';
 
 type Props = {
   updateStarter: (string, boolean) => void,

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 
-import { RAW_COLORS, COLORS } from '../../constants';
+import { RAW_COLORS } from '../../constants';
 
 type Props = {
   size: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge',

--- a/src/components/LoadingScreen/LoadingScreen.js
+++ b/src/components/LoadingScreen/LoadingScreen.js
@@ -11,7 +11,7 @@ import {
 } from '../../reducers/app-status.reducer';
 
 import guppyLoaderSrc from '../../assets/images/guppy-loader.gif';
-import { RAW_COLORS, COLORS, Z_INDICES } from '../../constants';
+import { RAW_COLORS, Z_INDICES } from '../../constants';
 import { ellipsify } from '../../utils';
 
 type Props = {

--- a/src/components/OnlineChecker/OnlineChecker.js
+++ b/src/components/OnlineChecker/OnlineChecker.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
-import { RAW_COLORS, Z_INDICES, COLORS } from '../../constants';
+import { RAW_COLORS, Z_INDICES } from '../../constants';
 
 import * as actions from '../../actions';
 import { getOnlineState } from '../../reducers/app-status.reducer';

--- a/src/components/ProjectPage/ProjectPage.js
+++ b/src/components/ProjectPage/ProjectPage.js
@@ -3,7 +3,6 @@ import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'react-redux';
 import styled, { keyframes } from 'styled-components';
-import { Tooltip } from 'react-tippy';
 import IconBase from 'react-icons-kit';
 import { packageIcon } from 'react-icons-kit/feather/packageIcon';
 
@@ -13,7 +12,6 @@ import { RAW_COLORS, COLORS, GRADIENTS } from '../../constants';
 import * as actions from '../../actions';
 
 import MainContentWrapper from '../MainContentWrapper';
-import Heading from '../Heading';
 import PixelShifter from '../PixelShifter';
 import Spacer from '../Spacer';
 import { FillButton } from '../Button';

--- a/src/components/ProjectPage/__snapshots__/ProjectPage.test.js.snap
+++ b/src/components/ProjectPage/__snapshots__/ProjectPage.test.js.snap
@@ -72,52 +72,9 @@ exports[`ProjectPage component should render header FlexRow 1`] = `
     reason="Align left edge of title with the modules on page"
     x={-2}
   >
-    <Tooltip
-      animateFill={true}
-      animation="shift"
-      arrow={false}
-      arrowSize="regular"
-      className=""
-      delay={0}
-      disabled={false}
-      distance={10}
-      duration={375}
-      followCursor={false}
-      hideDelay={0}
-      hideDuration={375}
-      hideOnClick={true}
-      html={null}
-      inertia={false}
-      interactive={false}
-      interactiveBorder={2}
-      multiple={false}
-      offset={0}
-      onHidden={[Function]}
-      onHide={[Function]}
-      onRequestClose={[Function]}
-      onShow={[Function]}
-      onShown={[Function]}
-      popperOptions={Object {}}
-      position="bottom"
-      size="regular"
-      sticky={false}
-      stickyDuration={200}
-      style={Object {}}
-      theme="dark"
-      title="path/to/project"
-      touchHold={false}
-      trigger="mouseenter focus"
-      unmountHTMLWhenHide={false}
-    >
-      <Heading
-        size="xlarge"
-        style={
-          Object {
-            "color": "#651fff",
-          }
-        }
-      />
-    </Tooltip>
+    <ProjectTitle
+      tooltip="path/to/project"
+    />
   </PixelShifter>
   <Connect(SettingsButton) />
 </styled.div>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please fill out the following template with details about your pull request:
-->

**Summary:**
<!--
Please describe the change, and any high-level information about why the implementation is the way it is.
-->
Quick-fix of failing snapshot test. (I also fixed some linting warnings.)

The snapshot needed an update because of project type icon change in `ProjectPage` component.